### PR TITLE
fix: add file_store mirror to periodic mirror check

### DIFF
--- a/src/tasks/mirror-check-v2.js
+++ b/src/tasks/mirror-check-v2.js
@@ -136,6 +136,7 @@ const runMirrorCheckV2 = async () => {
         org_uid: orgData.org_uid,
         data_model_version_store_id: orgData.data_model_version_store_id,
         registry_id: orgData.registry_id,
+        file_store_subscribed: orgData.file_store_subscribed,
       })}`,
     );
 
@@ -189,6 +190,27 @@ const runMirrorCheckV2 = async () => {
       } else {
         loggerV2.debug(
           `[v2]: [MIRROR_DEBUG] Skipping registry_id mirror - value is null/undefined`,
+        );
+      }
+
+      if (orgData.file_store_subscribed) {
+        try {
+          await OrganizationsV2.addMirror(
+            orgData.file_store_subscribed,
+            mirrorUrl,
+            true,
+          );
+          loggerV2.debug(
+            `[v2]: [MIRROR_DEBUG] Mirror ensured for file_store: ${orgData.file_store_subscribed}`,
+          );
+        } catch (error) {
+          loggerV2.error(
+            `[v2]: [MIRROR_DEBUG] Failed to ensure mirror for file_store ${orgData.file_store_subscribed}: ${error.message}`,
+          );
+        }
+      } else {
+        loggerV2.debug(
+          `[v2]: [MIRROR_DEBUG] Skipping file_store mirror - value is null/undefined`,
         );
       }
     } else {

--- a/src/tasks/mirror-check.js
+++ b/src/tasks/mirror-check.js
@@ -136,6 +136,7 @@ const runMirrorCheck = async () => {
         orgUid: orgData.orgUid,
         dataModelVersionStoreId: orgData.dataModelVersionStoreId,
         registryId: orgData.registryId,
+        fileStoreId: orgData.fileStoreId,
       })}`,
     );
 
@@ -189,6 +190,23 @@ const runMirrorCheck = async () => {
       } else {
         logger.debug(
           `[MIRROR_DEBUG] Skipping registryId mirror - value is null/undefined`,
+        );
+      }
+
+      if (orgData.fileStoreId) {
+        try {
+          await Organization.addMirror(orgData.fileStoreId, mirrorUrl, true);
+          logger.debug(
+            `[MIRROR_DEBUG] Mirror ensured for fileStoreId: ${orgData.fileStoreId}`,
+          );
+        } catch (error) {
+          logger.error(
+            `[MIRROR_DEBUG] Failed to ensure mirror for fileStoreId ${orgData.fileStoreId}: ${error.message}`,
+          );
+        }
+      } else {
+        logger.debug(
+          `[MIRROR_DEBUG] Skipping fileStoreId mirror - value is null/undefined`,
         );
       }
     } else {


### PR DESCRIPTION
## Summary

- The periodic mirror check task (`mirror-check.js` / `mirror-check-v2.js`) ensures mirrors exist for `org_uid`, `registry_id`, and `data_model_version_store_id` stores, but was **missing the `file_store`** entirely
- When the initial mirror creation during org creation fails (e.g., wallet temporarily unsynced), the file_store mirror was never retried by the periodic task, causing the CI test's organization mirror validation to fail
- Added file_store mirror creation to both V1 and V2 mirror check tasks so it is retried on the periodic schedule like all other org stores

## Root Cause Analysis

From [CI run #22002605727](https://github.com/Chia-Network/cadt/actions/runs/22002605727/job/63578714909?pr=1494):

1. During org creation at 21:11:53, the `add_mirror` RPC call for the file_store (`3a8b8ee6...`) failed with "Wallet needs to be fully synced before making transactions"
2. After org creation completed, `runMirrorCheckV2()` was triggered at 21:14:24 to retry any failed mirrors
3. The mirror check successfully created/verified mirrors for `org_uid`, `registry_id`, and `data_model_version_store_id`
4. But it **never attempted** the file_store mirror because the code simply didn't include it
5. Test validation found 0 mirrors for the file_store and failed

## Test plan

- [ ] Re-run the v2 live API tests to verify the file_store mirror is created by the periodic mirror check
- [ ] Verify the V1 mirror check also handles `fileStoreId` correctly