### PR TITLE
fix(V2): use correct mirror DB name in test verification helper

### DIFF
--- a/tests/v2/live-api/helpers/mysql-mirror-helpers.js
+++ b/tests/v2/live-api/helpers/mysql-mirror-helpers.js
@@ -64,7 +64,7 @@ export const getMirrorDbConfig = () => {
       host: mirrorDb.DB_HOST,
       user: mirrorDb.DB_USERNAME,
       password: mirrorDb.DB_PASSWORD,
-      database: `${mirrorDb.DB_NAME}_v2`, // V2 uses {DB_NAME}_v2
+      database: mirrorDb.DB_NAME,
     };
 
     console.log(`[${getTimestamp()}] MySQL Mirror: Found config - host=${cachedConfig.host}, database=${cachedConfig.database}`);


### PR DESCRIPTION
## Summary
- The `mysql-mirror-helpers.js` test helper was incorrectly appending `_v2` to the `DB_NAME` from config (e.g., `cadt_mirror_test` became `cadt_mirror_test_v2`)
- The CADT application uses `DB_NAME` as-is for the V2 mirror database, so the test was verifying against an empty/nonexistent database
- This caused all 63 mirror verification records to fail in the v2 live API tests

## Root Cause
| Component | Database Name Used |
|---|---|
| CADT app (`config.js` v2Mirror) | `cadt_mirror_test` (raw `DB_NAME`) |
| CADT migrations (`prepareV2Db`) | `cadt_mirror_test` (creates and migrates this) |
| Test helper (before fix) | `cadt_mirror_test_v2` (`DB_NAME` + `_v2`) |

## Fix
Removed the `_v2` suffix in `mysql-mirror-helpers.js` so the test verification connects to the same database that CADT actually writes to.

## Test plan
- [ ] Re-run v2 live API tests in CI and verify mirror verification passes
- [ ] Confirm all 63 records are found in the mirror database