### PR TITLE
Org import delete sub adjustments

### DIFF
--- a/docs/cadt_rpc_api.md
+++ b/docs/cadt_rpc_api.md
@@ -210,16 +210,14 @@ Response
 
 PUT Options: 
 
-|  Key   |  Type   |                     Description                      |
-|:------:|:-------:|:----------------------------------------------------:|
-| orgUid | String  | (Required) OrgUid of the home organization to import |
+|  Key   |  Type   |                                      Description                                      |
+|:------:|:-------:|:-------------------------------------------------------------------------------------:|
+| orgUid | String  |                 (Required) OrgUid of the home organization to import                  |
+| isHome | Boolean |  (Optional) Specify true if the specified orgUid should be imported as the home org   |
 
 ### PUT Examples
 
-#### Import a home organization that datalayer is subscribed to
-
-- This is typically used when an organization currently using CADT is installing a new instance and wants to use the same
-home organization and the current instance(s).
+#### Import an organization and subscribe to its stores on datalayer
 
 Request
 ```sh
@@ -232,7 +230,8 @@ curl --location -g --request PUT 'http://localhost:31310/v1/organizations/' \
 Response
 ```json
 {
-  "message":"Importing home organization."
+  "success": true,
+  "message": "Successfully imported organization. CADT will begin syncing data from datalayer shortly"
 }
 ```
 
@@ -240,16 +239,17 @@ DELETE Options: None
 
 ### DELETE Examples
 
-#### Delete home organization
+#### Delete organization
 
 Request
 ```sh
-curl --location --request DELETE 'http://localhost:31310/v1/organizations/'
+curl --location --request DELETE \
+'http://localhost:31310/v1/organizations/c9661d1ce77194c9e82311418aa4d370e25e10961d74d586636354746bc9ad65'
 ```
 Response
 ```json
 {
-  "message": "Your home organization was reset, please create a new one.",
+  "message": "Removed all organization records for organization ${orgUid} and unsubscribed from organization datalayer stores. cadt will not sync the organizations data from datalayer",
   "success": true
 
 }
@@ -259,9 +259,7 @@ Response
 - POST `/organizations/remove-mirror` - given a store ID and coin ID removes the mirror for a given store 
 - POST `/organizations/sync` - runs the process to sync all subscribed organization metadata with datalayer
 - POST `/organizations/create` - create an organization without an icon 
-- POST `/organizations/edit` - update an organization name and/or icon 
-- PUT `/organizations/import` - subscribe and import an organization via OrgUid 
-- DELETE `/organizations/import` - delete an organization's record from the CADT instance DB
+- POST `/organizations/edit` - update an organization name and/or icon
 - PUT `/organizations/resync` - resync an organization from datalayer 
 - POST `/organizations/mirror` - add a mirror for a datalayer store via the store ID 
 - GET `/organizations/metadata` - get an organizations metadata using the OrgUid 

--- a/docs/cadt_rpc_api.md
+++ b/docs/cadt_rpc_api.md
@@ -261,13 +261,11 @@ Response
 - POST `/organizations/create` - create an organization without an icon 
 - POST `/organizations/edit` - update an organization name and/or icon 
 - PUT `/organizations/import` - subscribe and import an organization via OrgUid 
