### PR TITLE
fix: skip wallet availability check for GET requests in global middleware

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -147,7 +147,9 @@ app.use(async function (req, res, next) {
   try {
     await assertChiaNetworkMatchInConfiguration();
     await assertDataLayerAvailable();
-    await assertWalletIsAvailable();
+    if (req.method !== 'GET') {
+      await assertWalletIsAvailable();
+    }
     next();
   } catch (err) {
     if (res.headersSent) {


### PR DESCRIPTION
## Summary

- Skip `assertWalletIsAvailable()` for GET requests in the global middleware (`src/middleware.js`), which was rejecting read-only API calls with 400 during transient wallet desyncs
- Fixes the **v2 governance body tests** CI failure on PR #1531 where governance GET endpoints (`/meta/pickList`, `/meta/glossary`, `/meta/orgList`, `/exists`) all returned 400 because the wallet was momentarily syncing a new block from the test's own datalayer writes

**Root cause**: The wallet transiently desyncs for a few seconds every time a datalayer update confirms on-chain. The global middleware called `assertWalletIsAvailable()` on *every* non-health request — including GET requests that only read from the local SQLite database. This matches the existing pattern where the home org sync check (line 341) already allows GET requests through.

## Test plan

- [ ] Verify the v2 governance body tests pass in CI (the previously failing job)
- [ ] Verify all other CI jobs continue to pass
- [ ] Confirm write endpoints (POST/PUT/PATCH/DELETE) still reject when wallet is not synced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to request gating in global middleware; it only relaxes checks for GET endpoints while preserving existing wallet enforcement for non-GET writes.
> 
> **Overview**
> Prevents global middleware from rejecting *read-only* GET requests when the wallet is temporarily unavailable by only running `assertWalletIsAvailable()` for non-GET methods.
> 
> Health checks and other existing assertions (`assertChiaNetworkMatchInConfiguration`, `assertDataLayerAvailable`) are unchanged; write operations still require wallet availability and will continue to return `400` on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be4946203bd33d55ef99a6383152809a42a80b16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->