### PR TITLE
Security updates 02 25

### DIFF
--- a/src/models/projects/projects.model.js
+++ b/src/models/projects/projects.model.js
@@ -250,6 +250,7 @@ class Project extends Model {
       sql = `${sql} AND orgUid = :orgUid`;
     }
 
+    searchStr = sanitizeSqliteFtsQuery(searchStr);
     const replacements = { search: searchStr, orgUid };
 
     const count = (

--- a/src/routes/v1/resources/staging.js
+++ b/src/routes/v1/resources/staging.js
@@ -9,6 +9,7 @@ import {
   stagingGetQuerySchema,
   stagingRetrySchema,
   commitStagingSchema,
+  stagingEditSchema,
 } from '../../../validations';
 
 const validator = joiExpress.createValidator({ passError: true });
@@ -22,7 +23,7 @@ StagingRouter.get('/offer', (req, res) => {
   return StagingController.generateOfferFile(req, res);
 });
 
-StagingRouter.put('/', (req, res) => {
+StagingRouter.put('/', validator.body(stagingEditSchema), (req, res) => {
   return StagingController.editRecord(req, res);
 });
 

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -3,7 +3,7 @@ import yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 
-import { getDataModelVersion } from './helpers';
+import { getDataModelVersion, mergeObjects } from './helpers';
 import { defaultConfig } from './defaultConfig.js';
 import { getChiaRoot } from './chia-root.js';
 
@@ -43,6 +43,7 @@ export const getConfig = _.memoize(() => {
         console.log(`ENV FILE OVERRIDE: RUNNING IN SIMULATOR MODE`);
       }
 
+      mergeObjects(yml, defaultConfig);
       return yml;
     } catch (e) {
       console.error(`Config file not found at ${configFile}`, e);

--- a/src/utils/defaultConfig.js
+++ b/src/utils/defaultConfig.js
@@ -30,6 +30,22 @@ export const defaultConfig = {
       MIRROR_CHECK_TASK_INTERVAL: 86460,
       VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL: 1800,
     },
+    /**
+     * limits to prevent loop bound DOS attack
+     */
+    REQUEST_CONTENT_LIMITS: {
+      STAGING: {
+        EDIT_DATA_LEN: 200,
+      },
+      UNITS: {
+        INCLUDE_COLUMNS_LEN: 200,
+        MARKETPLACE_IDENTIFIERS_LEN: 200,
+      },
+      PROJECTS: {
+        INCLUDE_COLUMNS_LEN: 200,
+        PROJECT_IDS_LEN: 200,
+      },
+    },
   },
   GOVERNANCE: {
     GOVERNANCE_BODY_ID:

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -122,3 +122,34 @@ export const updateNilVerificationBodyAsEmptyString = (stagedItem) => {
     return;
   }
 };
+
+/**
+ * merges the source into the target without altering the data already present in target
+ * @param target {object}
+ * @param source {object}
+ * @returns {void}
+ */
+export function mergeObjects(target, source) {
+  if (typeof source !== 'object' || source === null) {
+    return;
+  }
+
+  for (let key of Object.keys(source)) {
+    if (typeof source[key] === 'object' && source[key] !== null) {
+      if (
+        !(key in target) ||
+        typeof target[key] !== 'object' ||
+        target[key] === null
+      ) {
+        target[key] = {};
+      }
+      // Recursively merge the structure
+      mergeObjects(target[key], source[key]);
+    } else {
+      // If it's a primitive in source and doesn't exist in target, copy it
+      if (!(key in target)) {
+        target[key] = source[key];
+      }
+    }
+  }
+}

--- a/src/validations/projects.validations.js
+++ b/src/validations/projects.validations.js
@@ -15,6 +15,9 @@ import {
 } from '../utils/string-utils';
 
 import { pickListValidation } from '../utils/validation-utils';
+import { getConfig } from '../utils/config-loader.js';
+
+const { REQUEST_CONTENT_LIMITS } = getConfig();
 
 export const baseSchema = {
   // warehouseProjectId - derived upon creation
@@ -64,11 +67,19 @@ export const projectsGetQuerySchema = Joi.object({
   page: Joi.number().optional(),
   limit: Joi.number().max(1000).min(1).optional(),
   search: Joi.string().optional(),
-  columns: Joi.array().items(Joi.string()).single().optional(),
+  columns: Joi.array()
+    .items(Joi.string())
+    .single()
+    .optional()
+    .max(REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN),
   orgUid: Joi.string().optional(),
   warehouseProjectId: Joi.string().optional(),
   xls: Joi.boolean().optional(),
-  projectIds: Joi.array().items(Joi.string()).single().optional(),
+  projectIds: Joi.array()
+    .items(Joi.string())
+    .single()
+    .optional()
+    .max(REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN),
   order: Joi.string().regex(genericSortColumnRegex).optional(),
   filter: Joi.string().regex(genericFilterRegex).optional(),
   onlyMarketplaceProjects: Joi.boolean().optional(),

--- a/src/validations/projects.validations.js
+++ b/src/validations/projects.validations.js
@@ -17,7 +17,7 @@ import {
 import { pickListValidation } from '../utils/validation-utils';
 import { getConfig } from '../utils/config-loader.js';
 
-const { REQUEST_CONTENT_LIMITS } = getConfig();
+const { APP } = getConfig();
 
 export const baseSchema = {
   // warehouseProjectId - derived upon creation
@@ -71,7 +71,7 @@ export const projectsGetQuerySchema = Joi.object({
     .items(Joi.string())
     .single()
     .optional()
-    .max(REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN),
+    .max(APP.REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN),
   orgUid: Joi.string().optional(),
   warehouseProjectId: Joi.string().optional(),
   xls: Joi.boolean().optional(),
@@ -79,7 +79,7 @@ export const projectsGetQuerySchema = Joi.object({
     .items(Joi.string())
     .single()
     .optional()
-    .max(REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN),
+    .max(APP.REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN),
   order: Joi.string().regex(genericSortColumnRegex).optional(),
   filter: Joi.string().regex(genericFilterRegex).optional(),
   onlyMarketplaceProjects: Joi.boolean().optional(),

--- a/src/validations/staging.validations.js
+++ b/src/validations/staging.validations.js
@@ -1,4 +1,6 @@
 import Joi from 'joi';
+import { getConfig } from '../utils/config-loader.js';
+const { REQUEST_CONTENT_LIMITS } = getConfig();
 
 export const stagingDeleteSchema = Joi.object({
   uuid: Joi.string().required(),
@@ -17,7 +19,10 @@ export const commitStagingSchema = Joi.object({
 
 export const stagingEditSchema = Joi.object({
   uuid: Joi.string().required(),
-  data: Joi.object().required(),
+  data: Joi.array()
+    .items(Joi.object())
+    .required()
+    .max(REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN),
 });
 
 export const stagingGetQuerySchema = Joi.object()

--- a/src/validations/staging.validations.js
+++ b/src/validations/staging.validations.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import { getConfig } from '../utils/config-loader.js';
-const { REQUEST_CONTENT_LIMITS } = getConfig();
+const { APP } = getConfig();
 
 export const stagingDeleteSchema = Joi.object({
   uuid: Joi.string().required(),
@@ -22,7 +22,7 @@ export const stagingEditSchema = Joi.object({
   data: Joi.array()
     .items(Joi.object())
     .required()
-    .max(REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN),
+    .max(APP.REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN),
 });
 
 export const stagingGetQuerySchema = Joi.object()

--- a/src/validations/units.validations.js
+++ b/src/validations/units.validations.js
@@ -10,7 +10,7 @@ import {
 } from '../utils/string-utils';
 import { getConfig } from '../utils/config-loader.js';
 
-const { REQUEST_CONTENT_LIMITS } = getConfig();
+const { APP } = getConfig();
 
 const unitsBaseSchema = {
   // warehouseUnitId - derived upon unit creation
@@ -64,7 +64,7 @@ export const unitsGetQuerySchema = Joi.object({
   columns: Joi.array()
     .items(Joi.string())
     .single()
-    .max(REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN),
+    .max(APP.REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN),
   orgUid: Joi.string(),
   order: Joi.alternatives().try(
     Joi.string().valid('SERIALNUMBER', 'ASC', 'DESC').optional(),
@@ -74,7 +74,7 @@ export const unitsGetQuerySchema = Joi.object({
   marketplaceIdentifiers: Joi.array()
     .items(Joi.string())
     .single()
-    .max(REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN),
+    .max(APP.REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN),
   hasMarketplaceIdentifier: Joi.boolean(),
   onlyTokenizedUnits: Joi.boolean(),
   includeProjectInfoInSearch: Joi.boolean(),

--- a/src/validations/units.validations.js
+++ b/src/validations/units.validations.js
@@ -8,6 +8,9 @@ import {
   genericFilterRegex,
   genericSortColumnRegex,
 } from '../utils/string-utils';
+import { getConfig } from '../utils/config-loader.js';
+
+const { REQUEST_CONTENT_LIMITS } = getConfig();
 
 const unitsBaseSchema = {
   // warehouseUnitId - derived upon unit creation
@@ -58,14 +61,20 @@ export const unitsGetQuerySchema = Joi.object({
   limit: Joi.number().max(1000).min(1).required(),
   search: Joi.string().optional(),
   warehouseUnitId: Joi.string(),
-  columns: Joi.array().items(Joi.string()).single(),
+  columns: Joi.array()
+    .items(Joi.string())
+    .single()
+    .max(REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN),
   orgUid: Joi.string(),
   order: Joi.alternatives().try(
     Joi.string().valid('SERIALNUMBER', 'ASC', 'DESC').optional(),
     Joi.string().regex(genericSortColumnRegex).min(1).max(100).optional(),
   ),
   xls: Joi.boolean(),
-  marketplaceIdentifiers: Joi.array().items(Joi.string()).single(),
+  marketplaceIdentifiers: Joi.array()
+    .items(Joi.string())
+    .single()
+    .max(REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN),
   hasMarketplaceIdentifier: Joi.boolean(),
   onlyTokenizedUnits: Joi.boolean(),
   includeProjectInfoInSearch: Joi.boolean(),


### PR DESCRIPTION
fixes length prop injection vectors

in `src/utils/defaultConfig.js` this section has been added:

```
/**
     * limits to prevent loop bound DOS attack
     */
    REQUEST_CONTENT_LIMITS: {
      STAGING: {
        EDIT_DATA_LEN: 200,
      },
      UNITS: {
        INCLUDE_COLUMNS_LEN: 200,
        MARKETPLACE_IDENTIFIERS_LEN: 200,
      },
      PROJECTS: {
        INCLUDE_COLUMNS_LEN: 200,
        PROJECT_IDS_LEN: 200,
      },
    },
```

if adding to the config file these values go in the `APP` section, here is the same thing as yaml:

```
REQUEST_CONTENT_LIMITS:
  STAGING:
    EDIT_DATA_LEN: 200
  UNITS:
    INCLUDE_COLUMNS_LEN: 200
    MARKETPLACE_IDENTIFIERS_LEN: 200
  PROJECTS:
    INCLUDE_COLUMNS_LEN: 200
    PROJECT_IDS_LEN: 200
```