### PR TITLE
Update README.md: nvm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ To install from source:
 ```
 git clone git@github.com:Chia-Network/cadt.git
 cd cadt
-nvm install 18.16
-nvm use 18.16
+nvm install 20.16
+nvm use 20.16
 npm run start
 ```
 


### PR DESCRIPTION
nvm 18.16 is no longer able to run the latest cadt.
This PR updates the minimum Node.js version requirement to v20.16 for running the latest CADT. The change is based on error responses encountered when using v18.16 during npm run start, as well as a review of dependency updates that necessitate this version upgrade.