### PR TITLE
fix: add wallet readiness check and retry logic to V1 store creation

### DIFF
--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -453,7 +453,7 @@ const waitForSpendableCoins = async (
   let lastLogTime = 0;
 
   logger.info(
-    `[v2]: Waiting for ${requiredCoins} coins of at least ${minMojosPerCoin} mojos each (timeout: ${maxWaitMs / 1000}s)`,
+    `[wallet]: Waiting for ${requiredCoins} coins of at least ${minMojosPerCoin} mojos each (timeout: ${maxWaitMs / 1000}s)`,
   );
 
   while (Date.now() - startTime < maxWaitMs) {
@@ -468,7 +468,7 @@ const waitForSpendableCoins = async (
         if (Date.now() - lastLogTime > 30000) {
           lastLogTime = Date.now();
           logger.info(
-            `[v2]: Waiting for pending transactions to confirm before org creation (${elapsed}s elapsed)`,
+            `[wallet]: Waiting for pending transactions to confirm before org creation (${elapsed}s elapsed)`,
           );
         }
         await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
@@ -479,7 +479,7 @@ const waitForSpendableCoins = async (
       const coinResult = await getCoinRecords();
 
       if (!coinResult.success || !coinResult.coin_records) {
-        logger.warn('[v2]: Could not get coin records, retrying...');
+        logger.warn('[wallet]: Could not get coin records, retrying...');
         await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
         continue;
       }
@@ -498,19 +498,19 @@ const waitForSpendableCoins = async (
       if (Date.now() - lastLogTime > 30000) {
         lastLogTime = Date.now();
         logger.info(
-          `[v2]: Found ${usableCoins.length} usable coins (need ${requiredCoins}) with total ${totalBalance} mojos (${elapsed}s elapsed)`,
+          `[wallet]: Found ${usableCoins.length} usable coins (need ${requiredCoins}) with total ${totalBalance} mojos (${elapsed}s elapsed)`,
         );
         if (usableCoins.length > 0 && usableCoins.length < 10) {
           // Log individual coins for debugging
           usableCoins.forEach((coin, i) => {
-            logger.debug(`[v2]:   Coin ${i + 1}: ${coin.amount} mojos, id: ${coin.id?.substring(0, 16)}...`);
+            logger.debug(`[wallet]:   Coin ${i + 1}: ${coin.amount} mojos, id: ${coin.id?.substring(0, 16)}...`);
           });
         }
       }
 
       if (usableCoins.length >= requiredCoins) {
         logger.info(
-          `[v2]: Sufficient coins available: ${usableCoins.length} coins of ${minMojosPerCoin}+ mojos (need ${requiredCoins})`,
+          `[wallet]: Sufficient coins available: ${usableCoins.length} coins of ${minMojosPerCoin}+ mojos (need ${requiredCoins})`,
         );
         return { success: true, coinCount: usableCoins.length, balance: totalBalance };
       }
@@ -518,12 +518,12 @@ const waitForSpendableCoins = async (
       // Not enough coins yet - check if we should warn about coin management
       if (elapsed > 60 && usableCoins.length < requiredCoins) {
         logger.warn(
-          `[v2]: Only ${usableCoins.length}/${requiredCoins} usable coins available after ${elapsed}s. ` +
+          `[wallet]: Only ${usableCoins.length}/${requiredCoins} usable coins available after ${elapsed}s. ` +
           `Coin management may need to split coins first.`,
         );
       }
     } catch (error) {
-      logger.warn(`[v2]: Error checking coin availability: ${error.message}`);
+      logger.warn(`[wallet]: Error checking coin availability: ${error.message}`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
@@ -531,13 +531,23 @@ const waitForSpendableCoins = async (
 
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
   logger.error(
-    `[v2]: Timeout waiting for spendable coins after ${elapsed}s`,
+    `[wallet]: Timeout waiting for spendable coins after ${elapsed}s`,
   );
   return {
     success: false,
     error: `Timeout waiting for ${requiredCoins} coins of ${minMojosPerCoin}+ mojos after ${elapsed}s`,
   };
 };
+
+const TRANSIENT_WALLET_ERRORS = [
+  'Wallet needs to be fully synced',
+  'DataLayerWallet not available',
+  'DataLayer Wallet already exists',
+  'No spendable coins',
+];
+
+const isTransientWalletError = (error) =>
+  TRANSIENT_WALLET_ERRORS.some((msg) => error.message?.includes(msg));
 
 export default {
   hasUnconfirmedTransactions,
@@ -553,4 +563,5 @@ export default {
   getWalletBlockchainSyncStatus,
   getCoinRecords,
   splitCoins,
+  isTransientWalletError,
 };

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { sequelize } from '../../database';
 
 import datalayer from '../../datalayer';
+import wallet from '../../datalayer/wallet.js';
 import { logger } from '../../config/logger';
 import { Audit, FileStore, Meta, ModelKeys, Staging } from '../';
 import { getConfig } from '../../utils/config-loader';
@@ -53,6 +54,8 @@ import {
 } from '../../utils/organization-creation-state.js';
 import { runMirrorCheck } from '../../tasks/mirror-check.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
+
+const { isTransientWalletError } = wallet;
 
 class Organization extends Model {
   static async getHomeOrg(includeAddress = true) {
@@ -210,6 +213,17 @@ class Organization extends Model {
         });
       }
 
+      if (!USE_SIMULATOR) {
+        const coinCheck = await wallet.waitForSpendableCoins(4);
+        if (!coinCheck.success) {
+          throw new Error(
+            `Cannot create organization: ${coinCheck.error || 'Insufficient spendable coins'}. ` +
+            'Please ensure wallet has sufficient balance, coin management has split coins, and no pending transactions.',
+          );
+        }
+        logger.info(`[v1]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
+      }
+
       // Execute the creation process
       return await Organization._executeOrganizationCreation(state, lockToken);
     } catch (error) {
@@ -243,6 +257,18 @@ class Organization extends Model {
       // Reset startedAt for new retry attempt
       state = updateState(state, { startedAt: new Date().toISOString() });
       await saveCreationState(state, Meta);
+    }
+
+    const neededCoins = getStoresToCreate(state).length;
+    if (!USE_SIMULATOR && neededCoins > 0) {
+      const coinCheck = await wallet.waitForSpendableCoins(neededCoins);
+      if (!coinCheck.success) {
+        throw new Error(
+          `Cannot resume organization creation: ${coinCheck.error || 'Insufficient spendable coins'}. ` +
+          'Please ensure wallet has sufficient balance, coin management has split coins, and no pending transactions.',
+        );
+      }
+      logger.info(`[v1]: Resuming org creation, ${coinCheck.coinCount} coins available (need ${neededCoins})`);
     }
 
     return await Organization._executeOrganizationCreation(state, lockToken);
@@ -458,17 +484,34 @@ class Organization extends Model {
       return state;
     }
 
-    // Create all stores in parallel
+    const maxRetries = 10;
+    const retryDelayMs = 30000;
+
+    // Create all stores in parallel, each with independent retry logic
     const createPromises = storesToCreate.map(async (storeType) => {
-      try {
-        logState(state, `Creating ${storeType} store`);
-        const storeId = await datalayer.createDataLayerStore();
-        logState(state, `Created ${storeType} store: ${storeId}`);
-        return { storeType, storeId, success: true };
-      } catch (error) {
-        logState(state, `Failed to create ${storeType} store: ${error.message}`, 'error');
-        return { storeType, storeId: null, success: false, error: error.message };
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          logState(state, `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
+          const storeId = await datalayer.createDataLayerStore();
+          logState(state, `Created ${storeType} store: ${storeId}`);
+          return { storeType, storeId, success: true };
+        } catch (error) {
+          if (isTransientWalletError(error) && attempt < maxRetries) {
+            logState(
+              state,
+              `Transient error creating ${storeType} store ` +
+                `(attempt ${attempt}/${maxRetries}): ${error.message}. ` +
+                `Retrying in ${retryDelayMs / 1000}s...`,
+              'warn',
+            );
+            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+            continue;
+          }
+          logState(state, `Failed to create ${storeType} store: ${error.message}`, 'error');
+          return { storeType, storeId: null, success: false, error: error.message };
+        }
       }
+      return { storeType, storeId: null, success: false, error: 'Retry loop exhausted without result' };
     });
 
     const results = await Promise.all(createPromises);

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -76,15 +76,7 @@ import ModelTypes from './organizations-v2.modeltypes.cjs';
 import { runMirrorCheckV2 } from '../../tasks/mirror-check-v2.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
-const TRANSIENT_WALLET_ERRORS = [
-  'Wallet needs to be fully synced',
-  'DataLayerWallet not available',
-  'DataLayer Wallet already exists',
-  'No spendable coins',
-];
-
-const isTransientWalletError = (error) =>
-  TRANSIENT_WALLET_ERRORS.some((msg) => error.message?.includes(msg));
+const { isTransientWalletError } = wallet;
 
 class OrganizationsV2 extends Model {
   static async create(values, options) {
@@ -315,16 +307,17 @@ class OrganizationsV2 extends Model {
       await saveCreationState(state, MetaV2);
     }
 
-    // Wait for sufficient spendable coins before resuming store creation
-    // We need 4 SEPARATE coins (one per parallel store creation), each large enough to cover COIN_SIZE + fee
-    const coinCheck = await wallet.waitForSpendableCoins(4);
-    if (!coinCheck.success) {
-      throw new Error(
-        `Cannot resume organization creation: ${coinCheck.error || 'Insufficient spendable coins'}. ` +
-        'Please ensure wallet has sufficient balance, coin management has split coins, and no pending transactions.',
-      );
+    const neededCoins = getStoresToCreate(state).length;
+    if (neededCoins > 0) {
+      const coinCheck = await wallet.waitForSpendableCoins(neededCoins);
+      if (!coinCheck.success) {
+        throw new Error(
+          `Cannot resume organization creation: ${coinCheck.error || 'Insufficient spendable coins'}. ` +
+          'Please ensure wallet has sufficient balance, coin management has split coins, and no pending transactions.',
+        );
+      }
+      loggerV2.info(`[v2]: Resuming org creation, ${coinCheck.coinCount} coins available (need ${neededCoins})`);
     }
-    loggerV2.info(`[v2]: Resuming org creation, ${coinCheck.coinCount} coins available`);
 
     return await OrganizationsV2._executeOrganizationCreation(state, MetaV2, lockToken);
   }


### PR DESCRIPTION
## Summary

- Adds `wallet.waitForSpendableCoins(4)` before V1 organization store creation and resume paths, ensuring the wallet is synced and has sufficient coins before attempting `createDataLayerStore` calls.
- Adds per-store transient wallet error retry logic (10 attempts, 30s backoff) to `_createStoresInParallel`, matching the existing V2 implementation.
- Adds `TRANSIENT_WALLET_ERRORS` list and `isTransientWalletError` helper (same patterns as V2: "Wallet needs to be fully synced", "DataLayerWallet not available", "DataLayer Wallet already exists", "No spendable coins").

### Problem

The V1 `_createStoresInParallel` method called `datalayer.createDataLayerStore()` directly without checking wallet readiness. When the wallet temporarily desyncs (e.g., due to peer timeout or weight proof validation failure), all 4 parallel store creation calls fail permanently with "Wallet needs to be fully synced" — no retry, no recovery. The creation state stays as `STORES_CREATING` forever while the background process has already exited.

This was observed in the `v1 to v2 upgrade test` CI job ([run 23157833856](https://github.com/Chia-Network/cadt/actions/runs/23157833856/job/67277269647)), where the wallet desynced at 17:54:14 due to a trusted peer timeout, all 4 stores failed at 17:54:33, and the test polled for 332 seconds before giving up.

The V2 equivalent already protects against this with `waitForSpendableCoins(4)` and per-store retry logic.

## Test plan

- [x] V1 integration tests pass (112 passing, 0 failing)
- [x] V2 integration tests pass (1272 passing, 1 pre-existing failure unrelated to this change)
- [x] No new lint errors introduced
- [ ] CI live API tests (v1 to v2 upgrade test should be more resilient to wallet desyncs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the V1 organization creation/resume flow to block on wallet coin availability and to retry transient wallet errors during parallel store creation, which can affect timing and failure modes in a critical onboarding path.
> 
> **Overview**
> Improves V1 organization creation resiliency by **gating create/resume on wallet readiness**: `createHomeOrganization` and `_resumeOrganizationCreation` now call `wallet.waitForSpendableCoins(...)` (using the number of remaining stores) and fail fast with a clearer error if coins/transactions aren’t ready.
> 
> Adds **per-store retry with backoff** to V1 parallel store creation: each `createDataLayerStore` call retries up to 10 times (30s delay) when `wallet.isTransientWalletError` matches known temporary wallet conditions. Common transient error detection is centralized in `datalayer/wallet.js` and the duplicated V2 helper is removed; wallet logs in `waitForSpendableCoins` are also renamed from `[v2]` to `[wallet]` for clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ea6f220bb3b53fa2005ed7add7905cdbf9e94a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->