### PR TITLE
fix: import organization assertion loop

### DIFF
--- a/docs/cadt_rpc_api.md
+++ b/docs/cadt_rpc_api.md
@@ -35,9 +35,9 @@ If using a `CADT_API_KEY` append `--header 'x-api-key: <your-api-key-here>'` to 
   - [POST Examples](#post-examples)
     - [Create an organization](#create-an-organization)
   - [PUT Examples](#put-examples)
-    - [Import a home organization](#import-a-home-organization-that-datalayer-is-subscribed-to)
+    - [Import an organization that datalayer is subscribed to](#import-an-organization-that-datalayer-is-subscribed-to)
   - [DELETE Examples](#delete-examples)
-    - [Delete a home organization](#reset-home-organization)
+    - [Delete a home organization](#delete-home-organization)
   - [Additional organizations resources](#additional-organizations-resources)
 - [`projects`](#projects)
   - [GET Examples](#get-examples-1)
@@ -210,16 +210,18 @@ Response
 
 PUT Options: 
 
-|  Key   |  Type   |                     Description                      |
-|:------:|:-------:|:----------------------------------------------------:|
-| orgUid | String  | (Required) OrgUid of the home organization to import |
+|  Key   |  Type   |                   Description                   |
+|:------:|:-------:|:-----------------------------------------------:|
+| orgUid | String  | (Required) OrgUid of the organization to import |
+| isHome | Boolean |        Set to true if home organization         |
 
 ### PUT Examples
 
-#### Import a home organization that datalayer is subscribed to
+#### Import an organization that datalayer is subscribed to
 
 - This is typically used when an organization currently using CADT is installing a new instance and wants to use the same
 home organization and the current instance(s).
+- This can be used to import an organization that is not a home organization as well
 
 Request
 ```sh
@@ -232,7 +234,8 @@ curl --location -g --request PUT 'http://localhost:31310/v1/organizations/' \
 Response
 ```json
 {
-  "message":"Importing home organization."
+  "message":"Successfully imported organization. cadt will begin syncing the organization's data from datalayer",
+  "success": true
 }
 ```
 
@@ -259,8 +262,7 @@ Response
 - POST `/organizations/remove-mirror` - given a store ID and coin ID removes the mirror for a given store 
 - POST `/organizations/sync` - runs the process to sync all subscribed organization metadata with datalayer
 - POST `/organizations/create` - create an organization without an icon 
-- POST `/organizations/edit` - update an organization name and/or icon 
-- PUT `/organizations/import` - subscribe and import an organization via OrgUid 
+- POST `/organizations/edit` - update an organization name and/or icon
 - DELETE `organizations/import` - delete an organization's record from the CADT instance DB 
 - PUT `organizations/subscribe` - subscribe to an organization datalayer singleton 
 - DELETE `organizations/unsubscribe` - unsubscribe from an organization datalayer singleton and keep CADT data 

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -193,45 +193,19 @@ export const resetHomeOrg = async (req, res) => {
   }
 };
 
-export const importOrg = async (req, res) => {
+export const importOrganization = async (req, res) => {
   try {
     await assertIfReadOnlyMode();
     await assertWalletIsSynced();
 
-    const { orgUid } = req.body;
+    await Organization.importOrganization(req.body.orgUid, req.body?.orgUid);
 
-    res.json({
+    res.status(200).json({
       message:
-        'Importing and subscribing organization this can take a few mins.',
-      success: true,
-    });
-
-    return Organization.importOrganization(orgUid);
-  } catch (error) {
-    console.trace(error);
-    res.status(400).json({
-      message: 'Error importing organization',
-      error: error.message,
-      success: false,
-    });
-  }
-};
-
-export const importHomeOrg = async (req, res) => {
-  try {
-    await assertIfReadOnlyMode();
-    await assertWalletIsSynced();
-
-    const { orgUid } = req.body;
-
-    await Organization.importHomeOrg(orgUid);
-
-    res.json({
-      message: 'Importing home organization.',
+        "Successfully imported organization. cadt will begin syncing the organization's data from datalayer",
       success: true,
     });
   } catch (error) {
-    console.trace(error);
     res.status(400).json({
       message: 'Error importing organization',
       error: error.message,
@@ -246,10 +220,13 @@ export const subscribeToOrganization = async (req, res) => {
     await assertWalletIsSynced();
     await assertHomeOrgExists();
 
-    await Organization.subscribeToOrganization(req.body.orgUid);
+    const resultMessage = await Organization.subscribeToOrganization(
+      req.body.orgUid,
+      req.body.registryId,
+    );
 
     return res.json({
-      message: 'Subscribed to organization',
+      message: resultMessage,
       success: true,
     });
   } catch (error) {

--- a/src/routes/v1/resources/organization.js
+++ b/src/routes/v1/resources/organization.js
@@ -11,7 +11,6 @@ import {
   resyncOrganizationSchema,
   subscribeOrganizationSchema,
   unsubscribeOrganizationSchema,
-  importHomeOrganizationSchema,
   removeMirrorSchema,
   addMirrorSchema,
   getMetaDataSchema,
@@ -59,17 +58,9 @@ OrganizationRouter.put('/edit', upload.single('file'), (req, res) => {
 
 OrganizationRouter.put(
   '/',
-  validator.body(importHomeOrganizationSchema),
-  (req, res) => {
-    return OrganizationController.importHomeOrg(req, res);
-  },
-);
-
-OrganizationRouter.put(
-  '/import',
   validator.body(importOrganizationSchema),
   (req, res) => {
-    return OrganizationController.importOrg(req, res);
+    return OrganizationController.importOrganization(req, res);
   },
 );
 

--- a/src/validations/organizations.validations.js
+++ b/src/validations/organizations.validations.js
@@ -7,10 +7,7 @@ export const newOrganizationWithIconSchema = Joi.object({
 
 export const importOrganizationSchema = Joi.object({
   orgUid: Joi.string().required(),
-});
-
-export const importHomeOrganizationSchema = Joi.object({
-  orgUid: Joi.string().required(),
+  isHome: Joi.bool().optional(),
 });
 
 export const unsubscribeOrganizationSchema = Joi.object({
@@ -19,6 +16,7 @@ export const unsubscribeOrganizationSchema = Joi.object({
 
 export const subscribeOrganizationSchema = Joi.object({
   orgUid: Joi.string().required(),
+  registryId: Joi.string().required(),
 });
 
 export const resyncOrganizationSchema = Joi.object({


### PR DESCRIPTION
this PR fixes the assertion loop in which you need to import an organization before subscribing and need to subscribe before importing

the calls to subscribe and import have been decoupled since the old method was failing due to the time it takes for data layer to sync a store once subscribed to it.

to import an organization the workflow is as follows
- subscribe to the org and registry stores with a PUT to `/v1/organizations/subscribe` (providing both store ids to avoid the aforementioned sync/lag issue)
- import the organization with a PUT to  `/v1/organizations` providing the orgUid. this adds the organization to teh cadt db. proving `"isHome": true` will have cadt attempt to import as a home organization.

NOTE: a separate call for importing the home org has been removed