### PR TITLE
fix: use correct meta key for user-deleted org tracking in V2

### DIFF
--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -1350,6 +1350,7 @@ class Organization extends Model {
                 ..._.omit(updateData, [
                   'registryId',
                   'dataModelVersionStoreId',
+                  'isHome',
                 ]),
                 prefix: updateData.prefix || '0',
                 metadata: JSON.stringify(metadata),

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -1605,11 +1605,10 @@ class OrganizationsV2 extends Model {
         }
       }
 
-      // Remove from deleted orgs list if present
+      // Remove from deleted orgs list if present so sync-default-organizations
+      // won't skip this org on future runs
       const { MetaV2 } = await import('./index.js');
-      await MetaV2.destroy({
-        where: { meta_key: 'userDeletedOrgUid', meta_value: orgUid },
-      });
+      await MetaV2.removeUserDeletedOrgUid(orgUid);
 
       loggerV2.info(`[v2]: Importing organization ${orgUid} ${isHome && 'as home'}`);
       loggerV2.debug(
@@ -1953,8 +1952,7 @@ class OrganizationsV2 extends Model {
 
     const transaction = await sequelizeV2.transaction();
     try {
-      // Import V2 models
-      const { MetaV2, AuditV2 } = await import('./index.js');
+      const { AuditV2 } = await import('./index.js');
 
       // Delete from organization table
       await OrganizationsV2.destroy({
@@ -1971,49 +1969,6 @@ class OrganizationsV2 extends Model {
         where: { org_uid: orgUid },
         transaction,
       });
-
-      // Delete from meta table (org-related metadata)
-      // Note: This delete might not match anything if the record doesn't exist
-      // We delete it here to clean up, but the main logic below handles create/update
-      await MetaV2.destroy({
-        where: { meta_key: 'userDeletedOrgUid', meta_value: orgUid },
-        transaction,
-      });
-
-      // Note: V2 data models (ProgramV2, ProjectV2, etc.) don't have org_uid fields
-      // They are associated with organizations through the registry, not directly.
-      // Data model records are shared across organizations that use the same registry.
-      // Therefore, we only delete from system tables (AuditV2, StagingV2, MetaV2) and the organization itself.
-
-      // Add to deleted orgs list (before commit so it's part of transaction)
-      // Use upsert instead of findOne + create/update to avoid unique constraint lock issues
-      // First, try to find existing record to get current value
-      const existingMeta = await MetaV2.findOne({
-        where: { meta_key: 'userDeletedOrgUid' },
-        transaction,
-      });
-
-      let deletedOrgs = [];
-      if (existingMeta) {
-        // Parse existing value and add orgUid if not already present
-        try {
-          deletedOrgs = JSON.parse(existingMeta.meta_value || '[]');
-        } catch {
-          deletedOrgs = [];
-        }
-      }
-
-      if (!deletedOrgs.includes(orgUid)) {
-        deletedOrgs.push(orgUid);
-        // Use upsert to handle both create and update cases atomically
-        // This avoids unique constraint lock issues
-        await MetaV2.upsert({
-          meta_key: 'userDeletedOrgUid',
-          meta_value: JSON.stringify(deletedOrgs),
-        }, {
-          transaction,
-        });
-      }
 
       await transaction.commit();
     } catch (error) {
@@ -2065,7 +2020,13 @@ class OrganizationsV2 extends Model {
         `an error occurred while deleting records corresponding to organization ${orgUid}. no changes have been made`,
       );
     }
-    // Success case - release mutexes
+    // Record the deletion in the meta table while still holding the mutexes so
+    // sync-default-organizations-v2 cannot slip in between the delete and the
+    // meta write and re-import the org.  addUserDeletedOrgUid does not acquire
+    // either mutex, so this cannot deadlock.
+    const { MetaV2: MetaV2Post } = await import('./index.js');
+    await MetaV2Post.addUserDeletedOrgUid(orgUid);
+
     releaseAddDeleteMutex();
     releaseAuditTransactionMutex();
   }
@@ -2117,6 +2078,7 @@ class OrganizationsV2 extends Model {
                 ..._.omit(updateData, [
                   'registry_id',
                   'data_model_version_store_id',
+                  'is_home',
                 ]),
                 metadata: metadataJson,
               },


### PR DESCRIPTION
## Summary

- **Fix meta key mismatch in V2 `deleteAllOrganizationData`**: The function used a hardcoded `'userDeletedOrgUid'` meta key instead of the `'userDeletedOrgs'` constant defined in `MetaV2`. This meant `sync-default-organizations-v2` could not find the deleted org in its check and would re-import it with `is_home: false`, silently removing a participant's home org status. Replaced the inline meta logic with `MetaV2.addUserDeletedOrgUid()` to match V1's correct pattern.
- **Fix `importOrganization` cleanup**: The `MetaV2.destroy()` call used the wrong meta key and tried to match `meta_value` against a single orgUid when the actual value is a JSON array, so it never matched. Replaced with `MetaV2.removeUserDeletedOrgUid()`.
- **Prevent `syncOrganizationMeta` from overwriting `is_home`/`isHome`**: Added the home org flag to the `_.omit()` list in both V1 and V2 `syncOrganizationMeta`, so datalayer store data can never overwrite this CADT-internal field.

## Root Cause

Investigated on the `cadt-participant1-testing` k8s pod. The org was deleted via the API at 17:32 UTC, recorded under `meta_key = 'userDeletedOrgUid'`. Within 40 seconds, `sync-default-organizations-v2` ran, checked `meta_key = 'userDeletedOrgs'` (different key), found nothing, and re-imported the org with `is_home: false`.

## Test plan

- [ ] Verify V2 org delete followed by sync-default-organizations does NOT re-import the org
- [ ] Verify V2 org import correctly removes the org from the user-deleted list
- [ ] Verify `syncOrganizationMeta` does not overwrite `is_home` even if store data contains it
- [ ] Existing integration tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches V2 org delete/import flows and mutex timing; a mistake could cause orgs to be incorrectly re-imported or skipped during background sync.
> 
> **Overview**
> Fixes V2 user-deleted organization tracking by replacing ad-hoc `MetaV2.destroy`/JSON-array manipulation with `MetaV2.removeUserDeletedOrgUid()` on import and `MetaV2.addUserDeletedOrgUid()` on delete, using the correct `userDeletedOrgs` meta key.
> 
> Adjusts V2 deletion to write the “user deleted” marker **while still holding mutexes** (after the DB transaction) to prevent `sync-default-organizations-v2` from re-importing an org between deletion and meta update.
> 
> Prevents `syncOrganizationMeta` from overwriting the home-org flag by omitting `isHome` (V1) / `is_home` (V2) from store-driven updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 917baa58755af74ebfef658b362c24f0cb893d0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->