### PR TITLE
feat: add in-memory concurrency guard for organization operations

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -450,7 +450,7 @@ Response
 
 #### Get organization creation status
 
-Returns the status of any in-progress, completed, or failed organization creation process. This endpoint is useful for monitoring the progress of organization creation, which involves creating multiple blockchain stores.
+Returns the status of any in-progress, completed, or failed organization creation **or upgrade** process. This endpoint is useful for monitoring the progress of organization creation, which involves creating multiple blockchain stores.
 
 **Organization creation now uses parallel store creation, significantly reducing the time required compared to sequential creation.**
 
@@ -502,6 +502,33 @@ Response states:
 | COMPLETE | Organization creation finished successfully |
 | FAILED | Organization creation failed after max retries |
 
+Response when an upgrade is in progress (showing `liveStatus`):
+```json
+{
+    "inProgress": true,
+    "state": null,
+    "message": "No organization creation in progress",
+    "operation": "V1 to V2 upgrade",
+    "status": "Waiting for V2 registry store to confirm on blockchain",
+    "startedAt": "2026-01-26T12:00:00.000Z",
+    "elapsedSeconds": 195,
+    "liveStatus": {
+        "operation": "V1 to V2 upgrade",
+        "status": "Waiting for V2 registry store to confirm on blockchain",
+        "startedAt": "2026-01-26T12:00:00.000Z",
+        "elapsedSeconds": 195
+    },
+    "success": true
+}
+```
+
+> **Note:** This endpoint reports status from two sources:
+>
+> - **Meta table state** (detailed store-by-store progress for organization creation, with `state`, `stores`, and `progress` fields)
+> - **Live operation status** (in-memory status for any running operation including upgrades, in the `liveStatus` field)
+>
+> When both sources have data (e.g., during creation), both are included. When only an upgrade is running, the `liveStatus` field provides the status.
+
 **Crash Recovery:** If the server crashes or restarts during organization creation, it will automatically attempt to resume from where it left off. The server will retry up to 3 times before marking the creation as failed.
 
 ---
@@ -543,6 +570,7 @@ POST Options:
 - **Track the status of organization creation using the `/v2/organizations/creation-status` endpoint.**
 - If the server crashes or restarts during creation, it will automatically attempt to resume from where it left off (up to 3 retries).
 - V2 organizations can be created with either a JSON body or by uploading a file containing organization data.
+- **Only one organization operation (create, upgrade, or reclaim) can run at a time.** If another operation is already in progress, the endpoint returns `409 Conflict` with the current operation status.
 
 **Using JSON body:**
 
@@ -579,6 +607,20 @@ Response
 }
 ```
 
+Response (operation in progress - 409 Conflict)
+```json
+{
+    "message": "A home organization operation is already in progress: V2 organization creation. Please wait for it to complete.",
+    "operationStatus": {
+        "operation": "V2 organization creation",
+        "status": "Waiting for stores to confirm on blockchain (2/4 confirmed)",
+        "startedAt": "2026-01-26T12:00:00.000Z",
+        "elapsedSeconds": 195
+    },
+    "success": false
+}
+```
+
 ---
 
 #### Upgrade V1 organization to V2
@@ -586,6 +628,8 @@ Response
 - This endpoint allows existing V1 organizations to be upgraded to V2.
 - The upgrade process migrates V1 organization data to V2 format while maintaining V1/V2 isolation.
 - **Note**: The request body is optional. The endpoint automatically detects and uses the existing V1 home organization.
+- **Only one organization operation can run at a time.** If a creation, upgrade, or reclaim is already in progress, the endpoint returns `409 Conflict` with the current operation status.
+- **Track upgrade progress using the `/v2/organizations/creation-status` endpoint**, which now also reports upgrade status.
 
 Fields:
 
@@ -607,6 +651,20 @@ Response
 {
     "message": "Organization upgrade initiated successfully",
     "success": true
+}
+```
+
+Response (operation in progress - 409 Conflict)
+```json
+{
+    "message": "A home organization operation is already in progress: V2 organization creation. Please wait for it to complete.",
+    "operationStatus": {
+        "operation": "V2 organization creation",
+        "status": "Waiting for stores to confirm on blockchain (2/4 confirmed)",
+        "startedAt": "2026-01-26T12:00:00.000Z",
+        "elapsedSeconds": 195
+    },
+    "success": false
 }
 ```
 
@@ -897,6 +955,20 @@ Response (store not owned)
 {
     "message": "Error reclaiming home organization",
     "error": "store id b3d4e71d... is not owned by this chia wallet",
+    "success": false
+}
+```
+
+Response (operation in progress - 409 Conflict)
+```json
+{
+    "message": "A home organization operation is already in progress: V1 to V2 upgrade. Please wait for it to complete.",
+    "operationStatus": {
+        "operation": "V1 to V2 upgrade",
+        "status": "Waiting for data model version update to confirm on blockchain",
+        "startedAt": "2026-01-26T12:00:00.000Z",
+        "elapsedSeconds": 300
+    },
     "success": false
 }
 ```

--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -507,7 +507,7 @@ Response when an upgrade is in progress (showing `liveStatus`):
 {
     "inProgress": true,
     "state": null,
-    "message": "No organization creation in progress",
+    "message": "V1 to V2 upgrade: Waiting for V2 registry store to confirm on blockchain",
     "operation": "V1 to V2 upgrade",
     "status": "Waiting for V2 registry store to confirm on blockchain",
     "startedAt": "2026-01-26T12:00:00.000Z",

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -134,8 +134,8 @@ export const editHomeOrg = async (req, res) => {
 };
 
 export const createV2 = async (req, res) => {
-  let lockAcquired = false;
-  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
+  let lockToken = null;
+  const releaseLock = () => { if (lockToken) { const t = lockToken; lockToken = null; releaseOrgLock(t); } };
   try {
     await assertIfReadOnlyMode();
     await assertWalletIsSynced();
@@ -157,7 +157,8 @@ export const createV2 = async (req, res) => {
         });
       }
 
-      if (!tryAcquireOrgLock('V1 organization creation')) {
+      lockToken = tryAcquireOrgLock('V1 organization creation');
+      if (!lockToken) {
         const lockStatus = getOrgLockStatus();
         return res.status(409).json({
           message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
@@ -165,7 +166,6 @@ export const createV2 = async (req, res) => {
           success: false,
         });
       }
-      lockAcquired = true;
 
       const { name } = req.body;
       let icon;
@@ -179,6 +179,8 @@ export const createV2 = async (req, res) => {
 
       const dataModelVersion = 'v1';
 
+      const bgToken = lockToken;
+      lockToken = null;
       Organization.createHomeOrganization(name, icon, dataModelVersion)
         .catch((error) => {
           logger.error(
@@ -186,9 +188,8 @@ export const createV2 = async (req, res) => {
           );
         })
         .finally(() => {
-          releaseOrgLock();
+          releaseOrgLock(bgToken);
         });
-      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -208,8 +209,8 @@ export const createV2 = async (req, res) => {
 };
 
 export const create = async (req, res) => {
-  let lockAcquired = false;
-  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
+  let lockToken = null;
+  const releaseLock = () => { if (lockToken) { const t = lockToken; lockToken = null; releaseOrgLock(t); } };
   try {
     await assertIfReadOnlyMode();
     await assertWalletIsSynced();
@@ -225,7 +226,6 @@ export const create = async (req, res) => {
     } else {
       const { name, icon } = req.body;
 
-      // Validate name is required
       if (!name) {
         return res.status(400).json({
           message: 'Organization name is required',
@@ -240,7 +240,8 @@ export const create = async (req, res) => {
         });
       }
 
-      if (!tryAcquireOrgLock('V1 organization creation')) {
+      lockToken = tryAcquireOrgLock('V1 organization creation');
+      if (!lockToken) {
         const lockStatus = getOrgLockStatus();
         return res.status(409).json({
           message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
@@ -248,16 +249,12 @@ export const create = async (req, res) => {
           success: false,
         });
       }
-      lockAcquired = true;
 
-      // Icon is optional - use provided value or default to empty string
-      // Icon can be any string (URL, base64-encoded data, etc.) or empty
       const iconValue = icon !== undefined && icon !== null ? icon : '';
-
       const dataModelVersion = 'v1';
 
-      // Call createHomeOrganization asynchronously (don't await)
-      // This allows the HTTP request to return immediately while creation happens in background
+      const bgToken = lockToken;
+      lockToken = null;
       Organization.createHomeOrganization(name, iconValue, dataModelVersion)
         .catch((error) => {
           logger.error(
@@ -265,9 +262,8 @@ export const create = async (req, res) => {
           );
         })
         .finally(() => {
-          releaseOrgLock();
+          releaseOrgLock(bgToken);
         });
-      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -620,12 +616,13 @@ export const removeMirror = async (req, res) => {
  * @param {Object} res - Express response object
  */
 export const reclaimHome = async (req, res) => {
-  let lockAcquired = false;
-  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
+  let lockToken = null;
+  const releaseLock = () => { if (lockToken) { const t = lockToken; lockToken = null; releaseOrgLock(t); } };
   try {
     await assertIfReadOnlyMode();
 
-    if (!tryAcquireOrgLock('V1 home organization reclaim')) {
+    lockToken = tryAcquireOrgLock('V1 home organization reclaim');
+    if (!lockToken) {
       const lockStatus = getOrgLockStatus();
       return res.status(409).json({
         message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
@@ -633,7 +630,6 @@ export const reclaimHome = async (req, res) => {
         success: false,
       });
     }
-    lockAcquired = true;
 
     try {
     await assertWalletIsSynced();

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -181,7 +181,7 @@ export const createV2 = async (req, res) => {
 
       const bgToken = lockToken;
       lockToken = null;
-      Organization.createHomeOrganization(name, icon, dataModelVersion)
+      Organization.createHomeOrganization(name, icon, dataModelVersion, bgToken)
         .catch((error) => {
           logger.error(
             `[v1]: Error creating home organization in background: ${error.message}`,
@@ -255,7 +255,7 @@ export const create = async (req, res) => {
 
       const bgToken = lockToken;
       lockToken = null;
-      Organization.createHomeOrganization(name, iconValue, dataModelVersion)
+      Organization.createHomeOrganization(name, iconValue, dataModelVersion, bgToken)
         .catch((error) => {
           logger.error(
             `[v1]: Error creating home organization in background: ${error.message}`,

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -11,12 +11,18 @@ import {
 } from '../utils/data-assertions';
 
 
-import { ModelKeys, Audit, Organization, Staging } from '../models';
+import { ModelKeys, Audit, Organization, Staging, Meta } from '../models';
 import { getOwnedStores, getSubscriptions, getStoreData as getRawStoreData } from '../datalayer/persistance.js';
 import * as simulator from '../datalayer/simulator.js';
 import { decodeDataLayerResponse } from '../utils/datalayer-utils.js';
 import { getConfig } from '../utils/config-loader.js';
 import { logger } from '../config/logger';
+import {
+  tryAcquireOrgLock,
+  releaseOrgLock,
+  getOrgLockStatus,
+} from '../utils/org-operation-lock.js';
+import { hasInProgressCreation } from '../utils/organization-creation-state.js';
 
 const { USE_SIMULATOR } = getConfig().APP;
 
@@ -142,6 +148,22 @@ export const createV2 = async (req, res) => {
         success: false,
       });
     } else {
+      if (await hasInProgressCreation(Meta, 'v1')) {
+        return res.status(409).json({
+          message: 'A V1 organization creation is still in progress (from a previous session). Check status at GET /v1/organizations/creation-status.',
+          success: false,
+        });
+      }
+
+      if (!tryAcquireOrgLock('V1 organization creation')) {
+        const lockStatus = getOrgLockStatus();
+        return res.status(409).json({
+          message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
+          operationStatus: lockStatus,
+          success: false,
+        });
+      }
+
       const { name } = req.body;
       let icon;
 
@@ -154,7 +176,15 @@ export const createV2 = async (req, res) => {
 
       const dataModelVersion = 'v1';
 
-      Organization.createHomeOrganization(name, icon, dataModelVersion);
+      Organization.createHomeOrganization(name, icon, dataModelVersion)
+        .catch((error) => {
+          logger.error(
+            `[v1]: Error creating home organization in background: ${error.message}`,
+          );
+        })
+        .finally(() => {
+          releaseOrgLock();
+        });
 
       return res.json({
         message:
@@ -163,6 +193,7 @@ export const createV2 = async (req, res) => {
       });
     }
   } catch (error) {
+    releaseOrgLock();
     console.trace(error);
     res.status(400).json({
       message: 'Error initiating your organization',
@@ -196,6 +227,22 @@ export const create = async (req, res) => {
         });
       }
 
+      if (await hasInProgressCreation(Meta, 'v1')) {
+        return res.status(409).json({
+          message: 'A V1 organization creation is still in progress (from a previous session). Check status at GET /v1/organizations/creation-status.',
+          success: false,
+        });
+      }
+
+      if (!tryAcquireOrgLock('V1 organization creation')) {
+        const lockStatus = getOrgLockStatus();
+        return res.status(409).json({
+          message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
+          operationStatus: lockStatus,
+          success: false,
+        });
+      }
+
       // Icon is optional - use provided value or default to empty string
       // Icon can be any string (URL, base64-encoded data, etc.) or empty
       const iconValue = icon !== undefined && icon !== null ? icon : '';
@@ -204,13 +251,15 @@ export const create = async (req, res) => {
 
       // Call createHomeOrganization asynchronously (don't await)
       // This allows the HTTP request to return immediately while creation happens in background
-      Organization.createHomeOrganization(name, iconValue, dataModelVersion).catch(
-        (error) => {
+      Organization.createHomeOrganization(name, iconValue, dataModelVersion)
+        .catch((error) => {
           logger.error(
             `[v1]: Error creating home organization in background: ${error.message}`,
           );
-        },
-      );
+        })
+        .finally(() => {
+          releaseOrgLock();
+        });
 
       return res.json({
         message:
@@ -219,6 +268,7 @@ export const create = async (req, res) => {
       });
     }
   } catch (error) {
+    releaseOrgLock();
     res.status(400).json({
       message: 'Error initiating your organization',
       error: error.message,
@@ -564,8 +614,18 @@ export const removeMirror = async (req, res) => {
 export const reclaimHome = async (req, res) => {
   try {
     await assertIfReadOnlyMode();
-    await assertWalletIsSynced();
 
+    if (!tryAcquireOrgLock('V1 home organization reclaim')) {
+      const lockStatus = getOrgLockStatus();
+      return res.status(409).json({
+        message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
+        operationStatus: lockStatus,
+        success: false,
+      });
+    }
+
+    try {
+    await assertWalletIsSynced();
     const { orgUid } = req.body;
 
     const org = await Organization.findOne({
@@ -729,7 +789,11 @@ export const reclaimHome = async (req, res) => {
       message: `Organization ${orgUid} has been reclaimed as the home organization.`,
       success: true,
     });
+    } finally {
+      releaseOrgLock();
+    }
   } catch (error) {
+    releaseOrgLock();
     logger.error(`[v1]: Error reclaiming home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error reclaiming home organization',

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -134,6 +134,7 @@ export const editHomeOrg = async (req, res) => {
 };
 
 export const createV2 = async (req, res) => {
+  let lockAcquired = false;
   try {
     await assertIfReadOnlyMode();
     await assertWalletIsSynced();
@@ -163,6 +164,7 @@ export const createV2 = async (req, res) => {
           success: false,
         });
       }