-- DELETE `organizations/import` - delete an organization's record from the CADT instance DB 
-- PUT `organizations/subscribe` - subscribe to an organization datalayer singleton 
-- DELETE `organizations/unsubscribe` - unsubscribe from an organization datalayer singleton and keep CADT data 
-- PUT `organizations/resync` - resync an organization from datalayer 
-- POST `organizations/mirror` - add a mirror for a datalayer store via the store ID 
-- GET `organizations/metadata` - get an organizations metadata using the OrgUid 
-- GET `organizations/status` - the sync status of an organization via the OrgUid
+- DELETE `/organizations/import` - delete an organization's record from the CADT instance DB
+- PUT `/organizations/resync` - resync an organization from datalayer 
+- POST `/organizations/mirror` - add a mirror for a datalayer store via the store ID 
+- GET `/organizations/metadata` - get an organizations metadata using the OrgUid 
+- GET `/organizations/status` - the sync status of an organization via the OrgUid
 
 ---
 

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -368,14 +368,20 @@ export const resyncOrganization = async (req, res) => {
 
     await Organization.reconcileOrganization(organization);
 
-    await Organization.update({ registryHash: '0' }, { where: { orgUid } });
+    await Organization.update(
+      { registryHash: '0' },
+      { where: { orgUid }, transaction },
+    );
 
     await Promise.all([
       ...Object.keys(ModelKeys).map(
         async (key) =>
-          await ModelKeys[key].destroy({ where: { orgUid: req.body.orgUid } }),
+          await ModelKeys[key].destroy({
+            where: { orgUid: req.body.orgUid },
+            transaction,
+          }),
       ),
-      Audit.destroy({ where: { orgUid: req.body.orgUid } }),
+      Audit.destroy({ where: { orgUid: req.body.orgUid }, transaction }),
     ]);
 
     await transaction.commit();

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -13,7 +13,6 @@ import { getDataModelVersion } from '../utils/helpers';
 
 import { ModelKeys, Audit, Organization, Staging } from '../models';
 import { getOwnedStores, getSubscriptions } from '../datalayer/persistance.js';
-import { scrubOrganizationData } from '../utils/model-utils.js';
 
 export const findAll = async (req, res) => {
   return res.json(await Organization.getOrgsMap());
@@ -222,7 +221,7 @@ export const deleteOrganization = async (req, res) => {
       );
     }
 
-    await scrubOrganizationData(orgUid);
+    await Organization.scrubOrganizationData(orgUid);
 
     if (organization.isHome) {
       return res.json({

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -208,7 +208,7 @@ export const subscribeToOrganization = async (req, res) => {
 };
 
 export const deleteOrganization = async (req, res) => {
-  const { orgUid } = req.body;
+  const { orgUid } = req.params;
 
   try {
     const organization = await Organization.findOne({
@@ -233,20 +233,18 @@ export const deleteOrganization = async (req, res) => {
     }
 
     try {
-      // need to call this here because the task that normally does it cannot if there's no record of the organization
+      // need to call this here because the task that normally unsubscribes cannot if there's no record of the organization
       await Organization.unsubscribeFromOrganizationStores(organization);
     } catch (error) {
       return res.status(400).json({
-        message:
-          'Removed all organization records from cadt, but an error prevented unsubscribing from the organization on datalayer',
+        message: `Removed all organization records for organization ${orgUid} from cadt, but an error prevented unsubscribing from the organization on datalayer`,
         error: error.message,
         success: false,
       });
     }
 
     return res.json({
-      message:
-        'Removed all organization records and unsubscribed from organization datalayer stores. cadt will not sync the organizations data from datalayer',
+      message: `Removed all organization records for organization ${orgUid} and unsubscribed from organization datalayer stores. cadt will not sync the organizations data from datalayer`,
       success: true,
     });
   } catch (error) {
@@ -296,7 +294,7 @@ export const unsubscribeFromOrganization = async (req, res) => {
       }
 
       const { storeIds: subscriptions, success: successGettingSubscriptions } =
-        getSubscriptions();
+        await getSubscriptions();
       if (!successGettingSubscriptions) {
         throw new Error('failed to get subscribed stores from datalayer');
       }

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -596,7 +596,7 @@ const getSubscriptions = async () => {
       .send({});
 
     const data = response.body;
-    logger.debug(`data returned from ${url}: ${data.store_ids}`);
+    logger.debug(`data returned from ${url}: ${JSON.stringify(data)}`);
 
     if (data.success) {
       return { success: true, storeIds: data.store_ids };

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -295,14 +295,14 @@ const unsubscribeFromDataLayerStore = async (storeId) => {
 
     const data = response.body;
 
-    if (Object.keys(data).includes('success') && data.success) {
-      logger.info(`Successfully UnSubscribed: ${storeId}`);
-      return data;
+    if (data.success) {
+      logger.info(`Successfully Unsubscribed from store: ${storeId}`);
+      return true;
     }
 
     return false;
   } catch (error) {
-    logger.info(`Error UnSubscribing: ${error}`);
+    logger.error(`Error Unsubscribing from store ${storeId}. Error: ${error}`);
     return false;
   }
 };

--- a/src/datalayer/syncService.js
+++ b/src/datalayer/syncService.js
@@ -80,7 +80,9 @@ const getSubscribedStoreData = async (storeId) => {
     );
     const { confirmed } = await dataLayer.getRoot(storeId);
     if (!confirmed) {
-      throw new Error(`Store not found in DataLayer: ${storeId}.`);
+      throw new Error(
+        `${storeId} has not yet been confirmed. cannot get root.`,
+      );
     } else {
       logger.debug(
         `store data is confirmed available, proceeding to get data ${storeId}`,

--- a/src/datalayer/syncService.js
+++ b/src/datalayer/syncService.js
@@ -18,6 +18,29 @@ const unsubscribeFromDataLayerStore = async (storeId) => {
   }
 };
 
+const unsubscribeFromDataLayerStoreWithRetry = async (
+  storeId,
+  maxRetries = 60,
+  retryWaitMs = 600,
+) => {
+  if (!USE_SIMULATOR) {
+    let success = false;
+    let retryCount = 0;
+
+    while (!success) {
+      success = await dataLayer.unsubscribeFromDataLayerStore(storeId);
+      if (!success) {
+        if (retryCount >= maxRetries) {
+          throw new Error(
+            `failed to unsubscribe from store ${storeId} after ${maxRetries} attempts`,
+          );
+        }
+        await new Promise((resolve) => setTimeout(() => resolve, retryWaitMs));
+      }
+    }
+  }
+};
+
 const subscribeToStoreOnDataLayer = async (storeId) => {
   if (USE_SIMULATOR) {
     return simulator.subscribeToStoreOnDataLayer(storeId);
@@ -228,5 +251,6 @@ export default {
   POLLING_INTERVAL,
   getCurrentStoreData,
   unsubscribeFromDataLayerStore,
+  unsubscribeFromDataLayerStoreWithRetry,
   waitForAllTransactionsToConfirm,
 };

--- a/src/datalayer/syncService.js
+++ b/src/datalayer/syncService.js
@@ -52,15 +52,29 @@ const subscribeToStoreOnDataLayer = async (storeId) => {
 /**
  * gets and decodes data from a subscribed store.
  * will subscribe to any store id for which there is no subscription.
- * @param storeId to retrieve data from
+ *
+ * providing a subscription list will prevent calling the datalayer `/subscriptions` RPC.
+ * good idea if calling in a loop
+ *
+ * @param storeId {string} to retrieve data from
+ * @param providedSubscriptions {[string] | undefined} optional list of subscriptions. providing prevents RPC call
  * @returns {Promise<any>}
  */
-const getSubscribedStoreData = async (storeId) => {
-  const { storeIds: subscriptions, success } =
-    await dataLayer.getSubscriptions();
-  if (!success) {
-    throw new Error('failed to retrieve subscriptions from datalayer');
+const getSubscribedStoreData = async (
+  storeId,
+  providedSubscriptions = undefined,
+) => {
+  let subscriptions = providedSubscriptions;
+  if (!subscriptions) {
+    const { storeIds: rpcSubscriptions, success } =
+      await dataLayer.getSubscriptions();
+    if (!success) {
+      throw new Error('failed to retrieve subscriptions from datalayer');
+    }
+
+    subscriptions = rpcSubscriptions;
   }
+
   const alreadySubscribed = subscriptions.includes(storeId);
 
   if (!alreadySubscribed) {

--- a/src/models/meta/meta.model.js
+++ b/src/models/meta/meta.model.js
@@ -6,7 +6,63 @@ import { sequelize } from '../../database';
 
 import ModelTypes from './meta.modeltypes.cjs';
 
-class Meta extends Model {}
+export const USER_DELETED_ORGS = 'userDeletedOrgs';
+
+class Meta extends Model {
+  /**
+   *
+   * @returns {Promise<[string] | undefined>}
+   */
+  static async getUserDeletedOrgUids() {
+    const deletedOrgsString = await Meta.findOne({
+      where: { metaKey: USER_DELETED_ORGS },
+      raw: true,
+    });
+    if (!deletedOrgsString?.metaValue) {
+      return undefined;
+    }
+    return JSON.parse(deletedOrgsString.metaValue);
+  }
+
+  /**
+   * @param orgUid {string}
+   * @returns {Promise<void>}
+   */
+  static async addUserDeletedOrgUid(orgUid) {
+    const userDeletedOrgUids = await Meta.getUserDeletedOrgUids();
+    if (!userDeletedOrgUids) {
+      await Meta.create({
+        metaKey: USER_DELETED_ORGS,
+        metaValue: JSON.stringify([orgUid]),
+      });
+      return;
+    }
+
+    userDeletedOrgUids.push(orgUid);
+    await Meta.update(
+      { metaValue: JSON.stringify(userDeletedOrgUids) },
+      { where: { metaKey: USER_DELETED_ORGS } },
+    );
+  }
+
+  /**
+   * @param orgUid {string}
+   * @returns {Promise<void>}
+   */
+  static async removeUserDeletedOrgUid(orgUid) {
+    const userDeletedOrgUids = await Meta.getUserDeletedOrgUids();
+    if (!userDeletedOrgUids) {
+      return;
+    }
+    const revisedOrgUidArr = userDeletedOrgUids.filter(
+      (orgUidInArr) => orgUidInArr !== orgUid,
+    );
+    await Meta.update(
+      { metaValue: JSON.stringify(revisedOrgUidArr) },
+      { where: { metaKey: USER_DELETED_ORGS } },
+    );
+  }
+}
 
 Meta.init(ModelTypes, {
   sequelize,

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -595,8 +595,7 @@ class Organization extends Model {
           onTimeout(error);
         }
         logger.debug(`${error.message}. RETRYING`);
-      } finally {
-        await new Promise((resolve) => setTimeout(resolve, 300));
+        await new Promise((resolve) => setTimeout(resolve, 10000));
       }
     }
 
@@ -621,8 +620,7 @@ class Organization extends Model {
           onTimeout(error);
         }
         logger.debug(`${error.message}. RETRYING`);
-      } finally {
-        await new Promise((resolve) => setTimeout(resolve, 300));
+        await new Promise((resolve) => setTimeout(resolve, 3000));
       }
     }
 

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -429,7 +429,7 @@ class Organization extends Model {
     logger.verbose('acquiring mutex to import organization');
     const releaseMutex = await addOrDeleteOrganizationRecordMutex.acquire();
 
-    // any error caught is re-thrown. this is here because we need to release a mutex
+    // any error caught is re-thrown. this outer try is here because we need to release a mutex
     try {
       if (isHome) {
         try {
@@ -507,7 +507,7 @@ class Organization extends Model {
         dataModelVersionStoreId: storeIds.dataModelVersionStoreId,
         fileStoreId: orgData?.fileStoreId,
         subscribed: true,
-        isHome: false,
+        isHome,
       };
       logger.info(
         `adding and organization with the following info ${organizationData}`,

--- a/src/routes/v1/resources/organization.js
+++ b/src/routes/v1/resources/organization.js
@@ -14,7 +14,6 @@ import {
   removeMirrorSchema,
   addMirrorSchema,
   getMetaDataSchema,
-  deleteOrganizationSchema,
 } from '../../../validations';
 
 const validator = joiExpress.createValidator({ passError: true });
@@ -37,13 +36,9 @@ OrganizationRouter.post('/sync', (req, res) => {
   return OrganizationController.sync(req, res);
 });
 
-OrganizationRouter.delete(
-  '/',
-  validator.query(deleteOrganizationSchema),
-  (req, res) => {
-    return OrganizationController.deleteOrganization(req, res);
-  },
-);
+OrganizationRouter.delete('/:orgUid', (req, res) => {
+  return OrganizationController.deleteOrganization(req, res);
+});
 
 OrganizationRouter.post(
   '/',

--- a/src/routes/v1/resources/organization.js
+++ b/src/routes/v1/resources/organization.js
@@ -11,10 +11,10 @@ import {
   resyncOrganizationSchema,
   subscribeOrganizationSchema,
   unsubscribeOrganizationSchema,
-  importHomeOrganizationSchema,
   removeMirrorSchema,
   addMirrorSchema,
   getMetaDataSchema,
+  deleteOrganizationSchema,
 } from '../../../validations';
 
 const validator = joiExpress.createValidator({ passError: true });
@@ -37,9 +37,13 @@ OrganizationRouter.post('/sync', (req, res) => {
   return OrganizationController.sync(req, res);
 });
 
-OrganizationRouter.delete('/', (req, res) => {
-  return OrganizationController.resetHomeOrg(req, res);
-});
+OrganizationRouter.delete(
+  '/',
+  validator.query(deleteOrganizationSchema),
+  (req, res) => {
+    return OrganizationController.deleteOrganization(req, res);
+  },
+);
 
 OrganizationRouter.post(
   '/',
@@ -59,23 +63,11 @@ OrganizationRouter.put('/edit', upload.single('file'), (req, res) => {
 
 OrganizationRouter.put(
   '/',
-  validator.body(importHomeOrganizationSchema),
-  (req, res) => {
-    return OrganizationController.importHomeOrg(req, res);
-  },
-);
-
-OrganizationRouter.put(
-  '/import',
   validator.body(importOrganizationSchema),
   (req, res) => {
-    return OrganizationController.importOrg(req, res);
+    return OrganizationController.importOrganization(req, res);
   },
 );
-
-OrganizationRouter.delete('/import', (req, res) => {
-  return OrganizationController.deleteImportedOrg(req, res);
-});
 
 OrganizationRouter.put(
   '/subscribe',
@@ -89,7 +81,7 @@ OrganizationRouter.put(
   '/unsubscribe',
   validator.body(unsubscribeOrganizationSchema),
   (req, res) => {
-    return OrganizationController.unsubscribeToOrganization(req, res);
+    return OrganizationController.unsubscribeFromOrganization(req, res);
   },
 );
 

--- a/src/tasks/mirror-check.js
+++ b/src/tasks/mirror-check.js
@@ -85,10 +85,12 @@ const runMirrorCheck = async () => {
   const organizations = await Organization.getOrgsMap();
   const orgs = Object.keys(organizations);
   for (const org of orgs) {
-    const orgData = organizations[org];
-    await Organization.addMirror(orgData.orgUid, mirrorUrl, true);
-    await Organization.addMirror(orgData.dataModelVersionStoreId, true);
-    await Organization.addMirror(orgData.registryId, mirrorUrl, true);
+    if (org?.subscribed) {
+      const orgData = organizations[org];
+      await Organization.addMirror(orgData.orgUid, mirrorUrl, true);
+      await Organization.addMirror(orgData.dataModelVersionStoreId, true);
+      await Organization.addMirror(orgData.registryId, mirrorUrl, true);
+    }
   }
 };
 

--- a/src/tasks/sync-default-organizations.js
+++ b/src/tasks/sync-default-organizations.js
@@ -4,7 +4,7 @@ import {
   assertWalletIsSynced,
 } from '../utils/data-assertions.js';
 import { getDefaultOrganizationList } from '../utils/data-loaders.js';
-import { Organization } from '../models/index.js';
+import { Meta, Organization } from '../models/index.js';
 import { logger } from '../config/logger.js';
 import { getConfig } from '../utils/config-loader.js';
 
@@ -23,7 +23,16 @@ const task = new Task('sync-default-organizations', async () => {
         );
       }
 
+      const userDeletedOrgs = await Meta.getUserDeletedOrgUids();
+
       for (const { orgUid } of defaultOrgRecords) {
+        if (userDeletedOrgs.includes(orgUid)) {
+          logger.verbose(
+            `default organization ${orgUid} has been explicitly removed from this instance. not adding or checking that it exists`,
+          );
+          continue;
+        }
+
         const organization = await Organization.findOne({
           where: { orgUid },
           raw: true,
@@ -47,14 +56,14 @@ const task = new Task('sync-default-organizations', async () => {
   } catch (error) {
     logger.error(
       `failed to validate default organization records and subscriptions. Error ${error.message}. ` +
-        `Retrying in ${CONFIG?.TASKS?.GOVERNANCE_SYNC_TASK_INTERVAL || 30} seconds`,
+        `Retrying in ${CONFIG?.TASKS?.GOVERNANCE_SYNC_TASK_INTERVAL || 300} seconds`,
     );
   }
 });
 
 const job = new SimpleIntervalJob(
   {
-    seconds: CONFIG?.TASKS?.GOVERNANCE_SYNC_TASK_INTERVAL || 30,
+    seconds: CONFIG?.TASKS?.GOVERNANCE_SYNC_TASK_INTERVAL || 300,
     runImmediately: true,
   },
   task,

--- a/src/tasks/sync-default-organizations.js
+++ b/src/tasks/sync-default-organizations.js
@@ -26,7 +26,7 @@ const task = new Task('sync-default-organizations', async () => {
       const userDeletedOrgs = await Meta.getUserDeletedOrgUids();
 
       for (const { orgUid } of defaultOrgRecords) {
-        if (userDeletedOrgs.includes(orgUid)) {
+        if (userDeletedOrgs?.includes(orgUid)) {
           logger.verbose(
             `default organization ${orgUid} has been explicitly removed from this instance. not adding or checking that it exists`,
           );

--- a/src/tasks/sync-registries.js
+++ b/src/tasks/sync-registries.js
@@ -560,7 +560,7 @@ const syncOrganizationAudit = async (organization) => {
               record[ModelKeys[modelKey].primaryKeyAttributes[0]];
 
             if (diff.type === 'INSERT') {
-              logger.info(`UPSERTING: ${modelKey} - ${primaryKeyValue}`);
+              logger.verbose(`UPSERTING: ${modelKey} - ${primaryKeyValue}`);
 
               // Remove updatedAt fields if they exist
               // This is because the db will update this field automatically and its not allowed to be null
@@ -572,9 +572,7 @@ const syncOrganizationAudit = async (organization) => {
                 delete record.createdAt;
               }
 
-              logger.debug(
-                `upserting diff record and transaction to ${modelKey} model`,
-              );
+              logger.debug(`upserting diff record to ${modelKey} model`);
               await ModelKeys[modelKey].upsert(record, {
                 transaction,
                 mirrorTransaction,
@@ -593,7 +591,7 @@ const syncOrganizationAudit = async (organization) => {
           }
 
           // Create the Audit record
-          logger.debug(`creating audit model transaction entry`);
+          logger.debug(`writing change record `);
           await Audit.create(auditData, { transaction, mirrorTransaction });
         }
       }

--- a/src/tasks/sync-registries.js
+++ b/src/tasks/sync-registries.js
@@ -65,6 +65,10 @@ const task = new Task('sync-registries', async () => {
     } finally {
       releaseSyncTaskMutex();
     }
+  } else {
+    logger.debug(
+      'could not acquire sync registries mutex. trying again shortly',
+    );
   }
 });
 

--- a/src/tasks/validate-organization-table-and-subscriptions.js
+++ b/src/tasks/validate-organization-table-and-subscriptions.js
@@ -26,7 +26,7 @@ const task = new Task('validate-organization-table', async () => {
       for (const organization of organizations) {
         // this is in the loop to prevent this task from trying to operate on an organization that was deleted while it was running
         const deletedOrganizations = await Meta.getUserDeletedOrgUids();
-        if (deletedOrganizations.includes(organization.orgUid)) {
+        if (deletedOrganizations?.includes(organization.orgUid)) {
           continue;
         }
 
@@ -46,7 +46,7 @@ const task = new Task('validate-organization-table', async () => {
   } catch (error) {
     logger.error(
       `failed to validate default organization records and subscriptions. Error ${error.message}. ` +
-        `Retrying in ${CONFIG?.TASKS?.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL || 30} seconds`,
+        `Retrying in ${CONFIG?.TASKS?.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL || 900} seconds`,
     );
   }
 });
@@ -61,7 +61,7 @@ const task = new Task('validate-organization-table', async () => {
  */
 const job = new SimpleIntervalJob(
   {
-    seconds: CONFIG?.TASKS?.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL || 30,
+    seconds: CONFIG?.TASKS?.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL || 900,
     runImmediately: true,
   },
   task,

--- a/src/utils/data-assertions.js
+++ b/src/utils/data-assertions.js
@@ -113,13 +113,6 @@ export const assertRecordExistance = async (Model, pk) => {
   return record;
 };
 
-export const assertCanDeleteOrg = async (orgUid) => {
-  const homeOrg = await Organization.getHomeOrg();
-  if (homeOrg?.orgUid === orgUid) {
-    throw new Error(`Cant delete your own organization`);
-  }
-};
-
 export const assertHomeOrgExists = async () => {
   const homeOrg = await Organization.getHomeOrg();
   if (!homeOrg) {
@@ -130,7 +123,7 @@ export const assertHomeOrgExists = async () => {
 
   if (!homeOrg.subscribed) {
     throw new Error(
-      `Your Home organization is still confirming, please wait a little longer for it to finished.`,
+      `Your Home organization is still confirming, please wait a little longer for it to finish.`,
     );
   }
 

--- a/src/utils/model-utils.js
+++ b/src/utils/model-utils.js
@@ -27,6 +27,12 @@ export const syncRegistriesTaskMutex = new Mutex();
  */
 export const processingSyncRegistriesTransactionMutex = new Mutex();
 
+/**
+ * mutex which should be acquired by any function what intends on deleting or adding rows to the organization table
+ * @type {Mutex}
+ */
+export const addOrDeleteOrganizationRecordMutex = new Mutex();
+
 export function formatModelAssociationName(model) {
   if (model == null || model.model == null) return '';
 

--- a/src/utils/model-utils.js
+++ b/src/utils/model-utils.js
@@ -2,15 +2,6 @@ import { columnsToInclude } from './helpers.js';
 import Sequelize from 'sequelize';
 
 import { Mutex } from 'async-mutex';
-import {
-  Audit,
-  FileStore,
-  ModelKeys,
-  Organization,
-  Staging,
-} from '../models/index.js';
-import { sequelize } from '../database/index.js';
-import { logger } from '../config/logger.js';
 
 export async function waitForSyncRegistriesTransaction() {
   if (processingSyncRegistriesTransactionMutex.isLocked()) {
@@ -40,37 +31,6 @@ export function formatModelAssociationName(model) {
   if (model == null || model.model == null) return '';
 
   return `${model.model.name}${model.pluralize ? 's' : ''}`;
-}
-
-/**
- * removes all records of an organization from all models with an `orgUid` column
- * @param orgUid
- */
-export async function scrubOrganizationData(orgUid) {
-  logger.info(
-    `deleting all database entries corresponding to organization ${orgUid}`,
-  );
-  const transaction = await sequelize.transaction();
-  try {
-    for (const model of ModelKeys) {
-      await model.destroy({ where: { orgUid }, transaction });
-    }
-
-    await Staging.truncate();
-    await Organization.destroy({ where: { orgUid }, transaction });
-    await FileStore.destroy({ where: { orgUid }, transaction });
-    await Audit.destroy({ where: { orgUid }, transaction });
-
-    await transaction.commit();
-  } catch (error) {
-    logger.error(
-      `failed to delete all db records for organization ${orgUid}, rolling back changes. Error: ${error.message}`,
-    );
-    await transaction.rollback();
-    throw new Error(
-      `an error occurred while deleting records corresponding to organization ${orgUid}. no changes have been made`,
-    );
-  }
 }
 
 /**

--- a/src/validations/organizations.validations.js
+++ b/src/validations/organizations.validations.js
@@ -7,9 +7,10 @@ export const newOrganizationWithIconSchema = Joi.object({
 
 export const importOrganizationSchema = Joi.object({
   orgUid: Joi.string().required(),
+  isHome: Joi.bool().optional(),
 });
 
-export const importHomeOrganizationSchema = Joi.object({
+export const deleteOrganizationSchema = Joi.object({
   orgUid: Joi.string().required(),
 });
 

--- a/src/validations/organizations.validations.js
+++ b/src/validations/organizations.validations.js
@@ -10,10 +10,6 @@ export const importOrganizationSchema = Joi.object({
   isHome: Joi.bool().optional(),
 });
 
-export const deleteOrganizationSchema = Joi.object({
-  orgUid: Joi.string().required(),
-});
-
 export const unsubscribeOrganizationSchema = Joi.object({
   orgUid: Joi.string().required(),
 });

--- a/tests/resources/organization.spec.js
+++ b/tests/resources/organization.spec.js
@@ -7,6 +7,7 @@ import datalayer from '../../src/datalayer';
 import { pullPickListValues } from '../../src/utils/data-loaders';
 const TEST_WAIT_TIME = datalayer.POLLING_INTERVAL * 2;
 import * as testFixtures from '../test-fixtures';
+import { getHomeOrgId } from '../test-fixtures';
 
 describe('Orgainzation Resource CRUD', function () {
   before(async function () {
@@ -23,10 +24,14 @@ describe('Orgainzation Resource CRUD', function () {
       // add a project to the staging table
       await testFixtures.createNewProject();
 
-      const response = await supertest(app).delete(`/v1/organizations`).send();
+      const homeOrgUid = await getHomeOrgId();
+      const response = await supertest(app)
+        .delete(`/v1/organizations/${homeOrgUid}`)
+        .send();
+      const body = response.body;
 
-      expect(response.body.message).to.equal(
-        'Your home organization was deleted from this instance. (note that it still exists in datalayer)',
+      expect(body.message).to.equal(
+        'Your home organization was deleted from this instance. cadt will no longer sync its data. (note that this org still exists in datalayer)',
       );
 
       const stagingData = await testFixtures.getLastCreatedStagingRecord();
@@ -66,10 +71,11 @@ describe('Orgainzation Resource CRUD', function () {
       // add a project to the staging table
       await testFixtures.createNewProject();
 
+      const homeOrgUid = await getHomeOrgId();
       const response = await supertest(app)
         .put(`/v1/organizations/resync`)
         .send({
-          orgUid: '1',
+          orgUid: homeOrgUid,
         });
 
       expect(response.body.message).to.equal(

--- a/tests/resources/projects.spec.js
+++ b/tests/resources/projects.spec.js
@@ -60,7 +60,7 @@ describe('Project Resource CRUD', function () {
           page: 1,
           limit: 100,
         });
-        expect(projects.data.length).to.equal(12);
+        expect(projects.data.length).to.equal(10);
       }).timeout(TEST_WAIT_TIME * 10);
 
       it('gets all the projects filtered by orgUid', async function () {
@@ -262,16 +262,23 @@ describe('Project Resource CRUD', function () {
           icon: 'https://www.chia.net/wp-content/uploads/2023/01/chia-logo-dark.svg',
         });
       }).timeout(TEST_WAIT_TIME * 10);
+
       it('errors if there is a current set of pending commits', function () {});
+
       it('errors if there if there is no connection to the datalayer', function () {});
+
       it('errors if the warehouseProjectId is not in the payload', function () {});
+
       it('errors if the warehouseProjectId is an existing record', function () {});
+
       it('errors if trying to update a child table that is not an existing record', function () {});
+
       it('errors if the orgUid of the project does not equal the home organization', function () {});
     });
 
     describe('success states', function () {
       it('updates a new project with no child tables', function () {});
+
       it('updates a new project with all child tables', function () {});
     });
   });
@@ -279,15 +286,21 @@ describe('Project Resource CRUD', function () {
   describe('DELETE Projects - Delete', function () {
     describe('error states', function () {
       it('errors if no home organization exists', function () {});
+
       it('errors if there is a current set of pending commits', function () {});
+
       it('errors if there if there is no connection to the datalayer', function () {});
+
       it('errors if the warehouseProjectId is not in the payload', function () {});
+
       it('errors if the warehouseProjectId is an existing record', function () {});
+
       it('errors if the orgUid of the project does not equal the home organization', function () {});
     });
 
     describe('success states', function () {
       it('updates a new project with no child tables', function () {});
+
       it('updates a new project with all child tables', function () {});
     });
   });


### PR DESCRIPTION
this PR fixes the behavior for deleting an organization and unsubscribing from an organization. the calls to delete and import home and non-home organizations has been unified to `/v1/organizations`. when importing a home organization send `isHome: true` in the request body.