### PR TITLE
fix: subscribe to org store before sync check in v1 importOrganization

### DIFF
--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -881,9 +881,21 @@ class Organization extends Model {
    * @returns {Promise<void>}
    */
   static async importOrganization(orgUid, isHome = false) {
-    // Check if store is synced BEFORE acquiring mutex to avoid blocking other operations
-    // If store is not synced, skip import - it will be retried on next task run
+    // Subscribe to the org store first, then check sync status.
+    // This ensures new org stores get subscribed on the first pass so they can
+    // begin syncing, and subsequent runs will find them synced and proceed.
     if (!USE_SIMULATOR) {
+      try {
+        await datalayer.subscribeToStoreOnDataLayer(orgUid);
+      } catch (error) {
+        logger.warn(
+          `[v1]: Could not subscribe to store for ${orgUid}, skipping import: ${error.message}`,
+        );
+        return;
+      }
+
+      // Check if store is synced BEFORE acquiring mutex to avoid blocking other operations
+      // If store is not synced, skip import - it will be retried on next task run
       try {
         const syncStatus = await datalayer.getDataLayerStoreSyncStatus(orgUid);
         if (!isDlStoreSynced(syncStatus?.sync_status)) {


### PR DESCRIPTION
## Summary

- Fixes a chicken-and-egg bug in v1 `importOrganization()` where `getDataLayerStoreSyncStatus` was called before the store was subscribed. For unsubscribed stores, datalayer's `get_sync_status` RPC throws (`"No store id stored in the local database"`), causing the method to return early and never reach `subscribeToOrganization()`. Every retry from `sync-default-organizations` hit the same wall — the store was never subscribed and could never report as synced.
- Ports the subscribe-first pattern already used in v2's `importOrganization`: subscribe to the store first (no-op if already subscribed), then check sync status. New stores begin syncing on the first pass and subsequent retries find them progressively more synced.

## Test plan

- [ ] Verify v1 and v2 integration tests pass (`npm run test:v1` / `npm run test:v2`)
- [ ] Confirm v2 remote sync CI test still passes (this change is v1-only)
- [ ] On a real node: delete a non-home org from CADT DB, verify `sync-default-organizations` task re-imports it on next run without manual datalayer subscription

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes v1 org import flow to subscribe before checking sync status, which affects how imports are gated/retried and could impact background sync behavior if subscription or status calls behave unexpectedly.
> 
> **Overview**
> Fixes a v1 import deadlock where `importOrganization()` could bail out on `getDataLayerStoreSyncStatus()` errors for unsubscribed stores, preventing the org from ever being subscribed/synced.
> 
> `importOrganization()` now attempts `datalayer.subscribeToStoreOnDataLayer(orgUid)` first (and skips import with a warning if that fails), then performs the existing pre-mutex sync-status check to decide whether to proceed or retry later.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b21e630c501bd7ffe7aefa4a157f14622d0250d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->