+      lockAcquired = true;
 
       const { name } = req.body;
       let icon;
@@ -193,7 +195,7 @@ export const createV2 = async (req, res) => {
       });
     }
   } catch (error) {
-    releaseOrgLock();
+    if (lockAcquired) releaseOrgLock();
     console.trace(error);
     res.status(400).json({
       message: 'Error initiating your organization',
@@ -204,6 +206,7 @@ export const createV2 = async (req, res) => {
 };
 
 export const create = async (req, res) => {
+  let lockAcquired = false;
   try {
     await assertIfReadOnlyMode();
     await assertWalletIsSynced();
@@ -242,6 +245,7 @@ export const create = async (req, res) => {
           success: false,
         });
       }
+      lockAcquired = true;
 
       // Icon is optional - use provided value or default to empty string
       // Icon can be any string (URL, base64-encoded data, etc.) or empty
@@ -268,7 +272,7 @@ export const create = async (req, res) => {
       });
     }
   } catch (error) {
-    releaseOrgLock();
+    if (lockAcquired) releaseOrgLock();
     res.status(400).json({
       message: 'Error initiating your organization',
       error: error.message,
@@ -612,6 +616,7 @@ export const removeMirror = async (req, res) => {
  * @param {Object} res - Express response object
  */
 export const reclaimHome = async (req, res) => {
+  let lockAcquired = false;
   try {
     await assertIfReadOnlyMode();
 
@@ -623,6 +628,7 @@ export const reclaimHome = async (req, res) => {
         success: false,
       });
     }
+    lockAcquired = true;
 
     try {
     await assertWalletIsSynced();
@@ -793,7 +799,7 @@ export const reclaimHome = async (req, res) => {
       releaseOrgLock();
     }
   } catch (error) {
-    releaseOrgLock();
+    if (lockAcquired) releaseOrgLock();
     logger.error(`[v1]: Error reclaiming home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error reclaiming home organization',

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -135,6 +135,7 @@ export const editHomeOrg = async (req, res) => {
 
 export const createV2 = async (req, res) => {
   let lockAcquired = false;
+  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
   try {
     await assertIfReadOnlyMode();
     await assertWalletIsSynced();
@@ -187,6 +188,7 @@ export const createV2 = async (req, res) => {
         .finally(() => {
           releaseOrgLock();
         });
+      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -195,7 +197,7 @@ export const createV2 = async (req, res) => {
       });
     }
   } catch (error) {
-    if (lockAcquired) releaseOrgLock();
+    releaseLock();
     console.trace(error);
     res.status(400).json({
       message: 'Error initiating your organization',
@@ -207,6 +209,7 @@ export const createV2 = async (req, res) => {
 
 export const create = async (req, res) => {
   let lockAcquired = false;
+  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
   try {
     await assertIfReadOnlyMode();
     await assertWalletIsSynced();
@@ -264,6 +267,7 @@ export const create = async (req, res) => {
         .finally(() => {
           releaseOrgLock();
         });
+      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -272,7 +276,7 @@ export const create = async (req, res) => {
       });
     }
   } catch (error) {
-    if (lockAcquired) releaseOrgLock();
+    releaseLock();
     res.status(400).json({
       message: 'Error initiating your organization',
       error: error.message,
@@ -617,6 +621,7 @@ export const removeMirror = async (req, res) => {
  */
 export const reclaimHome = async (req, res) => {
   let lockAcquired = false;
+  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
   try {
     await assertIfReadOnlyMode();
 
@@ -796,10 +801,10 @@ export const reclaimHome = async (req, res) => {
       success: true,
     });
     } finally {
-      releaseOrgLock();
+      releaseLock();
     }
   } catch (error) {
-    if (lockAcquired) releaseOrgLock();
+    releaseLock();
     logger.error(`[v1]: Error reclaiming home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error reclaiming home organization',

--- a/src/controllers/v2/organizations-v2.controller.js
+++ b/src/controllers/v2/organizations-v2.controller.js
@@ -83,6 +83,7 @@ const getStoreDataPromise = async (storeId) => {
  * @param {Object} res - Express response object
  */
 export const create = async (req, res) => {
+  let lockAcquired = false;
   try {
     await assertV2IfReadOnlyMode();
 
@@ -102,6 +103,7 @@ export const create = async (req, res) => {
         success: false,
       });
     }
+    lockAcquired = true;
 
     // Check if V1 home org exists in database (only if V1 is enabled)
     // When V1 is disabled, the V1 organizations table may not exist
@@ -234,7 +236,7 @@ export const create = async (req, res) => {
       });
     }
   } catch (error) {
-    releaseOrgLock();
+    if (lockAcquired) releaseOrgLock();
     loggerV2.error(`[v2]: Error creating V2 home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error creating V2 home organization',
@@ -250,6 +252,7 @@ export const create = async (req, res) => {
  * @param {Object} res - Express response object
  */
 export const upgrade = async (req, res) => {
+  let lockAcquired = false;
   try {
     await assertV2IfReadOnlyMode();
 
@@ -269,6 +272,7 @@ export const upgrade = async (req, res) => {
         success: false,
       });
     }
+    lockAcquired = true;
 
     // Note: assertWalletIsSyncedV2 and assertNoPendingCommitsExcludingTransfers don't exist yet
     // await assertWalletIsSyncedV2();
@@ -450,7 +454,7 @@ export const upgrade = async (req, res) => {
       });
     }
   } catch (error) {
-    releaseOrgLock();
+    if (lockAcquired) releaseOrgLock();
     loggerV2.error(`[v2]: Error upgrading to V2 organization: ${error.message}`);
     res.status(400).json({
       message: 'Error upgrading to V2 organization',
@@ -1132,6 +1136,7 @@ export const removeMirror = async (req, res) => {
  * @param {Object} res - Express response object
  */
 export const reclaimHome = async (req, res) => {
+  let lockAcquired = false;
   try {
     await assertV2IfReadOnlyMode();
 
@@ -1143,6 +1148,7 @@ export const reclaimHome = async (req, res) => {
         success: false,
       });
     }
+    lockAcquired = true;
 
     try {
     await assertWalletIsSynced();
@@ -1311,7 +1317,7 @@ export const reclaimHome = async (req, res) => {
       releaseOrgLock();
     }
   } catch (error) {
-    releaseOrgLock();
+    if (lockAcquired) releaseOrgLock();
     loggerV2.error(`[v2]: Error reclaiming home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error reclaiming home organization',

--- a/src/controllers/v2/organizations-v2.controller.js
+++ b/src/controllers/v2/organizations-v2.controller.js
@@ -38,6 +38,12 @@ import { getStoreData as getRawStoreData } from '../../datalayer/persistance.js'
 import * as simulator from '../../datalayer/simulator.js';
 import { decodeHex, decodeDataLayerResponse } from '../../utils/datalayer-utils.js';
 import { getConfig } from '../../utils/config-loader.js';
+import {
+  tryAcquireOrgLock,
+  releaseOrgLock,
+  getOrgLockStatus,
+} from '../../utils/org-operation-lock.js';
+import { hasInProgressCreation } from '../../utils/organization-creation-state.js';
 
 const { USE_SIMULATOR } = getConfig().APP;
 
@@ -80,6 +86,23 @@ export const create = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
 
+    const { MetaV2: MetaV2Model } = await import('../../models/v2/index.js');
+    if (await hasInProgressCreation(MetaV2Model, 'v2')) {
+      return res.status(409).json({
+        message: 'A V2 organization creation is still in progress (from a previous session). Check status at GET /v2/organizations/creation-status.',
+        success: false,
+      });
+    }
+
+    if (!tryAcquireOrgLock('V2 organization creation')) {
+      const lockStatus = getOrgLockStatus();
+      return res.status(409).json({
+        message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
+        operationStatus: lockStatus,
+        success: false,
+      });
+    }
+
     // Check if V1 home org exists in database (only if V1 is enabled)
     // When V1 is disabled, the V1 organizations table may not exist
     const configV1 = getConfig();
@@ -92,6 +115,7 @@ export const create = async (req, res) => {
       });
 
       if (v1Org) {
+        releaseOrgLock();
         // V1 org exists - check for V1 singleton in datalayer
         if (v1Org.dataModelVersionStoreId) {
           try {
@@ -141,6 +165,7 @@ export const create = async (req, res) => {
     });
 
     if (existingV2Org) {
+      releaseOrgLock();
       return res.status(400).json({
         message: 'V2 home organization already exists',
         success: false,
@@ -158,6 +183,7 @@ export const create = async (req, res) => {
     }
 
     if (!name) {
+      releaseOrgLock();
       return res.status(400).json({
         message: 'Organization name is required',
         success: false,
@@ -185,15 +211,21 @@ export const create = async (req, res) => {
           error: error.message,
           success: false,
         });
+      } finally {
+        releaseOrgLock();
       }
     } else {
       // Call createHomeOrganization asynchronously (don't await)
       // This allows the HTTP request to return immediately while creation happens in background
-      OrganizationsV2.createHomeOrganization(name, icon, 'v2').catch((error) => {
-        loggerV2.error(
-          `[v2]: Error creating V2 home organization in background: ${error.message}`,
-        );
-      });
+      OrganizationsV2.createHomeOrganization(name, icon, 'v2')
+        .catch((error) => {
+          loggerV2.error(
+            `[v2]: Error creating V2 home organization in background: ${error.message}`,
+          );
+        })
+        .finally(() => {
+          releaseOrgLock();
+        });
 
       return res.json({
         message:
@@ -219,6 +251,24 @@ export const create = async (req, res) => {
 export const upgrade = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
+
+    const { MetaV2: MetaV2Model } = await import('../../models/v2/index.js');
+    if (await hasInProgressCreation(MetaV2Model, 'v2')) {
+      return res.status(409).json({
+        message: 'A V2 organization creation is still in progress (from a previous session). Check status at GET /v2/organizations/creation-status.',
+        success: false,
+      });
+    }
+
+    if (!tryAcquireOrgLock('V1 to V2 upgrade')) {
+      const lockStatus = getOrgLockStatus();
+      return res.status(409).json({
+        message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
+        operationStatus: lockStatus,
+        success: false,
+      });
+    }
+
     // Note: assertWalletIsSyncedV2 and assertNoPendingCommitsExcludingTransfers don't exist yet
     // await assertWalletIsSyncedV2();
     // await assertNoPendingCommitsExcludingTransfers();
@@ -228,6 +278,7 @@ export const upgrade = async (req, res) => {
     const enableV1 = configV1?.ENABLE !== false;
 
     if (!enableV1) {
+      releaseOrgLock();
       return res.status(400).json({
         message: 'V1 is disabled. Cannot upgrade from V1 when V1 is not enabled.',
         success: false,
@@ -241,6 +292,7 @@ export const upgrade = async (req, res) => {
     });
 
     if (!v1Org) {
+      releaseOrgLock();
       return res.status(400).json({
         message:
           'V1 home organization not found. Cannot upgrade without existing V1 organization.',
@@ -251,6 +303,7 @@ export const upgrade = async (req, res) => {
     // CRITICAL: Verify V1 org is fully populated before attempting upgrade
     // Check required store IDs exist
     if (!v1Org.dataModelVersionStoreId) {
+      releaseOrgLock();
       return res.status(400).json({
         message:
           'V1 organization is missing dataModelVersionStoreId. Organization creation may still be in progress.',
@@ -261,6 +314,7 @@ export const upgrade = async (req, res) => {
     // Check that orgHash is populated (indicates org store data was written)
     const nullHash = '0x0000000000000000000000000000000000000000000000000000000000000000';
     if (!v1Org.orgHash || v1Org.orgHash === nullHash || v1Org.orgHash === '0') {
+      releaseOrgLock();
       return res.status(400).json({
         message:
           'V1 organization orgHash is not populated. Organization creation has not completed writing data to the org store. Please wait for V1 organization creation to complete.',
@@ -275,6 +329,7 @@ export const upgrade = async (req, res) => {
 
       if (!singletonData || singletonData instanceof Error) {
         loggerV2.debug(`[v2]: Cannot read singleton data from ${v1Org.dataModelVersionStoreId}`);
+        releaseOrgLock();
         return res.status(400).json({
           message:
             'Cannot read V1 singleton data. V1 organization may still be creating or blockchain data is not yet available. Please wait and try again.',
@@ -284,6 +339,7 @@ export const upgrade = async (req, res) => {
 
       if (!singletonData.keys_values || singletonData.keys_values.length === 0) {
         loggerV2.debug(`[v2]: Singleton store ${v1Org.dataModelVersionStoreId} is empty`);
+        releaseOrgLock();
         return res.status(400).json({
           message:
             'V1 singleton store is empty. V1 organization creation has not completed writing data to the blockchain. Please wait for V1 organization creation to complete before upgrading.',
@@ -300,6 +356,7 @@ export const upgrade = async (req, res) => {
 
       if (!singletonMap.v1) {
         loggerV2.debug(`[v2]: Singleton store ${v1Org.dataModelVersionStoreId} missing v1 key`);
+        releaseOrgLock();
         return res.status(400).json({
           message:
             'V1 singleton store does not contain v1 key. V1 organization creation has not completed. Please wait for V1 organization creation to fully complete before upgrading.',
@@ -310,6 +367,7 @@ export const upgrade = async (req, res) => {
       loggerV2.info(`[v2]: V1 singleton validated - v1 key exists with registry ${singletonMap.v1}`);
     } catch (error) {
       loggerV2.error(`[v2]: Error validating V1 singleton: ${error.message}`);
+      releaseOrgLock();
       return res.status(400).json({
         message:
           `Cannot validate V1 organization singleton store: ${error.message}. Please ensure V1 organization creation is complete before upgrading.`,
@@ -335,7 +393,7 @@ export const upgrade = async (req, res) => {
           }, {});
 
           if (singletonMap.v2 !== undefined) {
-            // Both V2 org exists and singleton has v2 key - upgrade already complete
+            releaseOrgLock();
             return res.status(400).json({
               message: 'V2 home organization already exists and upgrade is already complete.',
               success: false,
@@ -343,7 +401,6 @@ export const upgrade = async (req, res) => {
           }
         }
       } catch (error) {
-        // If we can't check singleton, proceed with upgrade attempt (might be partial upgrade)
         loggerV2.debug(`[v2]: Failed to check singleton for v2 key: ${error.message}`);
       }
     }
@@ -368,16 +425,22 @@ export const upgrade = async (req, res) => {
           error: error.message,
           success: false,
         });
+      } finally {
+        releaseOrgLock();
       }
     } else {
       // Call upgradeFromV1 asynchronously (don't await) in production mode
       // This allows the HTTP request to return immediately while upgrade happens in background
       // upgradeFromV1 will handle partial upgrades (V2 org exists but singleton missing v2 key)
-      OrganizationsV2.upgradeFromV1(name, icon).catch((error) => {
-        loggerV2.error(
-          `[v2]: Error upgrading V2 organization in background: ${error.message}`,
-        );
-      });
+      OrganizationsV2.upgradeFromV1(name, icon)
+        .catch((error) => {
+          loggerV2.error(
+            `[v2]: Error upgrading V2 organization in background: ${error.message}`,
+          );
+        })
+        .finally(() => {
+          releaseOrgLock();
+        });
 
       return res.json({
         message:
@@ -386,6 +449,7 @@ export const upgrade = async (req, res) => {
       });
     }
   } catch (error) {
+    releaseOrgLock();
     loggerV2.error(`[v2]: Error upgrading to V2 organization: ${error.message}`);
     res.status(400).json({
       message: 'Error upgrading to V2 organization',
@@ -483,9 +547,19 @@ export const homeOrgSyncStatus = async (req, res) => {
  */
 export const getCreationStatus = async (req, res) => {
   try {
-    const status = await OrganizationsV2.getCreationStatus();
+    const metaStatus = await OrganizationsV2.getCreationStatus();
+    const lockStatus = getOrgLockStatus();
+
     return res.json({
-      ...status,
+      ...metaStatus,
+      ...(lockStatus && !metaStatus.inProgress ? {
+        inProgress: true,
+        operation: lockStatus.operation,
+        status: lockStatus.status,
+        startedAt: lockStatus.startedAt,
+        elapsedSeconds: lockStatus.elapsedSeconds,
+      } : {}),
+      ...(lockStatus ? { liveStatus: lockStatus } : {}),
       success: true,
     });
   } catch (error) {
@@ -1059,8 +1133,18 @@ export const removeMirror = async (req, res) => {
 export const reclaimHome = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertWalletIsSynced();
 
+    if (!tryAcquireOrgLock('V2 home organization reclaim')) {
+      const lockStatus = getOrgLockStatus();
+      return res.status(409).json({
+        message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
+        operationStatus: lockStatus,
+        success: false,
+      });
+    }
+
+    try {
+    await assertWalletIsSynced();
     const { orgUid } = req.body;
 
     const org = await OrganizationsV2.findOne({
@@ -1222,7 +1306,11 @@ export const reclaimHome = async (req, res) => {
       message: `V2 organization ${orgUid} has been reclaimed as the home organization.`,
       success: true,
     });
+    } finally {
+      releaseOrgLock();
+    }
   } catch (error) {
+    releaseOrgLock();
     loggerV2.error(`[v2]: Error reclaiming home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error reclaiming home organization',

--- a/src/controllers/v2/organizations-v2.controller.js
+++ b/src/controllers/v2/organizations-v2.controller.js
@@ -83,8 +83,8 @@ const getStoreDataPromise = async (storeId) => {
  * @param {Object} res - Express response object
  */
 export const create = async (req, res) => {
-  let lockAcquired = false;
-  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
+  let lockToken = null;
+  const releaseLock = () => { if (lockToken) { const t = lockToken; lockToken = null; releaseOrgLock(t); } };
   try {
     await assertV2IfReadOnlyMode();
 
@@ -96,7 +96,8 @@ export const create = async (req, res) => {
       });
     }
 
-    if (!tryAcquireOrgLock('V2 organization creation')) {
+    lockToken = tryAcquireOrgLock('V2 organization creation');
+    if (!lockToken) {
       const lockStatus = getOrgLockStatus();
       return res.status(409).json({
         message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
@@ -104,12 +105,9 @@ export const create = async (req, res) => {
         success: false,
       });
     }
-    lockAcquired = true;
 
-    // Check if V1 home org exists in database (only if V1 is enabled)
-    // When V1 is disabled, the V1 organizations table may not exist
     const configV1 = getConfig();
-    const enableV1 = configV1?.ENABLE !== false; // Default to true if not set
+    const enableV1 = configV1?.ENABLE !== false;
 
     if (enableV1) {
       const v1Org = await Organization.findOne({
@@ -119,16 +117,13 @@ export const create = async (req, res) => {
 
       if (v1Org) {
         releaseLock();
-        // V1 org exists - check for V1 singleton in datalayer
         if (v1Org.dataModelVersionStoreId) {
           try {
             const singletonData = await getStoreDataPromise(
               v1Org.dataModelVersionStoreId,
             );
 
-            // Handle simulator mode - getStoreData might return Error object or false
             if (singletonData && !(singletonData instanceof Error) && singletonData.keys_values) {
-              // Check if singleton has v1 key
               const hasV1Key = singletonData.keys_values.some((kv) => {
                 try {
                   const decodedKey = decodeHex(kv.key);
@@ -147,12 +142,10 @@ export const create = async (req, res) => {
               }
             }
           } catch (error) {
-            // If getStoreData fails, we still error because V1 org exists
             loggerV2.debug(`[v2]: Failed to check V1 singleton: ${error.message}`);
           }
         }
 
-        // If V1 org exists but no singleton check possible, still error
         return res.status(400).json({
           message:
             'V1 organization detected. Please use /v2/organizations/upgrade endpoint',
@@ -161,7 +154,6 @@ export const create = async (req, res) => {
       }
     }
 
-    // Check if V2 home org already exists
     const existingV2Org = await OrganizationsV2.findOne({
       where: { is_home: true },
       raw: true,
@@ -175,12 +167,9 @@ export const create = async (req, res) => {
       });
     }
 
-    // Extract name and icon from request
-    // Support both JSON body and file upload for icon
     const name = req.body.name || '';
     let icon = req.body.icon || '';
 
-    // Handle file upload for icon
     if (req.file && req.file.buffer) {
       icon = `data:image/png;base64,${req.file.buffer.toString('base64')}`;
     }
@@ -195,8 +184,6 @@ export const create = async (req, res) => {
 
     const { USE_SIMULATOR } = getConfig().APP;
 
-    // In simulator mode, await creation and return orgUid immediately
-    // In production mode, return immediately and create in background
     if (USE_SIMULATOR) {
       try {
         const orgUid = await OrganizationsV2.createHomeOrganization(name, icon, 'v2');
@@ -218,8 +205,8 @@ export const create = async (req, res) => {
         releaseLock();
       }
     } else {
-      // Call createHomeOrganization asynchronously (don't await)
-      // This allows the HTTP request to return immediately while creation happens in background
+      const bgToken = lockToken;
+      lockToken = null;
       OrganizationsV2.createHomeOrganization(name, icon, 'v2')
         .catch((error) => {
           loggerV2.error(
@@ -227,9 +214,8 @@ export const create = async (req, res) => {
           );
         })
         .finally(() => {
-          releaseOrgLock();
+          releaseOrgLock(bgToken);
         });
-      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -254,8 +240,8 @@ export const create = async (req, res) => {
  * @param {Object} res - Express response object
  */
 export const upgrade = async (req, res) => {
-  let lockAcquired = false;
-  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
+  let lockToken = null;
+  const releaseLock = () => { if (lockToken) { const t = lockToken; lockToken = null; releaseOrgLock(t); } };
   try {
     await assertV2IfReadOnlyMode();
 
@@ -267,7 +253,8 @@ export const upgrade = async (req, res) => {
       });
     }
 
-    if (!tryAcquireOrgLock('V1 to V2 upgrade')) {
+    lockToken = tryAcquireOrgLock('V1 to V2 upgrade');
+    if (!lockToken) {
       const lockStatus = getOrgLockStatus();
       return res.status(409).json({
         message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
@@ -275,13 +262,7 @@ export const upgrade = async (req, res) => {
         success: false,
       });
     }
-    lockAcquired = true;
 
-    // Note: assertWalletIsSyncedV2 and assertNoPendingCommitsExcludingTransfers don't exist yet
-    // await assertWalletIsSyncedV2();
-    // await assertNoPendingCommitsExcludingTransfers();
-
-    // Check if V1 is enabled before accessing V1 tables
     const configV1 = getConfig();
     const enableV1 = configV1?.ENABLE !== false;
 
@@ -293,7 +274,6 @@ export const upgrade = async (req, res) => {
       });
     }
 
-    // Check if V1 home org exists
     const v1Org = await Organization.findOne({
       where: { isHome: true },
       raw: true,
@@ -308,8 +288,6 @@ export const upgrade = async (req, res) => {
       });
     }
 
-    // CRITICAL: Verify V1 org is fully populated before attempting upgrade
-    // Check required store IDs exist
     if (!v1Org.dataModelVersionStoreId) {
       releaseLock();
       return res.status(400).json({
@@ -319,7 +297,6 @@ export const upgrade = async (req, res) => {
       });
     }
 
-    // Check that orgHash is populated (indicates org store data was written)
     const nullHash = '0x0000000000000000000000000000000000000000000000000000000000000000';
     if (!v1Org.orgHash || v1Org.orgHash === nullHash || v1Org.orgHash === '0') {
       releaseLock();
@@ -330,8 +307,6 @@ export const upgrade = async (req, res) => {
       });
     }
 
-    // Check that the singleton store has data (v1 key)
-    // This is the critical check - the v1 key must exist before we can upgrade
     try {
       const singletonData = await getStoreDataPromise(v1Org.dataModelVersionStoreId);
 
@@ -355,7 +330,6 @@ export const upgrade = async (req, res) => {
         });
       }
 
-      // Check if singleton has v1 key
       const decodedData = decodeDataLayerResponse(singletonData);
       const singletonMap = decodedData.reduce((obj, current) => {
         obj[current.key] = current.value;
@@ -383,14 +357,12 @@ export const upgrade = async (req, res) => {
       });
     }
 
-    // Check if V2 org already exists and upgrade is complete
     const existingV2Org = await OrganizationsV2.findOne({
       where: { is_home: true },
       raw: true,
     });
 
     if (existingV2Org && v1Org.dataModelVersionStoreId) {
-      // Check if singleton has v2 key (indicating upgrade is complete)
       try {
         const singletonData = await getStoreDataPromise(v1Org.dataModelVersionStoreId);
         if (singletonData && !(singletonData instanceof Error) && singletonData.keys_values) {
@@ -413,12 +385,9 @@ export const upgrade = async (req, res) => {
       }
     }
 
-    // Get name and icon from V1 org
     const name = v1Org.name || '';
     const icon = v1Org.icon || '';
 
-    // In simulator mode, await the upgrade since there are no blockchain waits
-    // In production mode, call asynchronously to return immediately
     if (USE_SIMULATOR) {
       try {
         await OrganizationsV2.upgradeFromV1(name, icon);
@@ -437,9 +406,8 @@ export const upgrade = async (req, res) => {
         releaseLock();
       }
     } else {
-      // Call upgradeFromV1 asynchronously (don't await) in production mode
-      // This allows the HTTP request to return immediately while upgrade happens in background
-      // upgradeFromV1 will handle partial upgrades (V2 org exists but singleton missing v2 key)
+      const bgToken = lockToken;
+      lockToken = null;
       OrganizationsV2.upgradeFromV1(name, icon)
         .catch((error) => {
           loggerV2.error(
@@ -447,9 +415,8 @@ export const upgrade = async (req, res) => {
           );
         })
         .finally(() => {
-          releaseOrgLock();
+          releaseOrgLock(bgToken);
         });
-      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -1140,12 +1107,13 @@ export const removeMirror = async (req, res) => {
  * @param {Object} res - Express response object
  */
 export const reclaimHome = async (req, res) => {
-  let lockAcquired = false;
-  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
+  let lockToken = null;
+  const releaseLock = () => { if (lockToken) { const t = lockToken; lockToken = null; releaseOrgLock(t); } };
   try {
     await assertV2IfReadOnlyMode();
 
-    if (!tryAcquireOrgLock('V2 home organization reclaim')) {
+    lockToken = tryAcquireOrgLock('V2 home organization reclaim');
+    if (!lockToken) {
       const lockStatus = getOrgLockStatus();
       return res.status(409).json({
         message: `A home organization operation is already in progress: ${lockStatus.operation}. Please wait for it to complete.`,
@@ -1153,7 +1121,6 @@ export const reclaimHome = async (req, res) => {
         success: false,
       });
     }
-    lockAcquired = true;
 
     try {
     await assertWalletIsSynced();

--- a/src/controllers/v2/organizations-v2.controller.js
+++ b/src/controllers/v2/organizations-v2.controller.js
@@ -116,7 +116,6 @@ export const create = async (req, res) => {
       });
 
       if (v1Org) {
-        releaseLock();
         if (v1Org.dataModelVersionStoreId) {
           try {
             const singletonData = await getStoreDataPromise(
@@ -134,6 +133,7 @@ export const create = async (req, res) => {
               });
 
               if (hasV1Key) {
+                releaseLock();
                 return res.status(400).json({
                   message:
                     'V1 organization detected. Please use /v2/organizations/upgrade endpoint',
@@ -146,6 +146,7 @@ export const create = async (req, res) => {
           }
         }
 
+        releaseLock();
         return res.status(400).json({
           message:
             'V1 organization detected. Please use /v2/organizations/upgrade endpoint',
@@ -186,7 +187,7 @@ export const create = async (req, res) => {
 
     if (USE_SIMULATOR) {
       try {
-        const orgUid = await OrganizationsV2.createHomeOrganization(name, icon, 'v2');
+        const orgUid = await OrganizationsV2.createHomeOrganization(name, icon, 'v2', lockToken);
         return res.json({
           message: 'V2 organization created successfully',
           orgUid,
@@ -207,7 +208,7 @@ export const create = async (req, res) => {
     } else {
       const bgToken = lockToken;
       lockToken = null;
-      OrganizationsV2.createHomeOrganization(name, icon, 'v2')
+      OrganizationsV2.createHomeOrganization(name, icon, 'v2', bgToken)
         .catch((error) => {
           loggerV2.error(
             `[v2]: Error creating V2 home organization in background: ${error.message}`,
@@ -390,7 +391,7 @@ export const upgrade = async (req, res) => {
 
     if (USE_SIMULATOR) {
       try {
-        await OrganizationsV2.upgradeFromV1(name, icon);
+        await OrganizationsV2.upgradeFromV1(name, icon, lockToken);
         return res.json({
           message: 'V2 organization upgrade completed successfully.',
           success: true,
@@ -408,7 +409,7 @@ export const upgrade = async (req, res) => {
     } else {
       const bgToken = lockToken;
       lockToken = null;
-      OrganizationsV2.upgradeFromV1(name, icon)
+      OrganizationsV2.upgradeFromV1(name, icon, bgToken)
         .catch((error) => {
           loggerV2.error(
             `[v2]: Error upgrading V2 organization in background: ${error.message}`,

--- a/src/controllers/v2/organizations-v2.controller.js
+++ b/src/controllers/v2/organizations-v2.controller.js
@@ -531,6 +531,7 @@ export const getCreationStatus = async (req, res) => {
       ...metaStatus,
       ...(lockStatus && !metaStatus.inProgress ? {
         inProgress: true,
+        message: `${lockStatus.operation}: ${lockStatus.status}`,
         operation: lockStatus.operation,
         status: lockStatus.status,
         startedAt: lockStatus.startedAt,

--- a/src/controllers/v2/organizations-v2.controller.js
+++ b/src/controllers/v2/organizations-v2.controller.js
@@ -84,6 +84,7 @@ const getStoreDataPromise = async (storeId) => {
  */
 export const create = async (req, res) => {
   let lockAcquired = false;
+  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
   try {
     await assertV2IfReadOnlyMode();
 
@@ -117,7 +118,7 @@ export const create = async (req, res) => {
       });
 
       if (v1Org) {
-        releaseOrgLock();
+        releaseLock();
         // V1 org exists - check for V1 singleton in datalayer
         if (v1Org.dataModelVersionStoreId) {
           try {
@@ -167,7 +168,7 @@ export const create = async (req, res) => {
     });
 
     if (existingV2Org) {
-      releaseOrgLock();
+      releaseLock();
       return res.status(400).json({
         message: 'V2 home organization already exists',
         success: false,
@@ -185,7 +186,7 @@ export const create = async (req, res) => {
     }
 
     if (!name) {
-      releaseOrgLock();
+      releaseLock();
       return res.status(400).json({
         message: 'Organization name is required',
         success: false,
@@ -214,7 +215,7 @@ export const create = async (req, res) => {
           success: false,
         });
       } finally {
-        releaseOrgLock();
+        releaseLock();
       }
     } else {
       // Call createHomeOrganization asynchronously (don't await)
@@ -228,6 +229,7 @@ export const create = async (req, res) => {
         .finally(() => {
           releaseOrgLock();
         });
+      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -236,7 +238,7 @@ export const create = async (req, res) => {
       });
     }
   } catch (error) {
-    if (lockAcquired) releaseOrgLock();
+    releaseLock();
     loggerV2.error(`[v2]: Error creating V2 home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error creating V2 home organization',
@@ -253,6 +255,7 @@ export const create = async (req, res) => {
  */
 export const upgrade = async (req, res) => {
   let lockAcquired = false;
+  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
   try {
     await assertV2IfReadOnlyMode();
 
@@ -283,7 +286,7 @@ export const upgrade = async (req, res) => {
     const enableV1 = configV1?.ENABLE !== false;
 
     if (!enableV1) {
-      releaseOrgLock();
+      releaseLock();
       return res.status(400).json({
         message: 'V1 is disabled. Cannot upgrade from V1 when V1 is not enabled.',
         success: false,
@@ -297,7 +300,7 @@ export const upgrade = async (req, res) => {
     });
 
     if (!v1Org) {
-      releaseOrgLock();
+      releaseLock();
       return res.status(400).json({
         message:
           'V1 home organization not found. Cannot upgrade without existing V1 organization.',
@@ -308,7 +311,7 @@ export const upgrade = async (req, res) => {
     // CRITICAL: Verify V1 org is fully populated before attempting upgrade
     // Check required store IDs exist
     if (!v1Org.dataModelVersionStoreId) {
-      releaseOrgLock();
+      releaseLock();
       return res.status(400).json({
         message:
           'V1 organization is missing dataModelVersionStoreId. Organization creation may still be in progress.',
@@ -319,7 +322,7 @@ export const upgrade = async (req, res) => {
     // Check that orgHash is populated (indicates org store data was written)
     const nullHash = '0x0000000000000000000000000000000000000000000000000000000000000000';
     if (!v1Org.orgHash || v1Org.orgHash === nullHash || v1Org.orgHash === '0') {
-      releaseOrgLock();
+      releaseLock();
       return res.status(400).json({
         message:
           'V1 organization orgHash is not populated. Organization creation has not completed writing data to the org store. Please wait for V1 organization creation to complete.',
@@ -334,7 +337,7 @@ export const upgrade = async (req, res) => {
 
       if (!singletonData || singletonData instanceof Error) {
         loggerV2.debug(`[v2]: Cannot read singleton data from ${v1Org.dataModelVersionStoreId}`);
-        releaseOrgLock();
+        releaseLock();
         return res.status(400).json({
           message:
             'Cannot read V1 singleton data. V1 organization may still be creating or blockchain data is not yet available. Please wait and try again.',
@@ -344,7 +347,7 @@ export const upgrade = async (req, res) => {
 
       if (!singletonData.keys_values || singletonData.keys_values.length === 0) {
         loggerV2.debug(`[v2]: Singleton store ${v1Org.dataModelVersionStoreId} is empty`);
-        releaseOrgLock();
+        releaseLock();
         return res.status(400).json({
           message:
             'V1 singleton store is empty. V1 organization creation has not completed writing data to the blockchain. Please wait for V1 organization creation to complete before upgrading.',
@@ -361,7 +364,7 @@ export const upgrade = async (req, res) => {
 
       if (!singletonMap.v1) {
         loggerV2.debug(`[v2]: Singleton store ${v1Org.dataModelVersionStoreId} missing v1 key`);
-        releaseOrgLock();
+        releaseLock();
         return res.status(400).json({
           message:
             'V1 singleton store does not contain v1 key. V1 organization creation has not completed. Please wait for V1 organization creation to fully complete before upgrading.',
@@ -372,7 +375,7 @@ export const upgrade = async (req, res) => {
       loggerV2.info(`[v2]: V1 singleton validated - v1 key exists with registry ${singletonMap.v1}`);
     } catch (error) {
       loggerV2.error(`[v2]: Error validating V1 singleton: ${error.message}`);
-      releaseOrgLock();
+      releaseLock();
       return res.status(400).json({
         message:
           `Cannot validate V1 organization singleton store: ${error.message}. Please ensure V1 organization creation is complete before upgrading.`,
@@ -398,7 +401,7 @@ export const upgrade = async (req, res) => {
           }, {});
 
           if (singletonMap.v2 !== undefined) {
-            releaseOrgLock();
+            releaseLock();
             return res.status(400).json({
               message: 'V2 home organization already exists and upgrade is already complete.',
               success: false,
@@ -431,7 +434,7 @@ export const upgrade = async (req, res) => {
           success: false,
         });
       } finally {
-        releaseOrgLock();
+        releaseLock();
       }
     } else {
       // Call upgradeFromV1 asynchronously (don't await) in production mode
@@ -446,6 +449,7 @@ export const upgrade = async (req, res) => {
         .finally(() => {
           releaseOrgLock();
         });
+      lockAcquired = false; // ownership transferred to async .finally()
 
       return res.json({
         message:
@@ -454,7 +458,7 @@ export const upgrade = async (req, res) => {
       });
     }
   } catch (error) {
-    if (lockAcquired) releaseOrgLock();
+    releaseLock();
     loggerV2.error(`[v2]: Error upgrading to V2 organization: ${error.message}`);
     res.status(400).json({
       message: 'Error upgrading to V2 organization',
@@ -1137,6 +1141,7 @@ export const removeMirror = async (req, res) => {
  */
 export const reclaimHome = async (req, res) => {
   let lockAcquired = false;
+  const releaseLock = () => { if (lockAcquired) { lockAcquired = false; releaseOrgLock(); } };
   try {
     await assertV2IfReadOnlyMode();
 
@@ -1314,10 +1319,10 @@ export const reclaimHome = async (req, res) => {
       success: true,
     });
     } finally {
-      releaseOrgLock();
+      releaseLock();
     }
   } catch (error) {
-    if (lockAcquired) releaseOrgLock();
+    releaseLock();
     loggerV2.error(`[v2]: Error reclaiming home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error reclaiming home organization',

--- a/src/controllers/v2/organizations-v2.controller.js
+++ b/src/controllers/v2/organizations-v2.controller.js
@@ -234,6 +234,7 @@ export const create = async (req, res) => {
       });
     }
   } catch (error) {
+    releaseOrgLock();
     loggerV2.error(`[v2]: Error creating V2 home organization: ${error.message}`);
     res.status(400).json({
       message: 'Error creating V2 home organization',

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -162,7 +162,7 @@ class Organization extends Model {
    * @param {string} dataVersion - Data version (defaults to 'v1')
    * @returns {Promise<string>} The new organization UID
    */
-  static async createHomeOrganization(name, icon, dataVersion = 'v1') {
+  static async createHomeOrganization(name, icon, dataVersion = 'v1', lockToken = null) {
     try {
       logger.info('[v1]: Creating New Organization using parallel store creation.');
 
@@ -185,7 +185,7 @@ class Organization extends Model {
       let state = await loadCreationState(Meta, 'v1');
       if (state && state.state !== ORG_CREATION_STATES.COMPLETE && state.state !== ORG_CREATION_STATES.FAILED) {
         logger.info('[v1]: Found in-progress organization creation, resuming...');
-        return await Organization._resumeOrganizationCreation(state);
+        return await Organization._resumeOrganizationCreation(state, lockToken);
       }
 
       // Initialize state for new creation
@@ -211,7 +211,7 @@ class Organization extends Model {
       }
 
       // Execute the creation process
-      return await Organization._executeOrganizationCreation(state);
+      return await Organization._executeOrganizationCreation(state, lockToken);
     } catch (error) {
       logger.error(
         `[v1]: create organization process failed. Error: ${error.message}`,
@@ -228,7 +228,7 @@ class Organization extends Model {
    * @returns {Promise<string>} The organization UID
    * @private
    */
-  static async _resumeOrganizationCreation(state) {
+  static async _resumeOrganizationCreation(state, lockToken = null) {
     logState(state, `Resuming from state: ${state.state}`);
 
     // Check for timeout
@@ -245,7 +245,7 @@ class Organization extends Model {
       await saveCreationState(state, Meta);
     }
 
-    return await Organization._executeOrganizationCreation(state);
+    return await Organization._executeOrganizationCreation(state, lockToken);
   }
 
   /**
@@ -254,12 +254,12 @@ class Organization extends Model {
    * @returns {Promise<string>} The organization UID
    * @private
    */
-  static async _executeOrganizationCreation(state) {
+  static async _executeOrganizationCreation(state, lockToken = null) {
     try {
       // PHASE 1: Create stores in parallel
       if (state.state === ORG_CREATION_STATES.INITIALIZING ||
           state.state === ORG_CREATION_STATES.STORES_CREATING) {
-        updateOrgLockStatus('Creating stores on blockchain');
+        updateOrgLockStatus(lockToken, 'Creating stores on blockchain');
         state = updateState(state, { state: ORG_CREATION_STATES.STORES_CREATING });
         await saveCreationState(state, Meta);
 
@@ -268,14 +268,14 @@ class Organization extends Model {
 
       // Wait for all stores to be confirmed
       if (state.state === ORG_CREATION_STATES.STORES_CREATING) {
-        updateOrgLockStatus('Waiting for stores to confirm on blockchain');
+        updateOrgLockStatus(lockToken, 'Waiting for stores to confirm on blockchain');
         state = await Organization._waitForStoresConfirmation(state);
       }
 
       // PHASE 2: Push data to stores in parallel
       if (state.state === ORG_CREATION_STATES.STORES_CONFIRMED ||
           state.state === ORG_CREATION_STATES.DATA_PUSHING) {
-        updateOrgLockStatus('Writing data to stores');
+        updateOrgLockStatus(lockToken, 'Writing data to stores');
         state = updateState(state, { state: ORG_CREATION_STATES.DATA_PUSHING });
         await saveCreationState(state, Meta);
 
@@ -291,7 +291,7 @@ class Organization extends Model {
       }
 
       // PHASE 3: Finalize
-      updateOrgLockStatus('Finalizing organization record');
+      updateOrgLockStatus(lockToken, 'Finalizing organization record');
       state = updateState(state, { state: ORG_CREATION_STATES.FINALIZING });
       await saveCreationState(state, Meta);
 
@@ -411,7 +411,7 @@ class Organization extends Model {
       }
 
       // Mark complete and clear state
-      updateOrgLockStatus('Organization creation complete');
+      updateOrgLockStatus(lockToken, 'Organization creation complete');
       state = updateState(state, { state: ORG_CREATION_STATES.COMPLETE });
       await clearCreationState(Meta, 'v1');
 

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -52,6 +52,7 @@ import {
   hasInProgressCreation,
 } from '../../utils/organization-creation-state.js';
 import { runMirrorCheck } from '../../tasks/mirror-check.js';
+import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
 class Organization extends Model {
   static async getHomeOrg(includeAddress = true) {
@@ -258,6 +259,7 @@ class Organization extends Model {
       // PHASE 1: Create stores in parallel
       if (state.state === ORG_CREATION_STATES.INITIALIZING ||
           state.state === ORG_CREATION_STATES.STORES_CREATING) {
+        updateOrgLockStatus('Creating stores on blockchain');
         state = updateState(state, { state: ORG_CREATION_STATES.STORES_CREATING });
         await saveCreationState(state, Meta);
 
@@ -266,12 +268,14 @@ class Organization extends Model {
 
       // Wait for all stores to be confirmed
       if (state.state === ORG_CREATION_STATES.STORES_CREATING) {
+        updateOrgLockStatus('Waiting for stores to confirm on blockchain');
         state = await Organization._waitForStoresConfirmation(state);
       }
 
       // PHASE 2: Push data to stores in parallel
       if (state.state === ORG_CREATION_STATES.STORES_CONFIRMED ||
           state.state === ORG_CREATION_STATES.DATA_PUSHING) {
+        updateOrgLockStatus('Writing data to stores');
         state = updateState(state, { state: ORG_CREATION_STATES.DATA_PUSHING });
         await saveCreationState(state, Meta);
 
@@ -287,6 +291,7 @@ class Organization extends Model {
       }
 
       // PHASE 3: Finalize
+      updateOrgLockStatus('Finalizing organization record');
       state = updateState(state, { state: ORG_CREATION_STATES.FINALIZING });
       await saveCreationState(state, Meta);
 
@@ -406,6 +411,7 @@ class Organization extends Model {
       }
 
       // Mark complete and clear state
+      updateOrgLockStatus('Organization creation complete');
       state = updateState(state, { state: ORG_CREATION_STATES.COMPLETE });
       await clearCreationState(Meta, 'v1');
 

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -162,7 +162,7 @@ class OrganizationsV2 extends Model {
    * @returns {Promise<string>} The new organization UID
    * @throws {Error} If V1 org exists or V2 org already exists
    */
-  static async createHomeOrganization(name, icon, dataVersion = 'v2') {
+  static async createHomeOrganization(name, icon, dataVersion = 'v2', lockToken = null) {
     // Import MetaV2 for state persistence
     const { MetaV2 } = await import('./index.js');
 
@@ -193,7 +193,7 @@ class OrganizationsV2 extends Model {
       if (state && state.state !== ORG_CREATION_STATES.COMPLETE && state.state !== ORG_CREATION_STATES.FAILED) {
         loggerV2.info('[v2]: Found in-progress organization creation, resuming...');
         // Resume from where we left off
-        return await OrganizationsV2._resumeOrganizationCreation(state, MetaV2);
+        return await OrganizationsV2._resumeOrganizationCreation(state, MetaV2, lockToken);
       }
 
       // CRITICAL: Check for V1 home org in database (only if V1 is enabled)
@@ -280,7 +280,7 @@ class OrganizationsV2 extends Model {
       loggerV2.info(`[v2]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
 
       // Execute the creation process
-      return await OrganizationsV2._executeOrganizationCreation(state, MetaV2);
+      return await OrganizationsV2._executeOrganizationCreation(state, MetaV2, lockToken);
     } catch (error) {
       loggerV2.error(
         `[v2]: create V2 organization process failed. Error: ${error.message}`,
@@ -298,7 +298,7 @@ class OrganizationsV2 extends Model {
    * @returns {Promise<string>} The organization UID
    * @private
    */
-  static async _resumeOrganizationCreation(state, MetaV2) {
+  static async _resumeOrganizationCreation(state, MetaV2, lockToken = null) {
     logState(state, `Resuming from state: ${state.state}`);
 
     // Check for timeout
@@ -326,7 +326,7 @@ class OrganizationsV2 extends Model {
     }
     loggerV2.info(`[v2]: Resuming org creation, ${coinCheck.coinCount} coins available`);
 
-    return await OrganizationsV2._executeOrganizationCreation(state, MetaV2);
+    return await OrganizationsV2._executeOrganizationCreation(state, MetaV2, lockToken);
   }
 
   /**
@@ -336,12 +336,12 @@ class OrganizationsV2 extends Model {
    * @returns {Promise<string>} The organization UID
    * @private
    */
-  static async _executeOrganizationCreation(state, MetaV2) {
+  static async _executeOrganizationCreation(state, MetaV2, lockToken = null) {
     try {
       // PHASE 1: Create stores in parallel
       if (state.state === ORG_CREATION_STATES.INITIALIZING ||
           state.state === ORG_CREATION_STATES.STORES_CREATING) {
-        updateOrgLockStatus('Creating stores on blockchain');
+        updateOrgLockStatus(lockToken, 'Creating stores on blockchain');
         state = updateState(state, { state: ORG_CREATION_STATES.STORES_CREATING });
         await saveCreationState(state, MetaV2);
 
@@ -350,14 +350,14 @@ class OrganizationsV2 extends Model {
 
       // Wait for all stores to be confirmed
       if (state.state === ORG_CREATION_STATES.STORES_CREATING) {
-        updateOrgLockStatus('Waiting for stores to confirm on blockchain');
+        updateOrgLockStatus(lockToken, 'Waiting for stores to confirm on blockchain');
         state = await OrganizationsV2._waitForStoresConfirmation(state, MetaV2);
       }
 
       // PHASE 2: Push data to stores in parallel
       if (state.state === ORG_CREATION_STATES.STORES_CONFIRMED ||
           state.state === ORG_CREATION_STATES.DATA_PUSHING) {
-        updateOrgLockStatus('Writing data to stores');
+        updateOrgLockStatus(lockToken, 'Writing data to stores');
         state = updateState(state, { state: ORG_CREATION_STATES.DATA_PUSHING });
         await saveCreationState(state, MetaV2);
 
@@ -373,7 +373,7 @@ class OrganizationsV2 extends Model {
       }
 
       // PHASE 3: Finalize
-      updateOrgLockStatus('Finalizing organization record');
+      updateOrgLockStatus(lockToken, 'Finalizing organization record');
       state = updateState(state, { state: ORG_CREATION_STATES.FINALIZING });
       await saveCreationState(state, MetaV2);
 
@@ -476,7 +476,7 @@ class OrganizationsV2 extends Model {
       }
 
       // Mark complete and clear state
-      updateOrgLockStatus('Organization creation complete');
+      updateOrgLockStatus(lockToken, 'Organization creation complete');
       state = updateState(state, { state: ORG_CREATION_STATES.COMPLETE });
       await clearCreationState(MetaV2, 'v2');
 
@@ -752,10 +752,10 @@ class OrganizationsV2 extends Model {
    * @returns {Promise<string>} The new V2 organization UID
    * @throws {Error} If V1 org doesn't exist or V2 org already exists
    */
-  static async upgradeFromV1(name, icon) {
+  static async upgradeFromV1(name, icon, lockToken = null) {
     try {
       loggerV2.info('[v2]: Upgrading from V1 to V2 Organization, This could take a while.');
-      updateOrgLockStatus('Validating V1 singleton');
+      updateOrgLockStatus(lockToken, 'Validating V1 singleton');
 
       // CRITICAL: Check if V1 is enabled before accessing V1 tables
       const configV1 = getConfig();
@@ -918,7 +918,7 @@ class OrganizationsV2 extends Model {
       // Create new V2 registry store (v2 data store - different from V1)
       // CRITICAL: Reuse v1OrgUid and v1FileStoreId - do NOT create new stores for these
       loggerV2.verbose('[v2]: upgradeFromV1() is creating new V2 registryId store');
-      updateOrgLockStatus('Creating V2 registry store');
+      updateOrgLockStatus(lockToken, 'Creating V2 registry store');
       let newV2RegistryStoreId;
       if (USE_SIMULATOR) {
         newV2RegistryStoreId = 'v2-registry-' + Date.now();
@@ -958,7 +958,7 @@ class OrganizationsV2 extends Model {
       };
 
       if (!USE_SIMULATOR) {
-        updateOrgLockStatus('Waiting for V2 registry store to confirm on blockchain');
+        updateOrgLockStatus(lockToken, 'Waiting for V2 registry store to confirm on blockchain');
         loggerV2.info(
           '[v2]: upgrade from V1 to V2 organization process is waiting for V2 registry store creation to confirm on the blockchain',
         );
@@ -987,7 +987,7 @@ class OrganizationsV2 extends Model {
           `[v2]: Singleton store ${sharedDataModelVersionStoreId} already has v2 key. Skipping singleton update.`,
         );
       } else {
-        updateOrgLockStatus('Updating singleton store with v2 key');
+        updateOrgLockStatus(lockToken, 'Updating singleton store with v2 key');
         loggerV2.info(
           `[v2]: updating shared data model version store ${sharedDataModelVersionStoreId} to add v2 key`,
         );
@@ -1022,7 +1022,7 @@ class OrganizationsV2 extends Model {
       }
 
       if (!USE_SIMULATOR) {
-        updateOrgLockStatus('Waiting for data model version update to confirm on blockchain');
+        updateOrgLockStatus(lockToken, 'Waiting for data model version update to confirm on blockchain');
         loggerV2.info(
           '[v2]: upgrade from V1 to V2 organization process is waiting for data model version update to confirm on the blockchain',
         );
@@ -1041,7 +1041,7 @@ class OrganizationsV2 extends Model {
         `[v2]: data model version store ${sharedDataModelVersionStoreId} hash after v2 key addition: ${dataModelVersionStoreHash}`,
       );
 
-      updateOrgLockStatus('Adding V2 home organization to database');
+      updateOrgLockStatus(lockToken, 'Adding V2 home organization to database');
       loggerV2.info('[v2]: adding new V2 home organization to CADT database');
       // CRITICAL: Use v1OrgUid and v1FileStoreId - shared identity between v1 and v2
       // Note: data_model_version_store_hash uses the UPDATED hash (after v2 key addition), not V1 hash
@@ -1060,7 +1060,7 @@ class OrganizationsV2 extends Model {
       });
 
       const onConfirm = async () => {
-        updateOrgLockStatus('V2 Organization upgrade confirmed');
+        updateOrgLockStatus(lockToken, 'V2 Organization upgrade confirmed');
         loggerV2.info('[v2]: V2 Organization upgrade confirmed, you are ready to go');
         await OrganizationsV2.update(
           {

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -74,6 +74,7 @@ import {
 
 import ModelTypes from './organizations-v2.modeltypes.cjs';
 import { runMirrorCheckV2 } from '../../tasks/mirror-check-v2.js';
+import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
 const TRANSIENT_WALLET_ERRORS = [
   'Wallet needs to be fully synced',
@@ -340,6 +341,7 @@ class OrganizationsV2 extends Model {
       // PHASE 1: Create stores in parallel
       if (state.state === ORG_CREATION_STATES.INITIALIZING ||
           state.state === ORG_CREATION_STATES.STORES_CREATING) {
+        updateOrgLockStatus('Creating stores on blockchain');
         state = updateState(state, { state: ORG_CREATION_STATES.STORES_CREATING });
         await saveCreationState(state, MetaV2);
 
@@ -348,12 +350,14 @@ class OrganizationsV2 extends Model {
 
       // Wait for all stores to be confirmed
       if (state.state === ORG_CREATION_STATES.STORES_CREATING) {
+        updateOrgLockStatus('Waiting for stores to confirm on blockchain');
         state = await OrganizationsV2._waitForStoresConfirmation(state, MetaV2);
       }
 
       // PHASE 2: Push data to stores in parallel
       if (state.state === ORG_CREATION_STATES.STORES_CONFIRMED ||
           state.state === ORG_CREATION_STATES.DATA_PUSHING) {
+        updateOrgLockStatus('Writing data to stores');
         state = updateState(state, { state: ORG_CREATION_STATES.DATA_PUSHING });
         await saveCreationState(state, MetaV2);
 
@@ -369,6 +373,7 @@ class OrganizationsV2 extends Model {
       }
 
       // PHASE 3: Finalize
+      updateOrgLockStatus('Finalizing organization record');
       state = updateState(state, { state: ORG_CREATION_STATES.FINALIZING });
       await saveCreationState(state, MetaV2);
 
@@ -471,6 +476,7 @@ class OrganizationsV2 extends Model {
       }
 
       // Mark complete and clear state
+      updateOrgLockStatus('Organization creation complete');
       state = updateState(state, { state: ORG_CREATION_STATES.COMPLETE });
       await clearCreationState(MetaV2, 'v2');
 
@@ -749,6 +755,7 @@ class OrganizationsV2 extends Model {
   static async upgradeFromV1(name, icon) {
     try {
       loggerV2.info('[v2]: Upgrading from V1 to V2 Organization, This could take a while.');
+      updateOrgLockStatus('Validating V1 singleton');
 
       // CRITICAL: Check if V1 is enabled before accessing V1 tables
       const configV1 = getConfig();
@@ -911,6 +918,7 @@ class OrganizationsV2 extends Model {
       // Create new V2 registry store (v2 data store - different from V1)
       // CRITICAL: Reuse v1OrgUid and v1FileStoreId - do NOT create new stores for these
       loggerV2.verbose('[v2]: upgradeFromV1() is creating new V2 registryId store');
+      updateOrgLockStatus('Creating V2 registry store');
       let newV2RegistryStoreId;
       if (USE_SIMULATOR) {
         newV2RegistryStoreId = 'v2-registry-' + Date.now();
@@ -950,6 +958,7 @@ class OrganizationsV2 extends Model {
       };
 
       if (!USE_SIMULATOR) {
+        updateOrgLockStatus('Waiting for V2 registry store to confirm on blockchain');
         loggerV2.info(
           '[v2]: upgrade from V1 to V2 organization process is waiting for V2 registry store creation to confirm on the blockchain',
         );
@@ -978,6 +987,7 @@ class OrganizationsV2 extends Model {
           `[v2]: Singleton store ${sharedDataModelVersionStoreId} already has v2 key. Skipping singleton update.`,
         );
       } else {
+        updateOrgLockStatus('Updating singleton store with v2 key');
         loggerV2.info(
           `[v2]: updating shared data model version store ${sharedDataModelVersionStoreId} to add v2 key`,
         );
@@ -1012,6 +1022,7 @@ class OrganizationsV2 extends Model {
       }
 
       if (!USE_SIMULATOR) {
+        updateOrgLockStatus('Waiting for data model version update to confirm on blockchain');
         loggerV2.info(
           '[v2]: upgrade from V1 to V2 organization process is waiting for data model version update to confirm on the blockchain',
         );
@@ -1030,6 +1041,7 @@ class OrganizationsV2 extends Model {
         `[v2]: data model version store ${sharedDataModelVersionStoreId} hash after v2 key addition: ${dataModelVersionStoreHash}`,
       );
 
+      updateOrgLockStatus('Adding V2 home organization to database');
       loggerV2.info('[v2]: adding new V2 home organization to CADT database');
       // CRITICAL: Use v1OrgUid and v1FileStoreId - shared identity between v1 and v2
       // Note: data_model_version_store_hash uses the UPDATED hash (after v2 key addition), not V1 hash
@@ -1048,6 +1060,7 @@ class OrganizationsV2 extends Model {
       });
 
       const onConfirm = async () => {
+        updateOrgLockStatus('V2 Organization upgrade confirmed');
         loggerV2.info('[v2]: V2 Organization upgrade confirmed, you are ready to go');
         await OrganizationsV2.update(
           {

--- a/src/tasks/clean-up-failed-org-v2.js
+++ b/src/tasks/clean-up-failed-org-v2.js
@@ -88,13 +88,13 @@ const attemptRecovery = async () => {
     `[v2]: [Recovery] Attempting recovery (attempt ${state.retryCount}/${ORG_CREATION_CONFIG.MAX_RETRIES})`,
   );
 
-  if (!tryAcquireOrgLock('V2 organization recovery')) {
+  const token = tryAcquireOrgLock('V2 organization recovery');
+  if (!token) {
     loggerV2.warn('[v2]: [Recovery] Cannot acquire lock - another operation is in progress');
     return { success: false, message: 'Cannot acquire lock for recovery' };
   }
 
   try {
-    // Resume the creation - this will pick up from where it left off
     const orgUid = await OrganizationsV2.createHomeOrganization(
       state.name,
       state.icon,
@@ -110,7 +110,6 @@ const attemptRecovery = async () => {
   } catch (error) {
     loggerV2.error(`[v2]: [Recovery] Recovery attempt failed: ${error.message}`);
 
-    // Check if we should try again or give up
     state = await loadCreationState(MetaV2, 'v2');
     if (state && hasExceededMaxRetries(state)) {
       loggerV2.error('[v2]: [Recovery] Max retries exceeded after failed attempt. Giving up.');
@@ -125,7 +124,7 @@ const attemptRecovery = async () => {
       message: `Recovery attempt ${state?.retryCount || 'unknown'}/${ORG_CREATION_CONFIG.MAX_RETRIES} failed: ${error.message}`,
     };
   } finally {
-    releaseOrgLock();
+    releaseOrgLock(token);
   }
 };
 

--- a/src/tasks/clean-up-failed-org-v2.js
+++ b/src/tasks/clean-up-failed-org-v2.js
@@ -13,6 +13,7 @@ import {
   markAsFailed,
   getStatusSummary,
 } from '../utils/organization-creation-state.js';
+import { tryAcquireOrgLock, releaseOrgLock } from '../utils/org-operation-lock.js';
 
 const CONFIG = getConfig().APP;
 
@@ -87,6 +88,11 @@ const attemptRecovery = async () => {
     `[v2]: [Recovery] Attempting recovery (attempt ${state.retryCount}/${ORG_CREATION_CONFIG.MAX_RETRIES})`,
   );
 
+  if (!tryAcquireOrgLock('V2 organization recovery')) {
+    loggerV2.warn('[v2]: [Recovery] Cannot acquire lock - another operation is in progress');
+    return { success: false, message: 'Cannot acquire lock for recovery' };
+  }
+
   try {
     // Resume the creation - this will pick up from where it left off
     const orgUid = await OrganizationsV2.createHomeOrganization(
@@ -118,6 +124,8 @@ const attemptRecovery = async () => {
       success: false,
       message: `Recovery attempt ${state?.retryCount || 'unknown'}/${ORG_CREATION_CONFIG.MAX_RETRIES} failed: ${error.message}`,
     };
+  } finally {
+    releaseOrgLock();
   }
 };
 

--- a/src/tasks/clean-up-failed-org-v2.js
+++ b/src/tasks/clean-up-failed-org-v2.js
@@ -99,6 +99,7 @@ const attemptRecovery = async () => {
       state.name,
       state.icon,
       state.dataVersion,
+      token,
     );
 
     loggerV2.info(`[v2]: [Recovery] Successfully recovered organization creation. orgUid: ${orgUid}`);

--- a/src/tasks/clean-up-failed-org.js
+++ b/src/tasks/clean-up-failed-org.js
@@ -88,13 +88,13 @@ const attemptRecovery = async () => {
     `[v1]: [Recovery] Attempting recovery (attempt ${state.retryCount}/${ORG_CREATION_CONFIG.MAX_RETRIES})`,
   );
 
-  if (!tryAcquireOrgLock('V1 organization recovery')) {
+  const token = tryAcquireOrgLock('V1 organization recovery');
+  if (!token) {
     logger.warn('[v1]: [Recovery] Cannot acquire lock - another operation is in progress');
     return { success: false, message: 'Cannot acquire lock for recovery' };
   }
 
   try {
-    // Resume the creation - this will pick up from where it left off
     const orgUid = await Organization.createHomeOrganization(
       state.name,
       state.icon,
@@ -110,7 +110,6 @@ const attemptRecovery = async () => {
   } catch (error) {
     logger.error(`[v1]: [Recovery] Recovery attempt failed: ${error.message}`);
 
-    // Check if we should try again or give up
     state = await loadCreationState(Meta, 'v1');
     if (state && hasExceededMaxRetries(state)) {
       logger.error('[v1]: [Recovery] Max retries exceeded after failed attempt. Giving up.');
@@ -125,7 +124,7 @@ const attemptRecovery = async () => {
       message: `Recovery attempt ${state?.retryCount || 'unknown'}/${ORG_CREATION_CONFIG.MAX_RETRIES} failed: ${error.message}`,
     };
   } finally {
-    releaseOrgLock();
+    releaseOrgLock(token);
   }
 };
 

--- a/src/tasks/clean-up-failed-org.js
+++ b/src/tasks/clean-up-failed-org.js
@@ -13,6 +13,7 @@ import {
   markAsFailed,
   getStatusSummary,
 } from '../utils/organization-creation-state.js';
+import { tryAcquireOrgLock, releaseOrgLock } from '../utils/org-operation-lock.js';
 
 const CONFIG = getConfig().APP;
 
@@ -87,6 +88,11 @@ const attemptRecovery = async () => {
     `[v1]: [Recovery] Attempting recovery (attempt ${state.retryCount}/${ORG_CREATION_CONFIG.MAX_RETRIES})`,
   );
 
+  if (!tryAcquireOrgLock('V1 organization recovery')) {
+    logger.warn('[v1]: [Recovery] Cannot acquire lock - another operation is in progress');
+    return { success: false, message: 'Cannot acquire lock for recovery' };
+  }
+
   try {
     // Resume the creation - this will pick up from where it left off
     const orgUid = await Organization.createHomeOrganization(
@@ -118,6 +124,8 @@ const attemptRecovery = async () => {
       success: false,
       message: `Recovery attempt ${state?.retryCount || 'unknown'}/${ORG_CREATION_CONFIG.MAX_RETRIES} failed: ${error.message}`,
     };
+  } finally {
+    releaseOrgLock();
   }
 };
 

--- a/src/tasks/clean-up-failed-org.js
+++ b/src/tasks/clean-up-failed-org.js
@@ -99,6 +99,7 @@ const attemptRecovery = async () => {
       state.name,
       state.icon,
       state.dataVersion,
+      token,
     );
 
     logger.info(`[v1]: [Recovery] Successfully recovered organization creation. orgUid: ${orgUid}`);

--- a/src/utils/org-operation-lock.js
+++ b/src/utils/org-operation-lock.js
@@ -2,8 +2,19 @@ let currentOperation = null;
 let currentStatus = null;
 let startedAt = null;
 
+const MAX_LOCK_AGE_MS = 60 * 60 * 1000; // 1 hour
+
 export const tryAcquireOrgLock = (operationName) => {
-  if (currentOperation) return false;
+  if (currentOperation) {
+    const ageMs = Date.now() - new Date(startedAt).getTime();
+    if (ageMs < MAX_LOCK_AGE_MS) {
+      return false;
+    }
+    console.warn(
+      `[org-operation-lock] Lock held by "${currentOperation}" for ${Math.round(ageMs / 1000)}s ` +
+      `exceeded max age (${MAX_LOCK_AGE_MS / 1000}s). Force-releasing stale lock.`,
+    );
+  }
   currentOperation = operationName;
   currentStatus = 'Starting...';
   startedAt = new Date().toISOString();

--- a/src/utils/org-operation-lock.js
+++ b/src/utils/org-operation-lock.js
@@ -1,0 +1,32 @@
+let currentOperation = null;
+let currentStatus = null;
+let startedAt = null;
+
+export const tryAcquireOrgLock = (operationName) => {
+  if (currentOperation) return false;
+  currentOperation = operationName;
+  currentStatus = 'Starting...';
+  startedAt = new Date().toISOString();
+  return true;
+};
+
+export const releaseOrgLock = () => {
+  currentOperation = null;
+  currentStatus = null;
+  startedAt = null;
+};
+
+export const updateOrgLockStatus = (status) => { currentStatus = status; };
+export const getOrgLockOperation = () => currentOperation;
+export const isOrgLocked = () => currentOperation !== null;
+
+export const getOrgLockStatus = () => {
+  if (!currentOperation) return null;
+  const elapsedMs = Date.now() - new Date(startedAt).getTime();
+  return {
+    operation: currentOperation,
+    status: currentStatus,
+    startedAt,
+    elapsedSeconds: Math.round(elapsedMs / 1000),
+  };
+};

--- a/src/utils/org-operation-lock.js
+++ b/src/utils/org-operation-lock.js
@@ -49,9 +49,18 @@ export const releaseOrgLock = (token) => {
   return true;
 };
 
-export const updateOrgLockStatus = (status) => { currentStatus = status; };
-export const getOrgLockOperation = () => currentOperation;
-export const isOrgLocked = () => currentOperation !== null;
+/**
+ * Update the lock's progress status message.
+ * Only writes if the supplied token matches the current holder, preventing
+ * a stale background operation (whose lock was force-released via TTL)
+ * from overwriting the new holder's status.
+ * @param {string} token - the ownership token returned by tryAcquireOrgLock
+ * @param {string} status - the new status message
+ */
+export const updateOrgLockStatus = (token, status) => {
+  if (token !== currentToken) return;
+  currentStatus = status;
+};
 
 export const getOrgLockStatus = () => {
   if (!currentOperation) return null;

--- a/src/utils/org-operation-lock.js
+++ b/src/utils/org-operation-lock.js
@@ -1,30 +1,52 @@
 let currentOperation = null;
 let currentStatus = null;
 let startedAt = null;
+let currentToken = null;
+let tokenSeq = 0;
 
 const MAX_LOCK_AGE_MS = 60 * 60 * 1000; // 1 hour
 
+/**
+ * Attempt to acquire the global org-operation lock.
+ * @param {string} operationName - descriptive name for the operation
+ * @returns {string|null} an opaque ownership token (truthy) on success, or null on failure
+ */
 export const tryAcquireOrgLock = (operationName) => {
   if (currentOperation) {
     const ageMs = Date.now() - new Date(startedAt).getTime();
     if (ageMs < MAX_LOCK_AGE_MS) {
-      return false;
+      return null;
     }
     console.warn(
       `[org-operation-lock] Lock held by "${currentOperation}" for ${Math.round(ageMs / 1000)}s ` +
       `exceeded max age (${MAX_LOCK_AGE_MS / 1000}s). Force-releasing stale lock.`,
     );
   }
+  const token = `orglock-${++tokenSeq}`;
   currentOperation = operationName;
   currentStatus = 'Starting...';
   startedAt = new Date().toISOString();
-  return true;
+  currentToken = token;
+  return token;
 };
 
-export const releaseOrgLock = () => {
+/**
+ * Release the global org-operation lock.
+ * When called with a token, only releases if the token matches the current holder
+ * (prevents a stale .finally() from releasing a newer operation's lock).
+ * When called without a token, releases unconditionally (for test cleanup only).
+ * @param {string} [token] - the ownership token returned by tryAcquireOrgLock
+ * @returns {boolean} true if the lock was released, false if the token didn't match
+ */
+export const releaseOrgLock = (token) => {
+  if (token !== undefined && token !== currentToken) {
+    return false;
+  }
   currentOperation = null;
   currentStatus = null;
   startedAt = null;
+  currentToken = null;
+  return true;
 };
 
 export const updateOrgLockStatus = (status) => { currentStatus = status; };

--- a/tests/v2/integration/org-operation-lock-endpoints.spec.js
+++ b/tests/v2/integration/org-operation-lock-endpoints.spec.js
@@ -1,0 +1,324 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+import app from '../../../src/server.js';
+import { prepareV2Db } from '../../../src/database/v2/index.js';
+import { OrganizationsV2, MetaV2 } from '../../../src/models/v2/index.js';
+import { Organization, Meta } from '../../../src/models/index.js';
+import {
+  tryAcquireOrgLock,
+  releaseOrgLock,
+  updateOrgLockStatus,
+  isOrgLocked,
+} from '../../../src/utils/org-operation-lock.js';
+import {
+  createInitialState,
+  saveCreationState,
+  clearCreationState,
+  ORG_CREATION_STATES,
+} from '../../../src/utils/organization-creation-state.js';
+
+describe('Organization Operation Lock - Endpoint Guards', function () {
+  this.timeout(60000);
+
+  before(async function () {
+    await prepareV2Db();
+  });
+
+  afterEach(async function () {
+    releaseOrgLock();
+    await OrganizationsV2.destroy({ where: {} });
+    await Organization.destroy({ where: {} });
+    await clearCreationState(MetaV2, 'v2');
+    await clearCreationState(Meta, 'v1');
+  });
+
+  // ----------------------------------------------------------------
+  // V2 Create -- in-memory lock guard
+  // ----------------------------------------------------------------
+  describe('V2 Create -- in-memory lock guard', function () {
+    it('rejects when lock held', async function () {
+      tryAcquireOrgLock('V2 organization creation');
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+      expect(res.body.success).to.be.false;
+    });
+
+    it('rejects when Meta state in-progress', async function () {
+      const state = createInitialState('Test', '', 'v2', 'v2');
+      state.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(state, MetaV2);
+
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('still in progress');
+      expect(res.body.success).to.be.false;
+    });
+
+    it('succeeds when lock free and no Meta state (simulator)', async function () {
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.be.true;
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // V2 Upgrade -- in-memory lock guard
+  // ----------------------------------------------------------------
+  describe('V2 Upgrade -- in-memory lock guard', function () {
+    it('rejects when lock held by create', async function () {
+      tryAcquireOrgLock('V2 organization creation');
+      const res = await supertest(app)
+        .post('/v2/organizations/upgrade');
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+    });
+
+    it('rejects when lock held by upgrade', async function () {
+      tryAcquireOrgLock('V1 to V2 upgrade');
+      const res = await supertest(app)
+        .post('/v2/organizations/upgrade');
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+    });
+
+    it('rejects when Meta state in-progress', async function () {
+      const state = createInitialState('Test', '', 'v2', 'v2');
+      state.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(state, MetaV2);
+
+      const res = await supertest(app)
+        .post('/v2/organizations/upgrade');
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('still in progress');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // V2 Reclaim -- in-memory lock guard
+  // ----------------------------------------------------------------
+  describe('V2 Reclaim -- in-memory lock guard', function () {
+    it('rejects when lock held', async function () {
+      tryAcquireOrgLock('V2 organization creation');
+      const res = await supertest(app)
+        .post('/v2/organizations/reclaim-home')
+        .send({ orgUid: 'f1c54511-865e-4611-976c-7c3c1f704662' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // V1 Create -- in-memory lock guard
+  // ----------------------------------------------------------------
+  describe('V1 Create -- in-memory lock guard', function () {
+    it('rejects when lock held', async function () {
+      tryAcquireOrgLock('V1 organization creation');
+      const res = await supertest(app)
+        .post('/v1/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+    });
+
+    it('rejects when Meta state in-progress', async function () {
+      const state = createInitialState('Test', '', 'v1', 'v1');
+      state.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(state, Meta);
+
+      const res = await supertest(app)
+        .post('/v1/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('still in progress');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Cross-version blocking
+  // ----------------------------------------------------------------
+  describe('Cross-version blocking', function () {
+    it('V1 lock blocks V2 create', async function () {
+      tryAcquireOrgLock('V1 organization creation');
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+      expect(res.body.message).to.include('V1 organization creation');
+    });
+
+    it('V2 lock blocks V1 create', async function () {
+      tryAcquireOrgLock('V2 organization creation');
+      const res = await supertest(app)
+        .post('/v1/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+      expect(res.body.message).to.include('V2 organization creation');
+    });
+
+    it('V2 upgrade lock blocks V2 create', async function () {
+      tryAcquireOrgLock('V1 to V2 upgrade');
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.include('already in progress');
+      expect(res.body.message).to.include('V1 to V2 upgrade');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // Lock release after operation
+  // ----------------------------------------------------------------
+  describe('Lock release after operation', function () {
+    it('lock released after successful create (simulator)', async function () {
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Release Test Org' });
+
+      expect(res.status).to.equal(200);
+
+      // In simulator mode, creation is awaited so lock should be released
+      await new Promise(resolve => setImmediate(resolve));
+      expect(isOrgLocked()).to.be.false;
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // 409 response body format
+  // ----------------------------------------------------------------
+  describe('409 response body matches documented API contract', function () {
+    it('409 includes all documented fields', async function () {
+      tryAcquireOrgLock('V2 organization creation');
+      updateOrgLockStatus('Waiting for store');
+
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.message).to.be.a('string').that.includes('already in progress');
+      expect(res.body.success).to.be.false;
+      expect(res.body.operationStatus).to.be.an('object');
+    });
+
+    it('operationStatus has all documented fields', async function () {
+      tryAcquireOrgLock('V2 organization creation');
+      updateOrgLockStatus('Waiting for store');
+
+      const res = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Test Org' });
+
+      expect(res.status).to.equal(409);
+      const opStatus = res.body.operationStatus;
+      expect(opStatus.operation).to.be.a('string');
+      expect(opStatus.status).to.be.a('string');
+      expect(opStatus.startedAt).to.be.a('string');
+      expect(new Date(opStatus.startedAt).toISOString()).to.equal(opStatus.startedAt);
+      expect(opStatus.elapsedSeconds).to.be.a('number').that.is.at.least(0);
+    });
+
+    it('409 on upgrade includes operationStatus', async function () {
+      tryAcquireOrgLock('V2 organization creation');
+      const res = await supertest(app)
+        .post('/v2/organizations/upgrade');
+
+      expect(res.status).to.equal(409);
+      expect(res.body.operationStatus.operation).to.equal('V2 organization creation');
+    });
+
+    it('409 on reclaim includes operationStatus', async function () {
+      tryAcquireOrgLock('V1 to V2 upgrade');
+      const res = await supertest(app)
+        .post('/v2/organizations/reclaim-home')
+        .send({ orgUid: 'f1c54511-865e-4611-976c-7c3c1f704662' });
+
+      expect(res.status).to.equal(409);
+      expect(res.body.operationStatus.operation).to.equal('V1 to V2 upgrade');
+    });
+  });
+
+  // ----------------------------------------------------------------
+  // creation-status endpoint shows lock status
+  // ----------------------------------------------------------------
+  describe('creation-status endpoint shows lock status', function () {
+    it('returns lock status when upgrade in progress', async function () {
+      tryAcquireOrgLock('V1 to V2 upgrade');
+      updateOrgLockStatus('Creating registry store');
+
+      const res = await supertest(app)
+        .get('/v2/organizations/creation-status');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.inProgress).to.be.true;
+      expect(res.body.operation).to.equal('V1 to V2 upgrade');
+      expect(res.body.liveStatus).to.be.an('object');
+      expect(res.body.liveStatus.operation).to.equal('V1 to V2 upgrade');
+      expect(res.body.liveStatus.status).to.equal('Creating registry store');
+      expect(res.body.liveStatus.elapsedSeconds).to.be.a('number');
+    });
+
+    it('returns no lock status when idle', async function () {
+      releaseOrgLock();
+      await clearCreationState(MetaV2, 'v2');
+
+      const res = await supertest(app)
+        .get('/v2/organizations/creation-status');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.inProgress).to.be.false;
+      expect(res.body).to.not.have.property('liveStatus');
+    });
+
+    it('returns both Meta and lock status during creation', async function () {
+      const state = createInitialState('Test', '', 'v2', 'v2');
+      state.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(state, MetaV2);
+
+      tryAcquireOrgLock('V2 organization creation');
+      updateOrgLockStatus('Creating stores on blockchain');
+
+      const res = await supertest(app)
+        .get('/v2/organizations/creation-status');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.state).to.equal('STORES_CREATING');
+      expect(res.body.liveStatus).to.exist;
+      expect(res.body.liveStatus.operation).to.equal('V2 organization creation');
+      expect(res.body.liveStatus.status).to.equal('Creating stores on blockchain');
+    });
+
+    it('liveStatus reflects updated status', async function () {
+      tryAcquireOrgLock('test');
+      updateOrgLockStatus('A');
+      updateOrgLockStatus('B');
+
+      const res = await supertest(app)
+        .get('/v2/organizations/creation-status');
+
+      expect(res.status).to.equal(200);
+      expect(res.body.liveStatus.status).to.equal('B');
+    });
+  });
+});

--- a/tests/v2/integration/org-operation-lock-endpoints.spec.js
+++ b/tests/v2/integration/org-operation-lock-endpoints.spec.js
@@ -8,7 +8,7 @@ import {
   tryAcquireOrgLock,
   releaseOrgLock,
   updateOrgLockStatus,
-  isOrgLocked,
+  getOrgLockStatus,
 } from '../../../src/utils/org-operation-lock.js';
 import {
   createInitialState,
@@ -200,7 +200,7 @@ describe('Organization Operation Lock - Endpoint Guards', function () {
 
       // In simulator mode, creation is awaited so lock should be released
       await new Promise(resolve => setImmediate(resolve));
-      expect(isOrgLocked()).to.be.false;
+      expect(getOrgLockStatus()).to.be.null;
     });
   });
 
@@ -209,8 +209,8 @@ describe('Organization Operation Lock - Endpoint Guards', function () {
   // ----------------------------------------------------------------
   describe('409 response body matches documented API contract', function () {
     it('409 includes all documented fields', async function () {
-      tryAcquireOrgLock('V2 organization creation');
-      updateOrgLockStatus('Waiting for store');
+      const token = tryAcquireOrgLock('V2 organization creation');
+      updateOrgLockStatus(token, 'Waiting for store');
 
       const res = await supertest(app)
         .post('/v2/organizations')
@@ -223,8 +223,8 @@ describe('Organization Operation Lock - Endpoint Guards', function () {
     });
 
     it('operationStatus has all documented fields', async function () {
-      tryAcquireOrgLock('V2 organization creation');
-      updateOrgLockStatus('Waiting for store');
+      const token = tryAcquireOrgLock('V2 organization creation');
+      updateOrgLockStatus(token, 'Waiting for store');
 
       const res = await supertest(app)
         .post('/v2/organizations')
@@ -264,8 +264,8 @@ describe('Organization Operation Lock - Endpoint Guards', function () {
   // ----------------------------------------------------------------
   describe('creation-status endpoint shows lock status', function () {
     it('returns lock status when upgrade in progress', async function () {
-      tryAcquireOrgLock('V1 to V2 upgrade');
-      updateOrgLockStatus('Creating registry store');
+      const token = tryAcquireOrgLock('V1 to V2 upgrade');
+      updateOrgLockStatus(token, 'Creating registry store');
 
       const res = await supertest(app)
         .get('/v2/organizations/creation-status');
@@ -296,8 +296,8 @@ describe('Organization Operation Lock - Endpoint Guards', function () {
       state.state = ORG_CREATION_STATES.STORES_CREATING;
       await saveCreationState(state, MetaV2);
 
-      tryAcquireOrgLock('V2 organization creation');
-      updateOrgLockStatus('Creating stores on blockchain');
+      const token = tryAcquireOrgLock('V2 organization creation');
+      updateOrgLockStatus(token, 'Creating stores on blockchain');
 
       const res = await supertest(app)
         .get('/v2/organizations/creation-status');
@@ -310,9 +310,9 @@ describe('Organization Operation Lock - Endpoint Guards', function () {
     });
 
     it('liveStatus reflects updated status', async function () {
-      tryAcquireOrgLock('test');
-      updateOrgLockStatus('A');
-      updateOrgLockStatus('B');
+      const token = tryAcquireOrgLock('test');
+      updateOrgLockStatus(token, 'A');
+      updateOrgLockStatus(token, 'B');
 
       const res = await supertest(app)
         .get('/v2/organizations/creation-status');

--- a/tests/v2/integration/org-operation-lock-endpoints.spec.js
+++ b/tests/v2/integration/org-operation-lock-endpoints.spec.js
@@ -272,6 +272,7 @@ describe('Organization Operation Lock - Endpoint Guards', function () {
 
       expect(res.status).to.equal(200);
       expect(res.body.inProgress).to.be.true;
+      expect(res.body.message).to.equal('V1 to V2 upgrade: Creating registry store');
       expect(res.body.operation).to.equal('V1 to V2 upgrade');
       expect(res.body.liveStatus).to.be.an('object');
       expect(res.body.liveStatus.operation).to.equal('V1 to V2 upgrade');

--- a/tests/v2/integration/org-operation-lock.spec.js
+++ b/tests/v2/integration/org-operation-lock.spec.js
@@ -1,0 +1,136 @@
+import { expect } from 'chai';
+import {
+  tryAcquireOrgLock,
+  releaseOrgLock,
+  getOrgLockOperation,
+  isOrgLocked,
+  updateOrgLockStatus,
+  getOrgLockStatus,
+} from '../../../src/utils/org-operation-lock.js';
+
+describe('Organization Operation Lock', function () {
+
+  afterEach(function () {
+    releaseOrgLock();
+  });
+
+  describe('tryAcquireOrgLock', function () {
+    it('should acquire lock when not held', function () {
+      const result = tryAcquireOrgLock('test operation');
+      expect(result).to.be.true;
+    });
+
+    it('should return false when lock already held', function () {
+      tryAcquireOrgLock('first operation');
+      const result = tryAcquireOrgLock('second operation');
+      expect(result).to.be.false;
+    });
+
+    it('should report correct operation name via getOrgLockOperation', function () {
+      tryAcquireOrgLock('V2 organization creation');
+      expect(getOrgLockOperation()).to.equal('V2 organization creation');
+    });
+
+    it('should report isOrgLocked() as true when held', function () {
+      tryAcquireOrgLock('test operation');
+      expect(isOrgLocked()).to.be.true;
+    });
+
+    it('should set initial status to "Starting..."', function () {
+      tryAcquireOrgLock('test operation');
+      const status = getOrgLockStatus();
+      expect(status.status).to.equal('Starting...');
+    });
+
+    it('should set startedAt timestamp', function () {
+      const before = new Date().toISOString();
+      tryAcquireOrgLock('test operation');
+      const status = getOrgLockStatus();
+      expect(status.startedAt).to.be.a('string');
+      expect(new Date(status.startedAt).getTime()).to.be.at.least(new Date(before).getTime());
+    });
+  });
+
+  describe('releaseOrgLock', function () {
+    it('should release the lock so it can be re-acquired', function () {
+      tryAcquireOrgLock('first');
+      releaseOrgLock();
+      const result = tryAcquireOrgLock('second');
+      expect(result).to.be.true;
+      expect(getOrgLockOperation()).to.equal('second');
+    });
+
+    it('should clear operation name, status, and isOrgLocked after release', function () {
+      tryAcquireOrgLock('test');
+      releaseOrgLock();
+      expect(getOrgLockOperation()).to.be.null;
+      expect(isOrgLocked()).to.be.false;
+    });
+
+    it('should be safe to call when lock is not held (no-op)', function () {
+      releaseOrgLock();
+      releaseOrgLock();
+      expect(isOrgLocked()).to.be.false;
+    });
+
+    it('should make getOrgLockStatus return null', function () {
+      tryAcquireOrgLock('test');
+      releaseOrgLock();
+      expect(getOrgLockStatus()).to.be.null;
+    });
+  });
+
+  describe('updateOrgLockStatus', function () {
+    it('should update the status message', function () {
+      tryAcquireOrgLock('test');
+      updateOrgLockStatus('Creating stores');
+      const status = getOrgLockStatus();
+      expect(status.status).to.equal('Creating stores');
+    });
+
+    it('should be reflected in getOrgLockStatus', function () {
+      tryAcquireOrgLock('test');
+      updateOrgLockStatus('Phase 1');
+      updateOrgLockStatus('Phase 2');
+      expect(getOrgLockStatus().status).to.equal('Phase 2');
+    });
+  });
+
+  describe('getOrgLockStatus', function () {
+    it('should return null when no lock held', function () {
+      expect(getOrgLockStatus()).to.be.null;
+    });
+
+    it('should return full status object when lock held', function () {
+      tryAcquireOrgLock('V1 to V2 upgrade');
+      const status = getOrgLockStatus();
+      expect(status).to.have.property('operation', 'V1 to V2 upgrade');
+      expect(status).to.have.property('status', 'Starting...');
+      expect(status).to.have.property('startedAt').that.is.a('string');
+      expect(status).to.have.property('elapsedSeconds').that.is.a('number');
+    });
+
+    it('should include elapsedSeconds', function () {
+      tryAcquireOrgLock('test');
+      const status = getOrgLockStatus();
+      expect(status.elapsedSeconds).to.be.a('number');
+      expect(status.elapsedSeconds).to.be.at.least(0);
+    });
+
+    it('should reflect updated status message after updateOrgLockStatus', function () {
+      tryAcquireOrgLock('test');
+      updateOrgLockStatus('Waiting for blockchain');
+      const status = getOrgLockStatus();
+      expect(status.status).to.equal('Waiting for blockchain');
+    });
+  });
+
+  describe('cross-operation blocking', function () {
+    it('should block a different operation name when lock is held', function () {
+      tryAcquireOrgLock('V1 creation');
+      const result = tryAcquireOrgLock('V2 creation');
+      expect(result).to.be.false;
+      expect(getOrgLockOperation()).to.equal('V1 creation');
+    });
+  });
+});

--- a/tests/v2/integration/org-operation-lock.spec.js
+++ b/tests/v2/integration/org-operation-lock.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import {
   tryAcquireOrgLock,
   releaseOrgLock,
@@ -131,6 +132,54 @@ describe('Organization Operation Lock', function () {
       const result = tryAcquireOrgLock('V2 creation');
       expect(result).to.be.false;
       expect(getOrgLockOperation()).to.equal('V1 creation');
+    });
+  });
+
+  describe('staleness TTL', function () {
+    let clock;
+
+    afterEach(function () {
+      if (clock) {
+        clock.restore();
+        clock = null;
+      }
+    });
+
+    it('should reject acquisition when lock is held and under 1 hour old', function () {
+      tryAcquireOrgLock('first');
+      const result = tryAcquireOrgLock('second');
+      expect(result).to.be.false;
+      expect(getOrgLockOperation()).to.equal('first');
+    });
+
+    it('should force-release and re-acquire when lock exceeds 1 hour', function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+      tryAcquireOrgLock('stale operation');
+      clock.tick(60 * 60 * 1000 + 1);
+      const result = tryAcquireOrgLock('new operation');
+      expect(result).to.be.true;
+      expect(getOrgLockOperation()).to.equal('new operation');
+    });
+
+    it('should not force-release when lock is exactly at the threshold', function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+      tryAcquireOrgLock('threshold operation');
+      clock.tick(60 * 60 * 1000 - 1);
+      const result = tryAcquireOrgLock('new operation');
+      expect(result).to.be.false;
+      expect(getOrgLockOperation()).to.equal('threshold operation');
+    });
+
+    it('should reset status and startedAt after force-releasing stale lock', function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+      tryAcquireOrgLock('stale op');
+      updateOrgLockStatus('stuck somewhere');
+      clock.tick(60 * 60 * 1000 + 1);
+      tryAcquireOrgLock('fresh op');
+      const status = getOrgLockStatus();
+      expect(status.operation).to.equal('fresh op');
+      expect(status.status).to.equal('Starting...');
+      expect(status.elapsedSeconds).to.equal(0);
     });
   });
 });

--- a/tests/v2/integration/org-operation-lock.spec.js
+++ b/tests/v2/integration/org-operation-lock.spec.js
@@ -3,8 +3,6 @@ import sinon from 'sinon';
 import {
   tryAcquireOrgLock,
   releaseOrgLock,
-  getOrgLockOperation,
-  isOrgLocked,
   updateOrgLockStatus,
   getOrgLockStatus,
 } from '../../../src/utils/org-operation-lock.js';
@@ -34,14 +32,14 @@ describe('Organization Operation Lock', function () {
       expect(t1).to.not.equal(t2);
     });
 
-    it('should report correct operation name via getOrgLockOperation', function () {
+    it('should report correct operation name via getOrgLockStatus', function () {
       tryAcquireOrgLock('V2 organization creation');
-      expect(getOrgLockOperation()).to.equal('V2 organization creation');
+      expect(getOrgLockStatus().operation).to.equal('V2 organization creation');
     });
 
-    it('should report isOrgLocked() as true when held', function () {
+    it('should report lock as held via getOrgLockStatus when held', function () {
       tryAcquireOrgLock('test operation');
-      expect(isOrgLocked()).to.be.true;
+      expect(getOrgLockStatus()).to.not.be.null;
     });
 
     it('should set initial status to "Starting..."', function () {
@@ -64,11 +62,11 @@ describe('Organization Operation Lock', function () {
       const token = tryAcquireOrgLock('first');
       const released = releaseOrgLock(token);
       expect(released).to.be.true;
-      expect(isOrgLocked()).to.be.false;
+      expect(getOrgLockStatus()).to.be.null;
 
       const t2 = tryAcquireOrgLock('second');
       expect(t2).to.be.a('string');
-      expect(getOrgLockOperation()).to.equal('second');
+      expect(getOrgLockStatus().operation).to.equal('second');
     });
 
     it('should NOT release lock when called with a stale token', function () {
@@ -78,21 +76,20 @@ describe('Organization Operation Lock', function () {
       tryAcquireOrgLock('second');
       const released = releaseOrgLock(staleToken);
       expect(released).to.be.false;
-      expect(isOrgLocked()).to.be.true;
-      expect(getOrgLockOperation()).to.equal('second');
+      expect(getOrgLockStatus()).to.not.be.null;
+      expect(getOrgLockStatus().operation).to.equal('second');
     });
 
     it('should release unconditionally when called without a token (test cleanup)', function () {
       tryAcquireOrgLock('test');
       releaseOrgLock();
-      expect(getOrgLockOperation()).to.be.null;
-      expect(isOrgLocked()).to.be.false;
+      expect(getOrgLockStatus()).to.be.null;
     });
 
     it('should be safe to call when lock is not held (no-op)', function () {
       releaseOrgLock();
       releaseOrgLock();
-      expect(isOrgLocked()).to.be.false;
+      expect(getOrgLockStatus()).to.be.null;
     });
 
     it('should make getOrgLockStatus return null', function () {
@@ -125,28 +122,58 @@ describe('Organization Operation Lock', function () {
       // Stale background finally runs with old token
       const released = releaseOrgLock(bgToken);
       expect(released).to.be.false;
-      expect(isOrgLocked()).to.be.true;
-      expect(getOrgLockOperation()).to.equal('new operation');
+      expect(getOrgLockStatus()).to.not.be.null;
+      expect(getOrgLockStatus().operation).to.equal('new operation');
 
       // New holder can still release
       expect(releaseOrgLock(newToken)).to.be.true;
-      expect(isOrgLocked()).to.be.false;
+      expect(getOrgLockStatus()).to.be.null;
     });
   });
 
   describe('updateOrgLockStatus', function () {
-    it('should update the status message', function () {
-      tryAcquireOrgLock('test');
-      updateOrgLockStatus('Creating stores');
+    it('should update the status message when token matches', function () {
+      const token = tryAcquireOrgLock('test');
+      updateOrgLockStatus(token, 'Creating stores');
       const status = getOrgLockStatus();
       expect(status.status).to.equal('Creating stores');
     });
 
     it('should be reflected in getOrgLockStatus', function () {
-      tryAcquireOrgLock('test');
-      updateOrgLockStatus('Phase 1');
-      updateOrgLockStatus('Phase 2');
+      const token = tryAcquireOrgLock('test');
+      updateOrgLockStatus(token, 'Phase 1');
+      updateOrgLockStatus(token, 'Phase 2');
       expect(getOrgLockStatus().status).to.equal('Phase 2');
+    });
+
+    it('should reject updates from a stale token', function () {
+      const staleToken = tryAcquireOrgLock('old');
+      releaseOrgLock(staleToken);
+      const newToken = tryAcquireOrgLock('new');
+      updateOrgLockStatus(staleToken, 'stale update');
+      expect(getOrgLockStatus().status).to.equal('Starting...');
+      updateOrgLockStatus(newToken, 'valid update');
+      expect(getOrgLockStatus().status).to.equal('valid update');
+    });
+
+    it('should reject updates after TTL force-release', function () {
+      const clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+      const bgToken = tryAcquireOrgLock('slow op');
+      updateOrgLockStatus(bgToken, 'stuck');
+
+      clock.tick(60 * 60 * 1000 + 1);
+      const newToken = tryAcquireOrgLock('fresh op');
+      expect(newToken).to.be.a('string');
+
+      // Stale operation tries to update
+      updateOrgLockStatus(bgToken, 'should be ignored');
+      expect(getOrgLockStatus().status).to.equal('Starting...');
+
+      // New holder can update
+      updateOrgLockStatus(newToken, 'new status');
+      expect(getOrgLockStatus().status).to.equal('new status');
+
+      clock.restore();
     });
   });
 
@@ -172,8 +199,8 @@ describe('Organization Operation Lock', function () {
     });
 
     it('should reflect updated status message after updateOrgLockStatus', function () {
-      tryAcquireOrgLock('test');
-      updateOrgLockStatus('Waiting for blockchain');
+      const token = tryAcquireOrgLock('test');
+      updateOrgLockStatus(token, 'Waiting for blockchain');
       const status = getOrgLockStatus();
       expect(status.status).to.equal('Waiting for blockchain');
     });
@@ -184,7 +211,7 @@ describe('Organization Operation Lock', function () {
       tryAcquireOrgLock('V1 creation');
       const result = tryAcquireOrgLock('V2 creation');
       expect(result).to.be.null;
-      expect(getOrgLockOperation()).to.equal('V1 creation');
+      expect(getOrgLockStatus().operation).to.equal('V1 creation');
     });
   });
 
@@ -202,7 +229,7 @@ describe('Organization Operation Lock', function () {
       tryAcquireOrgLock('first');
       const result = tryAcquireOrgLock('second');
       expect(result).to.be.null;
-      expect(getOrgLockOperation()).to.equal('first');
+      expect(getOrgLockStatus().operation).to.equal('first');
     });
 
     it('should force-release and re-acquire when lock exceeds 1 hour', function () {
@@ -211,7 +238,7 @@ describe('Organization Operation Lock', function () {
       clock.tick(60 * 60 * 1000 + 1);
       const result = tryAcquireOrgLock('new operation');
       expect(result).to.be.a('string');
-      expect(getOrgLockOperation()).to.equal('new operation');
+      expect(getOrgLockStatus().operation).to.equal('new operation');
     });
 
     it('should not force-release when lock is exactly at the threshold', function () {
@@ -220,13 +247,13 @@ describe('Organization Operation Lock', function () {
       clock.tick(60 * 60 * 1000 - 1);
       const result = tryAcquireOrgLock('new operation');
       expect(result).to.be.null;
-      expect(getOrgLockOperation()).to.equal('threshold operation');
+      expect(getOrgLockStatus().operation).to.equal('threshold operation');
     });
 
     it('should reset status and startedAt after force-releasing stale lock', function () {
       clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
-      tryAcquireOrgLock('stale op');
-      updateOrgLockStatus('stuck somewhere');
+      const token = tryAcquireOrgLock('stale op');
+      updateOrgLockStatus(token, 'stuck somewhere');
       clock.tick(60 * 60 * 1000 + 1);
       tryAcquireOrgLock('fresh op');
       const status = getOrgLockStatus();

--- a/tests/v2/integration/org-operation-lock.spec.js
+++ b/tests/v2/integration/org-operation-lock.spec.js
@@ -16,15 +16,22 @@ describe('Organization Operation Lock', function () {
   });
 
   describe('tryAcquireOrgLock', function () {
-    it('should acquire lock when not held', function () {
-      const result = tryAcquireOrgLock('test operation');
-      expect(result).to.be.true;
+    it('should return a truthy token when lock is free', function () {
+      const token = tryAcquireOrgLock('test operation');
+      expect(token).to.be.a('string').that.is.not.empty;
     });
 
-    it('should return false when lock already held', function () {
+    it('should return null when lock already held', function () {
       tryAcquireOrgLock('first operation');
       const result = tryAcquireOrgLock('second operation');
-      expect(result).to.be.false;
+      expect(result).to.be.null;
+    });
+
+    it('should return unique tokens on successive acquisitions', function () {
+      const t1 = tryAcquireOrgLock('first');
+      releaseOrgLock(t1);
+      const t2 = tryAcquireOrgLock('second');
+      expect(t1).to.not.equal(t2);
     });
 
     it('should report correct operation name via getOrgLockOperation', function () {
@@ -53,15 +60,29 @@ describe('Organization Operation Lock', function () {
   });
 
   describe('releaseOrgLock', function () {
-    it('should release the lock so it can be re-acquired', function () {
-      tryAcquireOrgLock('first');
-      releaseOrgLock();
-      const result = tryAcquireOrgLock('second');
-      expect(result).to.be.true;
+    it('should release the lock when called with the correct token', function () {
+      const token = tryAcquireOrgLock('first');
+      const released = releaseOrgLock(token);
+      expect(released).to.be.true;
+      expect(isOrgLocked()).to.be.false;
+
+      const t2 = tryAcquireOrgLock('second');
+      expect(t2).to.be.a('string');
       expect(getOrgLockOperation()).to.equal('second');
     });
 
-    it('should clear operation name, status, and isOrgLocked after release', function () {
+    it('should NOT release lock when called with a stale token', function () {
+      const staleToken = tryAcquireOrgLock('first');
+      releaseOrgLock(staleToken);
+
+      tryAcquireOrgLock('second');
+      const released = releaseOrgLock(staleToken);
+      expect(released).to.be.false;
+      expect(isOrgLocked()).to.be.true;
+      expect(getOrgLockOperation()).to.equal('second');
+    });
+
+    it('should release unconditionally when called without a token (test cleanup)', function () {
       tryAcquireOrgLock('test');
       releaseOrgLock();
       expect(getOrgLockOperation()).to.be.null;
@@ -78,6 +99,38 @@ describe('Organization Operation Lock', function () {
       tryAcquireOrgLock('test');
       releaseOrgLock();
       expect(getOrgLockStatus()).to.be.null;
+    });
+  });
+
+  describe('ownership protection against TTL force-release', function () {
+    let clock;
+
+    afterEach(function () {
+      if (clock) {
+        clock.restore();
+        clock = null;
+      }
+    });
+
+    it('stale background .finally() should not release a new lock holder', function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+
+      const bgToken = tryAcquireOrgLock('slow background op');
+
+      // Simulate TTL expiry and new acquisition
+      clock.tick(60 * 60 * 1000 + 1);
+      const newToken = tryAcquireOrgLock('new operation');
+      expect(newToken).to.be.a('string');
+
+      // Stale background finally runs with old token
+      const released = releaseOrgLock(bgToken);
+      expect(released).to.be.false;
+      expect(isOrgLocked()).to.be.true;
+      expect(getOrgLockOperation()).to.equal('new operation');
+
+      // New holder can still release
+      expect(releaseOrgLock(newToken)).to.be.true;
+      expect(isOrgLocked()).to.be.false;
     });
   });
 
@@ -130,7 +183,7 @@ describe('Organization Operation Lock', function () {
     it('should block a different operation name when lock is held', function () {
       tryAcquireOrgLock('V1 creation');
       const result = tryAcquireOrgLock('V2 creation');
-      expect(result).to.be.false;
+      expect(result).to.be.null;
       expect(getOrgLockOperation()).to.equal('V1 creation');
     });
   });
@@ -148,7 +201,7 @@ describe('Organization Operation Lock', function () {
     it('should reject acquisition when lock is held and under 1 hour old', function () {
       tryAcquireOrgLock('first');
       const result = tryAcquireOrgLock('second');
-      expect(result).to.be.false;
+      expect(result).to.be.null;
       expect(getOrgLockOperation()).to.equal('first');
     });
 
@@ -157,7 +210,7 @@ describe('Organization Operation Lock', function () {
       tryAcquireOrgLock('stale operation');
       clock.tick(60 * 60 * 1000 + 1);
       const result = tryAcquireOrgLock('new operation');
-      expect(result).to.be.true;
+      expect(result).to.be.a('string');
       expect(getOrgLockOperation()).to.equal('new operation');
     });
 
@@ -166,7 +219,7 @@ describe('Organization Operation Lock', function () {
       tryAcquireOrgLock('threshold operation');
       clock.tick(60 * 60 * 1000 - 1);
       const result = tryAcquireOrgLock('new operation');
-      expect(result).to.be.false;
+      expect(result).to.be.null;
       expect(getOrgLockOperation()).to.equal('threshold operation');
     });
 


### PR DESCRIPTION
## Summary

- Adds an in-memory concurrency lock (`src/utils/org-operation-lock.js`) that prevents simultaneous execution of organization create, upgrade, and reclaim operations across both V1 and V2 APIs.
- Conflicting requests now receive a **409 Conflict** response with a live `operationStatus` object (operation name, current step, start time, elapsed seconds).
- Enhances `GET /v2/organizations/creation-status` with a `liveStatus` field for real-time progress of any running operation, including upgrades.

### Guarded endpoints

| Endpoint | Controller |
|---|---|
| `POST /v1/organizations` (create & createV2) | `organization.controller.js` |
| `POST /v1/organizations/reclaim-home` | `organization.controller.js` |
| `POST /v2/organizations` | `organizations-v2.controller.js` |
| `POST /v2/organizations/upgrade` | `organizations-v2.controller.js` |
| `POST /v2/organizations/reclaim-home` | `organizations-v2.controller.js` |

### Additional changes

- `updateOrgLockStatus()` milestone calls added to V1/V2 model creation and V2 upgrade flows for live progress tracking.
- V1 and V2 startup recovery tasks (`clean-up-failed-org.js`, `clean-up-failed-org-v2.js`) acquire and release the lock around recovery attempts.
- API documentation updated with 409 response examples and `liveStatus` response format.

## Test plan

- [x] Unit tests for `org-operation-lock` module (`tests/v2/integration/org-operation-lock.spec.js`)
- [x] Integration tests for endpoint guards, cross-version blocking, 409 response contract, and creation-status endpoint (`tests/v2/integration/org-operation-lock-endpoints.spec.js`)
- [x] Full `npm run test:v2` suite passes (no new failures introduced)
- [ ] Manual verification on dev server with concurrent API requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new global in-memory lock that changes behavior of org create/upgrade/reclaim/recovery flows and returns new `409 Conflict` responses, so regressions could block critical org operations or misreport status. Risk is mitigated by explicit TTL handling and added unit/integration tests, but concurrency/async edge cases remain.
> 
> **Overview**
> Adds a global in-memory *organization operation lock* to prevent concurrent home-organization operations (create/upgrade/reclaim/recovery) across both V1 and V2 APIs, returning `409 Conflict` with an `operationStatus` payload when a conflicting request arrives.
> 
> Threads the lock token through V1/V2 organization creation and V2 upgrade code paths to publish step-by-step progress via `updateOrgLockStatus`, and extends `GET /v2/organizations/creation-status` to include `liveStatus` (and to surface lock status even when no persisted creation state exists).
> 
> Updates startup recovery tasks to acquire/release the same lock, and refreshes API docs/tests to cover the new 409 contract, cross-version blocking, TTL stale-lock behavior, and `liveStatus` reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec25926dcad99e57592b215feddc53695d896d9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->