### PR TITLE
fix: size split coins to match operational requirements

### DIFF
--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -9,6 +9,7 @@ import { OrganizationsV2 } from '../models/v2/index.js';
 import { logger } from '../config/logger.js';
 import { getChiaRoot } from '../utils/chia-root.js';
 import { getMirrorUrl, decodeHex } from '../utils/datalayer-utils';
+import { isSplitInProgress } from '../tasks/coin-management.js';
 
 process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
 
@@ -206,9 +207,17 @@ const checkWalletBalanceForMirror = async (coinAmount, fee) => {
       );
       return { sufficient: true, fee: 0, balanceXCH: balanceXCH };
     } else {
-      logger.error(
-        `Insufficient funds: need ${coinAmount} mojos, have ${balanceMojos} mojos (balance: ${balanceXCH} XCH)`,
-      );
+      if (isSplitInProgress()) {
+        logger.warn(
+          `Wallet balance temporarily reduced by coin split in progress ` +
+          `(have ${balanceMojos} mojos, need ${coinAmount} mojos). ` +
+          `Skipping mirror creation - will retry after split confirms.`,
+        );
+      } else {
+        logger.error(
+          `Insufficient funds: need ${coinAmount} mojos, have ${balanceMojos} mojos (balance: ${balanceXCH} XCH)`,
+        );
+      }
       return { sufficient: false, fee: 0, balanceXCH: balanceXCH };
     }
   } catch (error) {

--- a/src/tasks/coin-management.js
+++ b/src/tasks/coin-management.js
@@ -12,11 +12,15 @@ const APP_CONFIG = CONFIG.APP;
 
 // Coin management constants
 const TARGET_COIN_COUNT = 15;      // Number of coins to maintain
-const COIN_SIZE = 1000000;         // Size of each coin in mojos (0.000001 XCH - matches xch_spam_amount)
-const MIN_COIN_SIZE = 1000000;     // Minimum acceptable coin size in mojos (matches default xch_spam_amount)
 const SPLIT_FEE = APP_CONFIG.DEFAULT_FEE || 3000; // Fee from config, fallback to 3000 mojos
 const DEFAULT_COIN_AMOUNT = APP_CONFIG.DEFAULT_COIN_AMOUNT || 300; // Coin amount for DataLayer operations from config
 const MIN_USABLE_COIN_SIZE = DEFAULT_COIN_AMOUNT + SPLIT_FEE; // A coin must cover both the operation amount and the fee to be usable
+const COIN_SIZE = MIN_USABLE_COIN_SIZE; // Each split coin must independently fund one full operation (amount + fee)
+const MIN_COIN_SIZE = MIN_USABLE_COIN_SIZE; // Minimum acceptable coin size must match operational requirement
+
+// Exported flag so other tasks (mirror check, etc.) can avoid operating
+// while a coin split has temporarily reduced the wallet's spendable balance.
+let splitInProgress = false;
 
 // 6 hours in seconds
 const SIX_HOURS_IN_SECONDS = 6 * 60 * 60;
@@ -106,11 +110,35 @@ const waitForSplitConfirmation = async (expectedNewCoins, originalCoinId) => {
 };
 
 /**
- * Check wallet coin count and split if necessary
- * Creates up to 15 coins of 1000000 mojos each for DataLayer operations
- * Uses DEFAULT_FEE from config for the split transaction fee
- * A coin is considered "usable" if its amount >= DEFAULT_COIN_AMOUNT + DEFAULT_FEE (must cover both operation and fee)
- * Will not split if resulting coins would be below MIN_COIN_SIZE (1000000 mojos)
+ * Execute a coin split and wait for confirmation, setting the splitInProgress
+ * flag so other tasks know the wallet balance is temporarily reduced.
+ */
+const executeSplit = async (coinId, numberOfCoins) => {
+  logger.info(`[COIN_MANAGEMENT] Splitting coin ${coinId} into ${numberOfCoins} new coins of ${COIN_SIZE} mojos each (fee: ${SPLIT_FEE} mojos)`);
+
+  splitInProgress = true;
+  try {
+    const splitResult = await wallet.splitCoins(coinId, numberOfCoins, COIN_SIZE, SPLIT_FEE);
+
+    if (splitResult.success) {
+      logger.info(`[COIN_MANAGEMENT] Successfully initiated coin split. Waiting for ${numberOfCoins} new coins of ${COIN_SIZE} mojos to confirm...`);
+      const confirmed = await waitForSplitConfirmation(numberOfCoins, coinId);
+      if (!confirmed) {
+        logger.warn('[COIN_MANAGEMENT] Split transaction may still be pending. Coins will be available once confirmed.');
+      }
+    } else {
+      logger.error(`[COIN_MANAGEMENT] Failed to split coins: ${splitResult.error}`);
+    }
+  } finally {
+    splitInProgress = false;
+  }
+};
+
+/**
+ * Check wallet coin count and split if necessary.
+ * Creates coins sized at DEFAULT_COIN_AMOUNT + DEFAULT_FEE so each coin can
+ * independently fund one DataLayer operation (mirror, store creation, etc.).
+ * Will create as many coins as the wallet can afford, up to TARGET_COIN_COUNT.
  */
 const runCoinManagement = async () => {
   logger.info('[COIN_MANAGEMENT] Starting coin management check');
@@ -191,16 +219,6 @@ const runCoinManagement = async () => {
     const coinsNeeded = TARGET_COIN_COUNT - coinCount;
     const requiredAmount = (coinsNeeded * COIN_SIZE) + SPLIT_FEE;
 
-    // Check if resulting coins would be above the minimum acceptable size
-    // Coins must be larger than xch_spam_amount (default 1,000,000 mojos) to be usable
-    if (COIN_SIZE < MIN_COIN_SIZE) {
-      logger.error(
-        `[COIN_MANAGEMENT] COIN_SIZE (${COIN_SIZE} mojos) is below MIN_COIN_SIZE (${MIN_COIN_SIZE} mojos). ` +
-        `Coins must be larger than xch_spam_amount to be usable. Aborting split.`
-      );
-      return;
-    }
-
     // Check if we have enough mojos in the largest coin
     if (largestCoinAmount < requiredAmount) {
       const currencySymbol = await getCurrencySymbol();
@@ -217,9 +235,9 @@ const runCoinManagement = async () => {
       // Verify the remainder (change) coin won't be below MIN_COIN_SIZE
       const totalSplitAmount = (maxPossibleCoins * COIN_SIZE) + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
+      let adjustedCoins = maxPossibleCoins;
       if (remainderAmount > 0 && remainderAmount < MIN_COIN_SIZE) {
-        // Reduce coins by one so the remainder stays above MIN_COIN_SIZE
-        const adjustedCoins = maxPossibleCoins - 1;
+        adjustedCoins = maxPossibleCoins - 1;
         if (adjustedCoins < 1) {
           logger.warn(
             `[COIN_MANAGEMENT] WARNING: Cannot split without creating a remainder coin below ${MIN_COIN_SIZE} mojos ` +
@@ -231,37 +249,15 @@ const runCoinManagement = async () => {
           `[COIN_MANAGEMENT] Reducing split from ${maxPossibleCoins} to ${adjustedCoins} coins to avoid ` +
           `creating a remainder below ${MIN_COIN_SIZE} mojos.`
         );
-        const splitResult = await wallet.splitCoins(coinId, adjustedCoins, COIN_SIZE, SPLIT_FEE);
-        if (splitResult.success) {
-          logger.info(`[COIN_MANAGEMENT] Successfully initiated coin split. Waiting for ${adjustedCoins} new coins of ${COIN_SIZE} mojos to confirm...`);
-          const confirmed = await waitForSplitConfirmation(adjustedCoins, coinId);
-          if (!confirmed) {
-            logger.warn('[COIN_MANAGEMENT] Split transaction may still be pending. Coins will be available once confirmed.');
-          }
-        } else {
-          logger.error(`[COIN_MANAGEMENT] Failed to split coins: ${splitResult.error}`);
-        }
-        return;
       }
 
       logger.warn(
         `[COIN_MANAGEMENT] WARNING: Insufficient balance to create ${coinsNeeded} coins. ` +
         `Need ${formatMojos(requiredAmount, currencySymbol)} but largest coin only has ${formatMojos(largestCoinAmount, currencySymbol)}. ` +
-        `Creating ${maxPossibleCoins} coins instead.`
+        `Creating ${adjustedCoins} coins instead.`
       );
 
-      // Create as many as we can
-      const splitResult = await wallet.splitCoins(coinId, maxPossibleCoins, COIN_SIZE, SPLIT_FEE);
-      if (splitResult.success) {
-        logger.info(`[COIN_MANAGEMENT] Successfully initiated coin split. Waiting for ${maxPossibleCoins} new coins of ${COIN_SIZE} mojos to confirm...`);
-        // Wait for the split to confirm before returning
-        const confirmed = await waitForSplitConfirmation(maxPossibleCoins, coinId);
-        if (!confirmed) {
-          logger.warn('[COIN_MANAGEMENT] Split transaction may still be pending. Coins will be available once confirmed.');
-        }
-      } else {
-        logger.error(`[COIN_MANAGEMENT] Failed to split coins: ${splitResult.error}`);
-      }
+      await executeSplit(coinId, adjustedCoins);
       return;
     }
 
@@ -271,7 +267,6 @@ const runCoinManagement = async () => {
     let actualCoinsToCreate = coinsNeeded;
 
     if (remainderAmount > 0 && remainderAmount < MIN_COIN_SIZE) {
-      // Reduce coins by one so the remainder stays above MIN_COIN_SIZE
       actualCoinsToCreate = coinsNeeded - 1;
       if (actualCoinsToCreate < 1) {
         logger.warn(
@@ -285,20 +280,7 @@ const runCoinManagement = async () => {
       );
     }
 
-    logger.info(`[COIN_MANAGEMENT] Splitting coin ${coinId} into ${actualCoinsToCreate} new coins of ${COIN_SIZE} mojos each (fee: ${SPLIT_FEE} mojos)`);
-
-    const splitResult = await wallet.splitCoins(coinId, actualCoinsToCreate, COIN_SIZE, SPLIT_FEE);
-
-    if (splitResult.success) {
-      logger.info(`[COIN_MANAGEMENT] Successfully initiated coin split. Waiting for ${actualCoinsToCreate} new coins of ${COIN_SIZE} mojos to confirm...`);
-      // Wait for the split to confirm before returning
-      const confirmed = await waitForSplitConfirmation(actualCoinsToCreate, coinId);
-      if (!confirmed) {
-        logger.warn('[COIN_MANAGEMENT] Split transaction may still be pending. Coins will be available once confirmed.');
-      }
-    } else {
-      logger.error(`[COIN_MANAGEMENT] Failed to split coins: ${splitResult.error}`);
-    }
+    await executeSplit(coinId, actualCoinsToCreate);
 
   } catch (error) {
     logger.error(`[COIN_MANAGEMENT] Error during coin management: ${error.message}`);
@@ -320,6 +302,8 @@ const job = new SimpleIntervalJob(
   { id: 'coin-management', preventOverrun: true },
 );
 
-// Export runCoinManagement for direct invocation during startup
-export { runCoinManagement };
+// Export runCoinManagement for direct invocation during startup.
+// splitInProgress is exported as a getter so consumers always read the live value.
+const isSplitInProgress = () => splitInProgress;
+export { runCoinManagement, isSplitInProgress };
 export default job;

--- a/tests/v2/integration/coin-management.spec.js
+++ b/tests/v2/integration/coin-management.spec.js
@@ -8,8 +8,8 @@ import wallet from '../../../src/datalayer/wallet.js';
  *
  * Tests for coin-management background task that ensures the wallet
  * has at least 15 coins for optimal CADT operation.
- * A coin is "usable" if its amount >= DEFAULT_COIN_AMOUNT + DEFAULT_FEE (must cover both operation and fee).
- * Coins must also exceed xch_spam_amount (default 1000000 mojos).
+ * Each coin is sized at DEFAULT_COIN_AMOUNT + DEFAULT_FEE so it can
+ * independently fund one full DataLayer operation (amount + fee).
  */
 describe('Coin Management Task Tests', function () {
   this.timeout(30000);
@@ -110,14 +110,16 @@ describe('Coin Management Task Tests', function () {
   });
 
   describe('Coin Splitting Calculations', function () {
-    // Constants matching coin-management.js
-    const COIN_SIZE = 1000000;         // Size of each coin in mojos (0.000001 XCH - matches xch_spam_amount)
-    const MIN_COIN_SIZE = 1000000;     // Minimum acceptable coin size (xch_spam_amount)
+    // Constants matching coin-management.js (using simulator/default config values)
+    const DEFAULT_COIN_AMOUNT = 300;   // DEFAULT_COIN_AMOUNT from config (simulator default)
     const SPLIT_FEE = 3000;            // Default fee (from config)
+    const MIN_USABLE_COIN_SIZE = DEFAULT_COIN_AMOUNT + SPLIT_FEE; // 3300
+    const COIN_SIZE = MIN_USABLE_COIN_SIZE; // Each coin must fund one full operation
+    const MIN_COIN_SIZE = MIN_USABLE_COIN_SIZE;
     const TARGET_COIN_COUNT = 15;      // Number of coins to maintain
 
-    it('should calculate correct coin size', function () {
-      expect(COIN_SIZE).to.equal(1000000);
+    it('should set COIN_SIZE equal to MIN_USABLE_COIN_SIZE', function () {
+      expect(COIN_SIZE).to.equal(MIN_USABLE_COIN_SIZE);
     });
 
     it('should ensure COIN_SIZE meets MIN_COIN_SIZE', function () {
@@ -125,10 +127,10 @@ describe('Coin Management Task Tests', function () {
     });
 
     it('should calculate max possible coins correctly', function () {
-      const largestCoinAmount = 5000000; // 5,000,000 mojos
+      const largestCoinAmount = 20000; // 20,000 mojos
       const maxPossibleCoins = Math.floor((largestCoinAmount - SPLIT_FEE) / COIN_SIZE);
-      // (5000000 - 3000) / 1000000 = 4.997 = 4
-      expect(maxPossibleCoins).to.equal(4);
+      // (20000 - 3000) / 3300 = 5.15 = 5
+      expect(maxPossibleCoins).to.equal(5);
     });
 
     it('should determine coins to create based on need and availability', function () {
@@ -152,7 +154,7 @@ describe('Coin Management Task Tests', function () {
     it('should handle case where coin is too small to split', function () {
       const largestCoinAmount = 3000; // Exactly the fee amount
       const maxPossibleCoins = Math.floor((largestCoinAmount - SPLIT_FEE) / COIN_SIZE);
-      // (3000 - 3000) / 1000000 = 0
+      // (3000 - 3000) / 3300 = 0
       expect(maxPossibleCoins).to.equal(0);
     });
 
@@ -160,41 +162,39 @@ describe('Coin Management Task Tests', function () {
       const currentCoinCount = 1;
       const coinsNeeded = TARGET_COIN_COUNT - currentCoinCount; // 14
       const requiredAmount = (coinsNeeded * COIN_SIZE) + SPLIT_FEE;
-      // (14 * 1000000) + 3000 = 14003000
-      expect(requiredAmount).to.equal(14003000);
+      // (14 * 3300) + 3000 = 49200
+      expect(requiredAmount).to.equal(49200);
     });
 
     it('should detect when remainder would be below MIN_COIN_SIZE', function () {
-      // Scenario: coin of 2500000 mojos, splitting into 2 coins of 1000000 each + 3000 fee
-      const largestCoinAmount = 2500000;
+      // Scenario: coin of 10000 mojos, splitting into 2 coins of 3300 each + 3000 fee
+      const largestCoinAmount = 10000;
       const coinsToCreate = 2;
       const totalSplitAmount = (coinsToCreate * COIN_SIZE) + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
-      // 2500000 - (2000000 + 3000) = 497000
-      expect(remainderAmount).to.equal(497000);
+      // 10000 - (6600 + 3000) = 400
+      expect(remainderAmount).to.equal(400);
       expect(remainderAmount).to.be.lessThan(MIN_COIN_SIZE);
     });
 
     it('should allow split when remainder is zero', function () {
       // Exact amount: 2 coins + fee, no remainder
-      const largestCoinAmount = (2 * COIN_SIZE) + SPLIT_FEE; // 2003000
+      const largestCoinAmount = (2 * COIN_SIZE) + SPLIT_FEE; // 9600
       const coinsToCreate = 2;
       const totalSplitAmount = (coinsToCreate * COIN_SIZE) + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
       expect(remainderAmount).to.equal(0);
-      // Zero remainder is fine (no dust coin created)
       const shouldReduceCoins = remainderAmount > 0 && remainderAmount < MIN_COIN_SIZE;
       expect(shouldReduceCoins).to.be.false;
     });
 
     it('should allow split when remainder exceeds MIN_COIN_SIZE', function () {
-      // Large coin with plenty of remainder
       const largestCoinAmount = 500000000; // 0.5 XCH
       const coinsToCreate = 3;
       const totalSplitAmount = (coinsToCreate * COIN_SIZE) + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
-      // 500000000 - (3000000 + 3000) = 496997000
-      expect(remainderAmount).to.equal(496997000);
+      // 500000000 - (9900 + 3000) = 499987100
+      expect(remainderAmount).to.equal(499987100);
       expect(remainderAmount).to.be.greaterThan(MIN_COIN_SIZE);
     });
   });
@@ -221,9 +221,9 @@ describe('Coin Management Task Tests', function () {
     });
 
     it('should format COIN_SIZE amount correctly', function () {
-      const mojos = 1000000; // COIN_SIZE (0.000001 XCH)
+      const mojos = 3300; // COIN_SIZE in simulator config (DEFAULT_COIN_AMOUNT + DEFAULT_FEE)
       const xch = mojos / 1000000000000;
-      expect(xch).to.equal(0.000001);
+      expect(xch).to.equal(0.0000000033);
     });
   });
 
@@ -260,12 +260,12 @@ describe('Coin Management Task Tests', function () {
 
   describe('Remaining Transactions Calculation', function () {
     it('should calculate remaining transactions correctly', function () {
-      const COIN_SIZE = 1000000;
-      const currentBalance = 1000000000; // 1 billion mojos (1 XCH)
+      const coinSize = 600000000; // Production COIN_SIZE (DEFAULT_COIN_AMOUNT + DEFAULT_FEE)
+      const currentBalance = 9000000000000; // 9 XCH in mojos
 
-      const remainingTransactions = Math.floor(currentBalance / COIN_SIZE);
-      // 1000000000 / 1000000 = 1000
-      expect(remainingTransactions).to.equal(1000);
+      const remainingTransactions = Math.floor(currentBalance / coinSize);
+      // 9000000000000 / 600000000 = 15000
+      expect(remainingTransactions).to.equal(15000);
     });
   });
 


### PR DESCRIPTION
## Summary

- `COIN_SIZE` was hardcoded to 1,000,000 mojos while CADT operations require `DEFAULT_COIN_AMOUNT + DEFAULT_FEE` (typically 600,000,000 mojos on production configs). This caused a perpetual splitting loop where coins were created 600x too small to be "usable" by CADT's own criteria, wasting 300M mojo in fees every 6 hours and temporarily draining spendable balance.
- Set `COIN_SIZE = MIN_USABLE_COIN_SIZE` (`DEFAULT_COIN_AMOUNT + DEFAULT_FEE`) so each split coin can independently fund one full DataLayer operation (mirror creation, store creation, etc.).
- Added a `splitInProgress` flag exported from coin-management so `checkWalletBalanceForMirror` in persistance.js logs a warning (not an error) when balance is temporarily reduced during an active coin split, making logs actionable instead of alarming.
- Consolidated three duplicate split-and-wait code paths into a single `executeSplit()` helper.

## Root Cause

On a system with `DEFAULT_COIN_AMOUNT=300000000` and `DEFAULT_FEE=300000000`:
1. `COIN_SIZE` was 1M mojos but `MIN_USABLE_COIN_SIZE` was 600M mojos — split coins were never considered "usable"
2. Coin management ran every 6 hours, found 0 usable coins, split the largest coin into 1M mojo pieces (burning 300M in fees), timed out waiting for 15 coins ≥ 600M, repeated forever
3. During the ~10-minute split confirmation window, the source coin was locked and `spendable_balance` dropped, causing mirror-check to log "Insufficient funds" errors

## Test plan

- [x] All 32 coin management unit tests updated and passing
- [x] Full v2 integration suite passes (1225 passing, 1 pre-existing failure unrelated to this change)
- [ ] Deploy to testnet instance and verify coin management creates coins of the correct size
- [ ] Verify mirror creation succeeds without "insufficient funds" errors after split completes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coin-splitting amounts and transaction flow in the wallet maintenance task, which can affect spendable balances and DataLayer operation reliability if mis-sized or mis-triggered. The changes are localized but touch on-chain transaction behavior and retry timing.
> 
> **Overview**
> Fixes the coin-management task to size split outputs at `DEFAULT_COIN_AMOUNT + DEFAULT_FEE` (instead of a hardcoded 1,000,000 mojos) so each resulting coin can independently fund a full DataLayer operation, avoiding repeated under-sized splits and wasted fees.
> 
> Refactors split logic into a single `executeSplit()` path and exports `isSplitInProgress()`; `checkWalletBalanceForMirror` now logs a warning and skips mirror creation when spendable balance is temporarily reduced by an in-flight split. Updates coin-management integration tests to match the new sizing and calculation expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20baea764d08e33afa908b41e67989995d137449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->