### PR TITLE
feat: specify columns for api responses

### DIFF
--- a/src/models/projects/projects.model.js
+++ b/src/models/projects/projects.model.js
@@ -49,10 +49,16 @@ class Project extends Model {
     return destroyResult;
   }
 
-  static async findAllMySQLFts(searchStr, orgUid, pagination) {
+  static async findAllMySQLFts(searchStr, orgUid, pagination, columns = []) {
     const { offset, limit } = pagination;
+    
+    let fields = '*';
+    if (columns.length) {
+      fields = columns.join(', ');
+    }
+    
     let sql = `
-    SELECT * FROM projects WHERE MATCH (
+    SELECT ${fields} FROM projects WHERE MATCH (
         warehouseProjectId,
         currentRegistry,
         registryOfOrigin,
@@ -103,12 +109,17 @@ class Project extends Model {
     };
   }
 
-  static async findAllSqliteFts(searchStr, orgUid, pagination) {
+  static async findAllSqliteFts(searchStr, orgUid, pagination, columns = []) {
     const { offset, limit } = pagination;
-
+  
+    let fields = '*';
+    if (columns.length) {
+      fields = columns.join(', ');
+    }
+    
     searchStr = searchStr = searchStr.replaceAll('-', '+');
 
-    let sql = `SELECT * FROM projects_fts WHERE projects_fts MATCH :search`;
+    let sql = `SELECT ${fields} FROM projects_fts WHERE projects_fts MATCH :search`;
 
     if (orgUid) {
       sql = `${sql} AND orgUid = :orgUid`;

--- a/src/routes/v1/resources/projects.js
+++ b/src/routes/v1/resources/projects.js
@@ -13,6 +13,7 @@ const querySchema = Joi.object()
     page: Joi.number(),
     limit: Joi.number(),
     search: Joi.string(),
+    columns: Joi.string(),
   })
   .with('page', 'limit');
 


### PR DESCRIPTION
Specify columns for API responses. Can pass in an optional search param `?columns=id,projectId` (comma separated)