### PR TITLE
build: revert dev dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,26 +59,26 @@
     "winston-daily-rotate-file": "^4.7.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.24.5",
-    "@babel/core": "^7.24.5",
+    "@babel/cli": "^7.24.1",
+    "@babel/core": "^7.24.4",
     "@babel/plugin-syntax-import-attributes": "^7.24.1",
-    "@babel/preset-env": "^7.24.5",
+    "@babel/preset-env": "^7.24.4",
     "@babel/register": "^7.23.7",
-    "@commitlint/cli": "^19.3.0",
-    "@commitlint/config-conventional": "^19.2.2",
-    "babel-plugin-module-resolver": "^5.0.2",
-    "chai": "^5.1.1",
+    "@commitlint/cli": "^19.2.1",
+    "@commitlint/config-conventional": "^19.1.0",
+    "babel-plugin-module-resolver": "^5.0.0",
+    "chai": "^5.1.0",
     "chai-http": "^4.4.0",
-    "eslint": "^9.2.0",
+    "eslint": "^8.57.0",
     "eslint-plugin-es": "^4.1.0",
-    "eslint-plugin-mocha": "^10.4.3",
+    "eslint-plugin-mocha": "^10.4.1",
     "husky": "^9.0.11",
     "mocha": "^10.4.0",
-    "semver": "^7.6.2",
+    "semver": "^7.6.0",
     "sinon": "^17.0.1",
     "socket.io-client": "^4.7.5",
     "standard-version": "^9.5.0",
-    "supertest": "^7.0.0"
+    "supertest": "^6.3.4"
   },
   "standard-version": {
     "skip": {


### PR DESCRIPTION
We need to update the node version before we can do most of these, which is not a job for this release. 