### PR TITLE
feat: add transaction health monitoring and recovery

### DIFF
--- a/src/controllers/governance.controller.js
+++ b/src/controllers/governance.controller.js
@@ -129,12 +129,7 @@ export const createGoveranceBody = async (req, res) => {
 
     Governance.createGoveranceBody().catch(async (error) => {
       logger.error('Error creating governance body in background:', error);
-      try {
-        await Meta.upsert({ metaKey: 'governanceCreationStatus', metaValue: 'failed' });
-        await Meta.upsert({ metaKey: 'governanceCreationError', metaValue: error.message });
-      } catch (metaError) {
-        logger.error(`Failed to record governance creation failure: ${metaError.message}`);
-      }
+      await Governance._setCreationStatus('failed', error.message);
     });
 
     return res.json({

--- a/src/controllers/governance.controller.js
+++ b/src/controllers/governance.controller.js
@@ -36,7 +36,6 @@ export const isCreated = async (req, res) => {
     });
 
     if (results) {
-      // Get the main governance body ID (the one to share with other instances)
       const mainGovernanceBodyId = await Meta.findOne({
         where: { metaKey: 'mainGoveranceBodyId' },
       });
@@ -47,9 +46,17 @@ export const isCreated = async (req, res) => {
         governanceBodyId: mainGovernanceBodyId?.metaValue || null,
       });
     } else {
+      // Include creation status when governance is not yet created
+      const creationStatus = await Meta.findOne({ where: { metaKey: 'governanceCreationStatus' } });
+      const creationError = await Meta.findOne({ where: { metaKey: 'governanceCreationError' } });
+      const creationStartedAt = await Meta.findOne({ where: { metaKey: 'governanceCreationStartedAt' } });
+
       return res.json({
         created: false,
         success: true,
+        creationStatus: creationStatus?.metaValue || null,
+        creationError: creationError?.metaValue || null,
+        creationStartedAt: creationStartedAt?.metaValue || null,
       });
     }
   } catch (error) {
@@ -120,7 +127,15 @@ export const createGoveranceBody = async (req, res) => {
     await assertWalletIsSynced();
     await assertCanBeGovernanceBody();
 
-    Governance.createGoveranceBody();
+    Governance.createGoveranceBody().catch(async (error) => {
+      logger.error('Error creating governance body in background:', error);
+      try {
+        await Meta.upsert({ metaKey: 'governanceCreationStatus', metaValue: 'failed' });
+        await Meta.upsert({ metaKey: 'governanceCreationError', metaValue: error.message });
+      } catch (metaError) {
+        logger.error(`Failed to record governance creation failure: ${metaError.message}`);
+      }
+    });
 
     return res.json({
       message:

--- a/src/controllers/v2/governance-v2.controller.js
+++ b/src/controllers/v2/governance-v2.controller.js
@@ -50,7 +50,6 @@ export const isCreated = async (req, res) => {
     });
 
     if (results) {
-      // Get the main governance body ID (the one to share with other instances)
       const mainGovernanceBodyId = await MetaV2.findOne({
         where: { meta_key: 'mainGoveranceBodyId' },
       });
@@ -61,9 +60,16 @@ export const isCreated = async (req, res) => {
         governanceBodyId: mainGovernanceBodyId?.meta_value || null,
       });
     } else {
+      const creationStatus = await MetaV2.findOne({ where: { meta_key: 'governanceCreationStatus' } });
+      const creationError = await MetaV2.findOne({ where: { meta_key: 'governanceCreationError' } });
+      const creationStartedAt = await MetaV2.findOne({ where: { meta_key: 'governanceCreationStartedAt' } });
+
       return res.json({
         created: false,
         success: true,
+        creationStatus: creationStatus?.meta_value || null,
+        creationError: creationError?.meta_value || null,
+        creationStartedAt: creationStartedAt?.meta_value || null,
       });
     }
   } catch (error) {
@@ -193,8 +199,14 @@ export const createGoveranceBody = async (req, res) => {
 
     // Start governance body creation in the background
     // Don't await - let it run asynchronously
-    GovernanceV2.createGoveranceBody().catch((error) => {
+    GovernanceV2.createGoveranceBody().catch(async (error) => {
       loggerV2.error('[v2]: Error creating governance body in background:', error);
+      try {
+        await MetaV2.upsert({ meta_key: 'governanceCreationStatus', meta_value: 'failed' });
+        await MetaV2.upsert({ meta_key: 'governanceCreationError', meta_value: error.message });
+      } catch (metaError) {
+        loggerV2.error(`[v2]: Failed to record governance creation failure: ${metaError.message}`);
+      }
     });
 
     // Return immediately - work happens in background

--- a/src/controllers/v2/governance-v2.controller.js
+++ b/src/controllers/v2/governance-v2.controller.js
@@ -201,12 +201,7 @@ export const createGoveranceBody = async (req, res) => {
     // Don't await - let it run asynchronously
     GovernanceV2.createGoveranceBody().catch(async (error) => {
       loggerV2.error('[v2]: Error creating governance body in background:', error);
-      try {
-        await MetaV2.upsert({ meta_key: 'governanceCreationStatus', meta_value: 'failed' });
-        await MetaV2.upsert({ meta_key: 'governanceCreationError', meta_value: error.message });
-      } catch (metaError) {
-        loggerV2.error(`[v2]: Failed to record governance creation failure: ${metaError.message}`);
-      }
+      await GovernanceV2._setCreationStatus('failed', error.message);
     });
 
     // Return immediately - work happens in background

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -891,12 +891,20 @@ const createDataLayerStore = async () => {
       .timeout(timeout)
       .send({
         fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+        verbose: true,
       });
 
     const data = response.body;
 
     if (data.success) {
-      return data.id;
+      // With verbose=true, the RPC returns { id, txs } where txs is an array
+      // of TransactionRecord objects, each with a `name` field (tx_id/bundle_id).
+      // Older nodes without verbose support will only return { id }.
+      const txIds = Array.isArray(data.txs)
+        ? data.txs.map((tx) => tx.name).filter(Boolean)
+        : [];
+
+      return { storeId: data.id, txIds };
     }
 
     throw new Error(data.error);

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -649,12 +649,8 @@ const classifyTransaction = (sentTo) => {
     return 'in_mempool';
   }
 
-  // All peers failed, none succeeded
-  if (hasFailed && !hasSuccess) {
-    const allFailed = sentTo.every(([, status]) => status === MempoolInclusionStatus.FAILED);
-    if (allFailed) {
-      return 'rejected';
-    }
+  if (hasFailed && sentTo.every(([, status]) => status === MempoolInclusionStatus.FAILED)) {
+    return 'rejected';
   }
 
   return 'pending';

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -785,8 +785,6 @@ const formatDuration = (seconds) => {
 const clearRejectedTransactions = async (walletId, txIds, context) => {
   const health = await getTransactionHealth(walletId);
 
-  const totalUnconfirmed = health.rejected.length + health.inMempool.length + health.pending.length;
-
   // Safety check: refuse if ANY unconfirmed tx is not rejected
   if (health.inMempool.length > 0 || health.pending.length > 0) {
     const reason =

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -223,8 +223,8 @@ const waitForAllTransactionsToConfirm = async (startTime = null, maxWaitMs = 180
     await new Promise((resolve) => setTimeout(resolve, 15000));
 
     if (anyUnconfirmed) {
-      // After 5 minutes of waiting, start logging health details
-      if (elapsed > 300000 && elapsed % 60000 < 15000) {
+      const elapsedAfterSleep = Date.now() - startTime;
+      if (elapsedAfterSleep > 300000 && elapsedAfterSleep % 60000 < 15000) {
         try {
           const dlWalletId = await getDLWalletId();
           const walletIds = dlWalletId ? ['1', dlWalletId] : ['1'];
@@ -234,7 +234,7 @@ const waitForAllTransactionsToConfirm = async (startTime = null, maxWaitMs = 180
             if (total > 0) {
               logger.info(
                 `waitForAllTransactionsToConfirm: wallet ${wid} still has ` +
-                `${total} unconfirmed tx(s) after ${Math.round(elapsed / 1000)}s ` +
+                `${total} unconfirmed tx(s) after ${Math.round(elapsedAfterSleep / 1000)}s ` +
                 `(${health.rejected.length} rejected, ${health.inMempool.length} in mempool, ` +
                 `${health.pending.length} pending)`,
               );
@@ -855,6 +855,7 @@ const TRANSIENT_WALLET_ERRORS = [
   'DataLayerWallet not available',
   'DataLayer Wallet already exists',
   'No spendable coins',
+  'UNIQUE constraint failed',
 ];
 
 const isTransientWalletError = (error) =>

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -567,13 +567,9 @@ const waitForSpendableCoins = async (
   }
 
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
-  logger.error(
-    `[wallet]: Timeout waiting for spendable coins after ${elapsed}s`,
-  );
-  return {
-    success: false,
-    error: `Timeout waiting for ${requiredCoins} coins of ${minMojosPerCoin}+ mojos after ${elapsed}s`,
-  };
+  const msg = `Timeout waiting for ${requiredCoins} coins of ${minMojosPerCoin}+ mojos after ${elapsed}s`;
+  logger.error(`[wallet]: ${msg}`);
+  throw new Error(msg);
 };
 
 // Mempool inclusion status codes from Chia wallet's TransactionRecord.sent_to

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -187,56 +187,93 @@ const waitForAllTransactionsToConfirm = async (startTime = null, maxWaitMs = 180
     return true;
   }
 
-  // Initialize start time on first call
   if (startTime === null) {
     startTime = Date.now();
   }
 
-  // Check for timeout (default 30 minutes)
   const elapsed = Date.now() - startTime;
   if (elapsed > maxWaitMs) {
-    logger.warn(`waitForAllTransactionsToConfirm timed out after ${Math.round(elapsed / 1000)}s - proceeding anyway`);
+    // On timeout, log diagnostic details instead of a generic message
+    try {
+      const dlWalletId = await getDLWalletId();
+      const walletIds = dlWalletId ? ['1', dlWalletId] : ['1'];
+      for (const wid of walletIds) {
+        const health = await getTransactionHealth(wid);
+        const total = health.rejected.length + health.inMempool.length + health.pending.length;
+        if (total > 0) {
+          logger.warn(
+            `waitForAllTransactionsToConfirm timed out after ${Math.round(elapsed / 1000)}s. ` +
+            `Wallet ${wid}: ${health.rejected.length} rejected, ${health.inMempool.length} in mempool, ` +
+            `${health.pending.length} pending. Oldest age: ${formatDuration(health.oldestUnconfirmedAge)}. ` +
+            `Proceeding anyway.`,
+          );
+        }
+      }
+    } catch (diagError) {
+      logger.warn(
+        `waitForAllTransactionsToConfirm timed out after ${Math.round(elapsed / 1000)}s ` +
+        `(diagnostic check also failed: ${diagError.message}) - proceeding anyway`,
+      );
+    }
     return true;
   }
 
   try {
-    const unconfirmedTransactions = await hasUnconfirmedTransactions();
-    await new Promise((resolve) => setTimeout(() => resolve(), 15000));
+    const anyUnconfirmed = await hasAnyUnconfirmedTransactions();
+    await new Promise((resolve) => setTimeout(resolve, 15000));
 
-    if (unconfirmedTransactions) {
+    if (anyUnconfirmed) {
+      // After 5 minutes of waiting, start logging health details
+      if (elapsed > 300000 && elapsed % 60000 < 15000) {
+        try {
+          const dlWalletId = await getDLWalletId();
+          const walletIds = dlWalletId ? ['1', dlWalletId] : ['1'];
+          for (const wid of walletIds) {
+            const health = await getTransactionHealth(wid);
+            const total = health.rejected.length + health.inMempool.length + health.pending.length;
+            if (total > 0) {
+              logger.info(
+                `waitForAllTransactionsToConfirm: wallet ${wid} still has ` +
+                `${total} unconfirmed tx(s) after ${Math.round(elapsed / 1000)}s ` +
+                `(${health.rejected.length} rejected, ${health.inMempool.length} in mempool, ` +
+                `${health.pending.length} pending)`,
+              );
+            }
+          }
+        } catch {
+          // best-effort diagnostics
+        }
+      }
+
       return waitForAllTransactionsToConfirm(startTime, maxWaitMs);
     }
 
     return true;
   } catch (error) {
-    // If we can't check transactions (wallet unavailable), wait and retry
     logger.warn(`Error checking transactions: ${error.message} - retrying...`);
-    await new Promise((resolve) => setTimeout(() => resolve(), 15000));
+    await new Promise((resolve) => setTimeout(resolve, 15000));
     return waitForAllTransactionsToConfirm(startTime, maxWaitMs);
   }
 };
 
-const hasUnconfirmedTransactions = async () => {
+const hasUnconfirmedTransactions = async (walletId = '1') => {
   const { cert, key, timeout } = getBaseOptions();
 
   const response = await superagent
     .post(`${rpcUrl}/get_transactions`)
     .send({
-      wallet_id: '1',
+      wallet_id: walletId,
       sort_key: 'RELEVANCE',
     })
     .key(key)
     .cert(cert)
     .timeout(timeout);
 
-  const data = JSON.parse(response.text);
+  const data = response.body || JSON.parse(response.text);
 
   if (data.success) {
-    console.log(
-      `Pending confirmations: ${
-        data.transactions.filter((transaction) => !transaction.confirmed).length
-      }`,
-    );
+    const pendingCount = data.transactions.filter((transaction) => !transaction.confirmed).length;
+    logger.debug(`Pending confirmations for wallet ${walletId}: ${pendingCount}`);
 
     return data.transactions.some((transaction) => !transaction.confirmed);
   }
@@ -539,6 +576,282 @@ const waitForSpendableCoins = async (
   };
 };
 
+// Mempool inclusion status codes from Chia wallet's TransactionRecord.sent_to
+const MempoolInclusionStatus = {
+  SUCCESS: 1,
+  PENDING: 2,
+  FAILED: 3,
+};
+
+// Cached DL wallet ID (discovered once, reused thereafter)
+let cachedDLWalletId = null;
+
+/**
+ * Discover the DataLayer wallet's wallet_id dynamically via get_wallets RPC.
+ * Caches the result so subsequent calls avoid the RPC round-trip.
+ * @returns {Promise<string|null>} The DL wallet's wallet_id as a string, or null if not found
+ */
+const getDLWalletId = async () => {
+  if (cachedDLWalletId !== null) {
+    return cachedDLWalletId;
+  }
+
+  if (USE_SIMULATOR) {
+    cachedDLWalletId = '2';
+    return cachedDLWalletId;
+  }
+
+  try {
+    const { cert, key, timeout } = getBaseOptions();
+
+    const response = await superagent
+      .post(`${rpcUrl}/get_wallets`)
+      .send({})
+      .key(key)
+      .cert(cert)
+      .timeout(timeout);
+
+    const data = response.body || JSON.parse(response.text);
+
+    if (data.success && Array.isArray(data.wallets)) {
+      // WalletType.DATA_LAYER = 14 in chia-blockchain
+      const dlWallet = data.wallets.find((w) => w.type === 14);
+      if (dlWallet) {
+        cachedDLWalletId = String(dlWallet.id);
+        logger.info(`Discovered DataLayer wallet_id: ${cachedDLWalletId}`);
+        return cachedDLWalletId;
+      }
+    }
+
+    logger.warn('DataLayer wallet not found via get_wallets RPC');
+    return null;
+  } catch (error) {
+    logger.error(`Error discovering DL wallet_id: ${error.message}`);
+    return null;
+  }
+};
+
+/**
+ * Classify a single transaction's status based on its sent_to array.
+ * sent_to is an array of [peer_id, status_code, error_message] tuples.
+ * @param {Array} sentTo - The sent_to array from a TransactionRecord
+ * @returns {'rejected'|'in_mempool'|'pending'}
+ */
+const classifyTransaction = (sentTo) => {
+  if (!sentTo || sentTo.length === 0) {
+    return 'pending';
+  }
+
+  const hasSuccess = sentTo.some(([, status]) => status === MempoolInclusionStatus.SUCCESS);
+  const hasFailed = sentTo.some(([, status]) => status === MempoolInclusionStatus.FAILED);
+
+  if (hasSuccess) {
+    return 'in_mempool';
+  }
+
+  // All peers failed, none succeeded
+  if (hasFailed && !hasSuccess) {
+    const allFailed = sentTo.every(([, status]) => status === MempoolInclusionStatus.FAILED);
+    if (allFailed) {
+      return 'rejected';
+    }
+  }
+
+  return 'pending';
+};
+
+/**
+ * Format rejection reasons from sent_to for logging.
+ * @param {Array} sentTo - The sent_to array from a TransactionRecord
+ * @returns {string} Human-readable rejection summary
+ */
+const formatRejectionReasons = (sentTo) => {
+  if (!sentTo || sentTo.length === 0) return 'no send attempts';
+  const failedEntries = sentTo.filter(([, status]) => status === MempoolInclusionStatus.FAILED);
+  if (failedEntries.length === 0) return 'no failures';
+  const reasons = failedEntries.map(([peerId, , errorMsg]) =>
+    `peer ${peerId?.substring(0, 8)}...: ${errorMsg || 'unknown error'}`
+  );
+  return `FAILED on ${failedEntries.length}/${sentTo.length} peers: ${reasons.join('; ')}`;
+};
+
+/**
+ * Get the health status of unconfirmed transactions for a given wallet.
+ * Classifies each unconfirmed tx as rejected, in_mempool, or pending.
+ * @param {string} walletId - The wallet_id to check
+ * @returns {Promise<{rejected: Array, inMempool: Array, pending: Array, stuckCount: number, oldestUnconfirmedAge: number|null}>}
+ */
+const getTransactionHealth = async (walletId) => {
+  const { cert, key, timeout } = getBaseOptions();
+
+  const response = await superagent
+    .post(`${rpcUrl}/get_transactions`)
+    .send({
+      wallet_id: walletId,
+      confirmed: false,
+      sort_key: 'RELEVANCE',
+    })
+    .key(key)
+    .cert(cert)
+    .timeout(timeout);
+
+  const data = response.body || JSON.parse(response.text);
+
+  if (!data.success) {
+    throw new Error(`get_transactions failed for wallet ${walletId}: ${data.error || 'unknown error'}`);
+  }
+
+  const unconfirmed = (data.transactions || []).filter((tx) => !tx.confirmed);
+  const now = Date.now() / 1000; // seconds
+
+  const result = {
+    rejected: [],
+    inMempool: [],
+    pending: [],
+    stuckCount: 0,
+    oldestUnconfirmedAge: null,
+  };
+
+  for (const tx of unconfirmed) {
+    const classification = classifyTransaction(tx.sent_to);
+    const txAge = tx.created_at_time ? now - tx.created_at_time : null;
+    const txRecord = {
+      name: tx.name,
+      type: tx.type,
+      amount: tx.amount,
+      createdAt: tx.created_at_time,
+      age: txAge,
+      sentTo: tx.sent_to,
+      rejectionReason: classification === 'rejected' ? formatRejectionReasons(tx.sent_to) : null,
+    };
+
+    result[classification === 'in_mempool' ? 'inMempool' : classification].push(txRecord);
+
+    if (txAge !== null) {
+      if (result.oldestUnconfirmedAge === null || txAge > result.oldestUnconfirmedAge) {
+        result.oldestUnconfirmedAge = txAge;
+      }
+    }
+  }
+
+  result.stuckCount = result.pending.filter((tx) => tx.age && tx.age > 600).length +
+    result.inMempool.filter((tx) => tx.age && tx.age > 600).length;
+
+  return result;
+};
+
+/**
+ * Check for unconfirmed transactions across both the standard wallet (id 1)
+ * and the DataLayer wallet.
+ * @returns {Promise<boolean>} true if either wallet has unconfirmed transactions
+ */
+const hasAnyUnconfirmedTransactions = async () => {
+  const standardHasUnconfirmed = await hasUnconfirmedTransactions('1');
+
+  const dlWalletId = await getDLWalletId();
+  if (dlWalletId && dlWalletId !== '1') {
+    const dlHasUnconfirmed = await hasUnconfirmedTransactions(dlWalletId);
+    return standardHasUnconfirmed || dlHasUnconfirmed;
+  }
+
+  return standardHasUnconfirmed;
+};
+
+/**
+ * Format a duration in seconds as a human-readable string (e.g., "12m 34s").
+ * @param {number} seconds
+ * @returns {string}
+ */
+const formatDuration = (seconds) => {
+  if (seconds == null) return 'unknown';
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+};
+
+/**
+ * Clear rejected transactions for a wallet, with mandatory audit logging.
+ *
+ * SAFETY: The Chia wallet RPC delete_unconfirmed_transactions deletes ALL
+ * unconfirmed txs for a wallet_id (no per-tx filter). Therefore this function
+ * REFUSES to clear unless ALL unconfirmed txs for the wallet are in the
+ * 'rejected' category.
+ *
+ * @param {string} walletId - The wallet_id to clear
+ * @param {string[]} txIds - The tx_ids we expect to clear (for audit logging)
+ * @param {string} context - Caller-provided context explaining why the clear is happening
+ * @returns {Promise<{cleared: boolean, reason: string}>}
+ */
+const clearRejectedTransactions = async (walletId, txIds, context) => {
+  const health = await getTransactionHealth(walletId);
+
+  const totalUnconfirmed = health.rejected.length + health.inMempool.length + health.pending.length;
+
+  // Safety check: refuse if ANY unconfirmed tx is not rejected
+  if (health.inMempool.length > 0 || health.pending.length > 0) {
+    const reason =
+      `Refusing to clear: wallet ${walletId} has ${health.inMempool.length} in-mempool ` +
+      `and ${health.pending.length} pending tx(s) alongside ${health.rejected.length} rejected. ` +
+      `delete_unconfirmed_transactions is wallet-wide and would destroy non-rejected txs.`;
+    logger.warn(reason, { walletId, context, txIds });
+    return { cleared: false, reason };
+  }
+
+  if (health.rejected.length === 0) {
+    return { cleared: false, reason: 'No rejected transactions to clear' };
+  }
+
+  // Verify the txIds we care about are actually in the rejected set
+  const rejectedNames = new Set(health.rejected.map((tx) => tx.name));
+  const matchedTxIds = txIds.filter((id) => rejectedNames.has(id));
+  const unmatchedTxIds = txIds.filter((id) => !rejectedNames.has(id));
+
+  if (unmatchedTxIds.length > 0) {
+    logger.warn(
+      `Some requested tx_ids not found in rejected set: ${JSON.stringify(unmatchedTxIds)}`,
+      { walletId, context },
+    );
+  }
+
+  // All unconfirmed txs are rejected -- safe to clear
+  const { cert, key, timeout } = getBaseOptions();
+
+  try {
+    await superagent
+      .post(`${rpcUrl}/delete_unconfirmed_transactions`)
+      .send({ wallet_id: walletId })
+      .key(key)
+      .cert(cert)
+      .timeout(timeout);
+  } catch (error) {
+    const reason = `RPC delete_unconfirmed_transactions failed: ${error.message}`;
+    logger.error(reason, { walletId, context });
+    return { cleared: false, reason };
+  }
+
+  // Mandatory audit log entry
+  const clearedTxDetails = health.rejected.map((tx) => ({
+    txId: tx.name,
+    age: formatDuration(tx.age),
+    reason: tx.rejectionReason,
+  }));
+
+  logger.warn(
+    `Cleared rejected transaction(s) for wallet ${walletId}`,
+    {
+      action: 'clear_rejected_transactions',
+      walletId,
+      txCount: health.rejected.length,
+      txIds: health.rejected.map((tx) => tx.name),
+      matchedRequestedTxIds: matchedTxIds,
+      details: clearedTxDetails,
+      context,
+    },
+  );
+
+  return { cleared: true, reason: `Cleared ${health.rejected.length} rejected transaction(s)` };
+};
+
 const TRANSIENT_WALLET_ERRORS = [
   'Wallet needs to be fully synced',
   'DataLayerWallet not available',
@@ -551,6 +864,7 @@ const isTransientWalletError = (error) =>
 
 export default {
   hasUnconfirmedTransactions,
+  hasAnyUnconfirmedTransactions,
   walletIsSynced,
   walletIsAvailable,
   getPublicAddress,
@@ -564,4 +878,8 @@ export default {
   getCoinRecords,
   splitCoins,
   isTransientWalletError,
+  getTransactionHealth,
+  getDLWalletId,
+  clearRejectedTransactions,
+  formatDuration,
 };

--- a/src/datalayer/writeService.js
+++ b/src/datalayer/writeService.js
@@ -18,19 +18,25 @@ const createDataLayerStore = async () => {
   await wallet.waitForAllTransactionsToConfirm();
 
   let storeId;
+  let txIds = [];
   if (USE_SIMULATOR) {
     storeId = await simulator.createDataLayerStore();
   } else {
     const result = await dataLayer.createDataLayerStore();
     storeId = result.storeId;
-    const txIds = result.txIds || [];
+    txIds = result.txIds || [];
 
     logger.info(
       `Created storeId: ${storeId}` +
       (txIds.length > 0 ? ` (tx_ids: ${txIds.join(', ')})` : '') +
       `, waiting for this to be confirmed on the blockchain.`,
     );
-    await waitForNewStoreToBeConfirmed(storeId, txIds);
+    try {
+      await waitForNewStoreToBeConfirmed(storeId, txIds);
+    } catch (confirmError) {
+      confirmError.txIds = txIds;
+      throw confirmError;
+    }
     await wallet.waitForAllTransactionsToConfirm();
 
     const mirrorUrl = await getMirrorUrl();
@@ -39,7 +45,7 @@ const createDataLayerStore = async () => {
     }
   }
 
-  return storeId;
+  return { storeId, txIds };
 };
 
 /**
@@ -53,16 +59,21 @@ const createDataLayerStore = async () => {
  */
 const createDataLayerStoreWithRetry = async (maxRetries = 3) => {
   if (USE_SIMULATOR) {
-    return createDataLayerStore();
+    const { storeId } = await createDataLayerStore();
+    return storeId;
   }
 
   const attemptedTxIds = [];
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const storeId = await createDataLayerStore();
+      const { storeId, txIds } = await createDataLayerStore();
+      attemptedTxIds.push(...txIds);
       return storeId;
     } catch (error) {
+      if (error.txIds) {
+        attemptedTxIds.push(...error.txIds);
+      }
       const isRejection = error.message?.includes('rejected');
 
       if (!isRejection || attempt >= maxRetries) {

--- a/src/datalayer/writeService.js
+++ b/src/datalayer/writeService.js
@@ -21,12 +21,16 @@ const createDataLayerStore = async () => {
   if (USE_SIMULATOR) {
     storeId = await simulator.createDataLayerStore();
   } else {
-    storeId = await dataLayer.createDataLayerStore();
+    const result = await dataLayer.createDataLayerStore();
+    storeId = result.storeId;
+    const txIds = result.txIds || [];
 
     logger.info(
-      `Created storeId: ${storeId}, waiting for this to be confirmed on the blockchain.`,
+      `Created storeId: ${storeId}` +
+      (txIds.length > 0 ? ` (tx_ids: ${txIds.join(', ')})` : '') +
+      `, waiting for this to be confirmed on the blockchain.`,
     );
-    await waitForNewStoreToBeConfirmed(storeId);
+    await waitForNewStoreToBeConfirmed(storeId, txIds);
     await wallet.waitForAllTransactionsToConfirm();
 
     const mirrorUrl = await getMirrorUrl();
@@ -38,12 +42,79 @@ const createDataLayerStore = async () => {
   return storeId;
 };
 
+/**
+ * Create a DataLayer store with rejection-aware retry.
+ * On rejected spend bundles, clears the rejected txs, clears pending roots,
+ * waits for wallet stability, and retries.
+ * Returns only the storeId (string) to callers -- tx correlation is handled internally.
+ *
+ * @param {number} maxRetries - Maximum number of retry attempts (default 3)
+ * @returns {Promise<string>} The confirmed storeId
+ */
+const createDataLayerStoreWithRetry = async (maxRetries = 3) => {
+  if (USE_SIMULATOR) {
+    return createDataLayerStore();
+  }
+
+  const attemptedTxIds = [];
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const storeId = await createDataLayerStore();
+      return storeId;
+    } catch (error) {
+      const isRejection = error.message?.includes('rejected');
+
+      if (!isRejection || attempt >= maxRetries) {
+        if (attempt >= maxRetries) {
+          logger.error(
+            `createDataLayerStoreWithRetry: all ${maxRetries} attempts failed`,
+            {
+              attemptedTxIds,
+              lastError: error.message,
+            },
+          );
+        }
+        throw error;
+      }
+
+      // Rejection detected -- attempt recovery
+      logger.warn(
+        `createDataLayerStoreWithRetry: attempt ${attempt} of ${maxRetries} ` +
+        `failed with rejection, attempting recovery`,
+        { error: error.message },
+      );
+
+      const dlWalletId = await wallet.getDLWalletId();
+      if (dlWalletId) {
+        const context =
+          `createDataLayerStoreWithRetry attempt ${attempt} of ${maxRetries}`;
+
+        const clearResult = await wallet.clearRejectedTransactions(
+          dlWalletId,
+          attemptedTxIds,
+          context,
+        );
+
+        if (!clearResult.cleared) {
+          logger.warn(
+            `Could not auto-clear rejected txs: ${clearResult.reason}. ` +
+            `Waiting for wallet to stabilize before retry.`,
+          );
+        }
+      }
+
+      // Wait for wallet to stabilize before retrying
+      await wallet.waitForAllTransactionsToConfirm();
+    }
+  }
+};
+
 const addMirror = async (storeId, url, force = false) => {
   return dataLayer.addMirror(storeId, url, force);
 };
 
-const waitForNewStoreToBeConfirmed = async (storeId, retry = 0) => {
-  // In simulator mode, stores are immediately confirmed
+const waitForNewStoreToBeConfirmed = async (storeId, txIds = [], retry = 0) => {
   if (USE_SIMULATOR) {
     logger.info(`StoreId: ${storeId} confirmed (simulator mode)`);
     return;
@@ -57,16 +128,55 @@ const waitForNewStoreToBeConfirmed = async (storeId, retry = 0) => {
 
   const { confirmed } = await dataLayer.getRoot(storeId);
 
-  if (!confirmed) {
-    logger.info(`Still waiting for ${storeId} to confirm`);
-    await new Promise((resolve) => {
-      setTimeout(() => {
-        resolve();
-      }, 30000);
-    });
-    return waitForNewStoreToBeConfirmed(storeId, retry + 1);
+  if (confirmed) {
+    logger.info(`StoreId: ${storeId} has been confirmed. Congrats!`);
+    return;
   }
-  logger.info(`StoreId: ${storeId} has been confirmed. Congrats!`);
+
+  // Check transaction health for early rejection detection
+  if (txIds.length > 0) {
+    try {
+      const dlWalletId = await wallet.getDLWalletId();
+      if (dlWalletId) {
+        const health = await wallet.getTransactionHealth(dlWalletId);
+        const rejectedNames = new Set(health.rejected.map((tx) => tx.name));
+        const ourRejected = txIds.filter((id) => rejectedNames.has(id));
+
+        if (ourRejected.length > 0) {
+          const rejectedTx = health.rejected.find((tx) => ourRejected.includes(tx.name));
+          const reason = rejectedTx?.rejectionReason || 'unknown rejection reason';
+          throw new Error(
+            `Store creation for ${storeId} was rejected by the network: ${reason}. ` +
+            `Rejected tx_ids: ${ourRejected.join(', ')}`,
+          );
+        }
+
+        // Warn if pending too long (> 10 minutes)
+        if (retry > 0 && retry % 20 === 0) {
+          const ourPending = [...health.inMempool, ...health.pending]
+            .filter((tx) => txIds.includes(tx.name));
+          if (ourPending.length > 0) {
+            const ages = ourPending.map((tx) => wallet.formatDuration(tx.age));
+            logger.warn(
+              `Store ${storeId} creation tx(s) still unconfirmed after ${retry * 30}s. ` +
+              `Tx ages: ${ages.join(', ')}. Status: ${ourPending.length} in mempool/pending.`,
+            );
+          }
+        }
+      }
+    } catch (healthError) {
+      // If the error is a rejection we threw above, re-throw it
+      if (healthError.message?.includes('rejected by the network')) {
+        throw healthError;
+      }
+      // Otherwise log and continue polling -- health check is best-effort
+      logger.debug(`Transaction health check failed (non-fatal): ${healthError.message}`);
+    }
+  }
+
+  logger.info(`Still waiting for ${storeId} to confirm (attempt ${retry + 1})`);
+  await new Promise((resolve) => setTimeout(resolve, 30000));
+  return waitForNewStoreToBeConfirmed(storeId, txIds, retry + 1);
 };
 
 const syncDataLayer = async (storeId, data, failedCallback) => {
@@ -163,12 +273,11 @@ export const pushChangesWhenStoreIsAvailable = async (
       );
     }
 
-    const hasUnconfirmedTransactions =
-      await wallet.hasUnconfirmedTransactions();
+    const hasUnconfirmed = await wallet.hasAnyUnconfirmedTransactions();
 
     const { confirmed } = await dataLayer.getRoot(storeId);
 
-    if (!hasUnconfirmedTransactions && confirmed) {
+    if (!hasUnconfirmed && confirmed) {
       logger.info(`pushing to datalayer ${storeId}`);
 
       const success = await dataLayer.pushChangeListToDataLayer(
@@ -191,6 +300,53 @@ export const pushChangesWhenStoreIsAvailable = async (
         );
       }
     } else {
+      // After 5 consecutive blocked retries, diagnose transaction health
+      if (retryAttempts > 0 && retryAttempts % 5 === 0) {
+        try {
+          const dlWalletId = await wallet.getDLWalletId();
+          const walletIds = dlWalletId ? ['1', dlWalletId] : ['1'];
+          for (const wid of walletIds) {
+            const health = await wallet.getTransactionHealth(wid);
+
+            if (health.rejected.length > 0) {
+              const txIds = health.rejected.map((tx) => tx.name);
+              const context =
+                `pushChangesWhenStoreIsAvailable for store ${storeId}, ` +
+                `retry ${retryAttempts}: detected ${health.rejected.length} rejected tx(s) in wallet ${wid}`;
+
+              const clearResult = await wallet.clearRejectedTransactions(wid, txIds, context);
+              if (clearResult.cleared) {
+                logger.info(
+                  `Auto-cleared rejected txs in wallet ${wid} during push to ${storeId}. ` +
+                  `Continuing without counting as a retry attempt.`,
+                );
+                // Re-enter without incrementing retry count
+                return pushChangesWhenStoreIsAvailable(storeId, changeList, failedCallback, retryAttempts);
+              }
+            }
+
+            if (health.stuckCount > 0 || (health.oldestUnconfirmedAge && health.oldestUnconfirmedAge > 900)) {
+              logger.warn(
+                `Push to store ${storeId} blocked by stuck transactions in wallet ${wid}: ` +
+                `${health.inMempool.length} in mempool, ${health.pending.length} pending, ` +
+                `oldest age: ${wallet.formatDuration(health.oldestUnconfirmedAge)}`,
+              );
+            }
+          }
+        } catch (healthError) {
+          logger.debug(`Transaction health check during push retry failed (non-fatal): ${healthError.message}`);
+        }
+      }
+
+      // Final retry exhaustion with diagnostic message
+      if (retryAttempts >= 60) {
+        const diagnosticMsg =
+          `Changes could not be pushed to store ${storeId} after ${retryAttempts} retries. ` +
+          `Your wallet may have unconfirmed transactions that are stuck. ` +
+          `Run 'chia wallet delete_unconfirmed_transactions -i <wallet_id>' to clear stuck transactions, then retry.`;
+        logger.error(diagnosticMsg);
+      }
+
       retryPushToStore(
         storeId,
         changeList,
@@ -239,6 +395,7 @@ const getValue = async (storeId, key) => {
 export default {
   addMirror,
   createDataLayerStore,
+  createDataLayerStoreWithRetry,
   dataLayerAvailable,
   pushDataLayerChangeList,
   syncDataLayer,

--- a/src/datalayer/writeService.js
+++ b/src/datalayer/writeService.js
@@ -329,10 +329,9 @@ export const pushChangesWhenStoreIsAvailable = async (
               if (clearResult.cleared) {
                 logger.info(
                   `Auto-cleared rejected txs in wallet ${wid} during push to ${storeId}. ` +
-                  `Continuing without counting as a retry attempt.`,
+                  `Resuming with incremented retry to prevent unbounded recursion.`,
                 );
-                // Re-enter without incrementing retry count
-                return pushChangesWhenStoreIsAvailable(storeId, changeList, failedCallback, retryAttempts);
+                return pushChangesWhenStoreIsAvailable(storeId, changeList, failedCallback, retryAttempts + 1);
               }
             }
 
@@ -405,7 +404,7 @@ const getValue = async (storeId, key) => {
 
 export default {
   addMirror,
-  createDataLayerStore,
+  createDataLayerStore: async () => (await createDataLayerStore()).storeId,
   createDataLayerStoreWithRetry,
   dataLayerAvailable,
   pushDataLayerChangeList,

--- a/src/datalayer/writeService.js
+++ b/src/datalayer/writeService.js
@@ -58,6 +58,10 @@ const createDataLayerStore = async () => {
  * @returns {Promise<string>} The confirmed storeId
  */
 const createDataLayerStoreWithRetry = async (maxRetries = 3) => {
+  if (maxRetries < 1) {
+    throw new Error('createDataLayerStoreWithRetry requires maxRetries >= 1');
+  }
+
   if (USE_SIMULATOR) {
     const { storeId } = await createDataLayerStore();
     return storeId;

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -33,6 +33,16 @@ const headerKeys = Object.freeze({
   SYNC_REMAINING: 'x-sync-remaining',
 });
 
+const HEALTH_ENDPOINTS = new Set([
+  '/health',
+  '/v1/health',
+  '/v2/health',
+  '/v1/health/wallet',
+  '/v2/health/wallet',
+]);
+
+const isHealthEndpoint = (path) => HEALTH_ENDPOINTS.has(path);
+
 const app = express();
 
 app.use(
@@ -49,8 +59,7 @@ const generalLimiter = rateLimit({
   standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   skip: (req) => {
-    // Skip rate limiting for health check endpoints
-    return req.path === '/health' || req.path === '/v1/health' || req.path === '/v2/health';
+    return isHealthEndpoint(req.path);
   },
   handler: (req, res) => {
     res.status(429).json({
@@ -71,8 +80,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 // Startup state middleware - blocks requests until CADT is fully ready
 // This runs early in the chain but after body parsing
 app.use(async function (req, res, next) {
-  // Always allow health endpoints
-  if (req.path === '/health' || req.path === '/v1/health' || req.path === '/v2/health') {
+  if (isHealthEndpoint(req.path)) {
     return next();
   }
 
@@ -139,8 +147,7 @@ app.use((req, res, next) => {
 
 // Common assertions on every endpoint
 app.use(async function (req, res, next) {
-  // Skip assertions for health endpoints
-  if (req.path === '/health' || req.path === '/v1/health' || req.path === '/v2/health') {
+  if (isHealthEndpoint(req.path)) {
     return next();
   }
 

--- a/src/models/file-store/file-store.model.js
+++ b/src/models/file-store/file-store.model.js
@@ -11,6 +11,7 @@ import { Organization } from '../';
 
 import datalayer from '../../datalayer';
 import { encodeHex } from '../../utils/datalayer-utils';
+import { logger } from '../../config/logger.js';
 
 import ModelTypes from './file-store.modeltypes.cjs';
 
@@ -67,12 +68,16 @@ class FileStore extends Model {
     const fileStoreId = myOrganization.fileStoreId;
 
     if (myOrganization && !fileStoreId) {
-      datalayer.createDataLayerStore().then((fileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId });
+      datalayer.waitForSpendableCoins(1).then(() =>
+        datalayer.createDataLayerStoreWithRetry()
+      ).then((newFileStoreId) => {
+        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId: newFileStoreId });
         Organization.update(
-          { fileStoreId },
+          { fileStoreId: newFileStoreId },
           { where: { orgUid: myOrganization.orgUid } },
         );
+      }).catch((error) => {
+        logger.error(`Failed to create file store: ${error.message}`);
       });
 
       throw new Error('New File store being created, please try again later.');
@@ -107,12 +112,16 @@ class FileStore extends Model {
     const fileStoreId = myOrganization?.fileStoreId;
 
     if (myOrganization && !fileStoreId) {
-      datalayer.createDataLayerStore().then((fileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId });
+      datalayer.waitForSpendableCoins(1).then(() =>
+        datalayer.createDataLayerStoreWithRetry()
+      ).then((newFileStoreId) => {
+        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId: newFileStoreId });
         Organization.update(
-          { fileStoreId },
+          { fileStoreId: newFileStoreId },
           { where: { orgUid: myOrganization.orgUid } },
         );
+      }).catch((error) => {
+        logger.error(`Failed to create file store: ${error.message}`);
       });
       throw new Error('New File store being created, please try again later.');
     }
@@ -152,12 +161,16 @@ class FileStore extends Model {
     const fileStoreId = myOrganization.fileStoreId;
 
     if (!fileStoreId) {
-      datalayer.createDataLayerStore().then((fileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId });
+      datalayer.waitForSpendableCoins(1).then(() =>
+        datalayer.createDataLayerStoreWithRetry()
+      ).then((newFileStoreId) => {
+        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId: newFileStoreId });
         Organization.update(
-          { fileStoreId },
+          { fileStoreId: newFileStoreId },
           { where: { orgUid: myOrganization.orgUid } },
         );
+      }).catch((error) => {
+        logger.error(`Failed to create file store: ${error.message}`);
       });
       throw new Error('New File store being created, please try again later.');
     }
@@ -180,7 +193,8 @@ class FileStore extends Model {
     let fileStoreId = myOrganization.fileStoreId;
 
     if (!fileStoreId) {
-      fileStoreId = await datalayer.createDataLayerStore();
+      await datalayer.waitForSpendableCoins(1);
+      fileStoreId = await datalayer.createDataLayerStoreWithRetry();
       datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId });
       throw new Error('New File store being created, please try again later.');
     }

--- a/src/models/governance/governance.model.js
+++ b/src/models/governance/governance.model.js
@@ -16,6 +16,20 @@ const { USE_SIMULATOR, USE_DEVELOPMENT_MODE } = getConfig().APP;
 import ModelTypes from './governance.modeltypes.cjs';
 
 class Governance extends Model {
+  static async _setCreationStatus(status, error = null) {
+    try {
+      await Meta.upsert({ metaKey: 'governanceCreationStatus', metaValue: status });
+      await Meta.upsert({ metaKey: 'governanceCreationStartedAt', metaValue: Meta._creationStartedAt || new Date().toISOString() });
+      if (error) {
+        await Meta.upsert({ metaKey: 'governanceCreationError', metaValue: String(error) });
+      } else {
+        await Meta.destroy({ where: { metaKey: 'governanceCreationError' } });
+      }
+    } catch (e) {
+      logger.error(`Failed to update governance creation status: ${e.message}`);
+    }
+  }
+
   static async createGoveranceBody() {
     if (GOVERNANCE_BODY_ID && GOVERNANCE_BODY_ID !== '') {
       throw new Error(
@@ -23,19 +37,22 @@ class Governance extends Model {
       );
     }
 
+    Meta._creationStartedAt = new Date().toISOString();
+    await Governance._setCreationStatus('creating_stores');
+
     const dataModelVersion = 'v1';
     await datalayer.waitForSpendableCoins(2);
-    // Create stores sequentially to avoid "DataLayer Wallet already exists"
-    // race condition when both calls try to initialize the wallet in parallel
-    const governanceBodyId = await datalayer.createDataLayerStore();
-    const governanceVersionId = await datalayer.createDataLayerStore();
+    const governanceBodyId = await datalayer.createDataLayerStoreWithRetry();
+    const governanceVersionId = await datalayer.createDataLayerStoreWithRetry();
+
+    await Governance._setCreationStatus('waiting_for_confirmation');
 
     const revertOrganizationIfFailed = async () => {
       logger.warn('Reverting Failed Governance Body Creation');
       await Meta.destroy({ where: { metaKey: 'governanceBodyId' } });
+      await Governance._setCreationStatus('failed', 'Governance body creation reverted');
     };
 
-    // sync the governance store
     await datalayer.syncDataLayer(
       governanceBodyId,
       {
@@ -43,6 +60,8 @@ class Governance extends Model {
       },
       revertOrganizationIfFailed,
     );
+
+    await Governance._setCreationStatus('syncing_data');
 
     const onConfirm = async () => {
       await Meta.upsert({
@@ -53,6 +72,7 @@ class Governance extends Model {
         metaKey: 'mainGoveranceBodyId',
         metaValue: governanceBodyId,
       });
+      await Governance._setCreationStatus('completed');
       logger.info('Governance body confirmed, you are ready to go');
     };
 

--- a/src/models/governance/governance.model.js
+++ b/src/models/governance/governance.model.js
@@ -19,7 +19,7 @@ class Governance extends Model {
   static async _setCreationStatus(status, error = null) {
     try {
       await Meta.upsert({ metaKey: 'governanceCreationStatus', metaValue: status });
-      await Meta.upsert({ metaKey: 'governanceCreationStartedAt', metaValue: Meta._creationStartedAt || new Date().toISOString() });
+      await Meta.upsert({ metaKey: 'governanceCreationStartedAt', metaValue: Governance._creationStartedAt || new Date().toISOString() });
       if (error) {
         await Meta.upsert({ metaKey: 'governanceCreationError', metaValue: String(error) });
       } else {
@@ -37,7 +37,7 @@ class Governance extends Model {
       );
     }
 
-    Meta._creationStartedAt = new Date().toISOString();
+    Governance._creationStartedAt = new Date().toISOString();
     await Governance._setCreationStatus('creating_stores');
 
     const dataModelVersion = 'v1';

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -474,8 +474,7 @@ class Organization extends Model {
           // Only orgUid is fixed in V1 simulator mode (original behavior)
           storeId = 'f1c54511-865e-4611-976c-7c3c1f704662';
         } else {
-          // Other stores get random UUIDs (original behavior - called createDataLayerStore)
-          storeId = await datalayer.createDataLayerStore();
+          storeId = await datalayer.createDataLayerStoreWithRetry();
         }
         state = markStoreCreated(state, storeType, storeId);
         state = markStoreConfirmed(state, storeType);
@@ -492,7 +491,7 @@ class Organization extends Model {
       for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
           logState(state, `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
-          const storeId = await datalayer.createDataLayerStore();
+          const storeId = await datalayer.createDataLayerStoreWithRetry();
           logState(state, `Created ${storeType} store: ${storeId}`);
           return { storeType, storeId, success: true };
         } catch (error) {
@@ -607,6 +606,29 @@ class Organization extends Model {
   }
 
   /**
+   * Lightweight health check for the direct-push path: detect rejected txs in the
+   * DL wallet and auto-clear them before scheduling a background retry.
+   * Non-blocking and best-effort -- failures are logged but don't propagate.
+   * @private
+   */
+  static async _checkAndClearRejectedTxs(storeType, storeId) {
+    try {
+      const dlWalletId = await wallet.getDLWalletId();
+      if (!dlWalletId) return;
+
+      const health = await wallet.getTransactionHealth(dlWalletId);
+      if (health.rejected.length > 0) {
+        const txIds = health.rejected.map((tx) => tx.name);
+        const context =
+          `_pushDataInParallel failed for ${storeType} store ${storeId}, scheduling retry`;
+        await wallet.clearRejectedTransactions(dlWalletId, txIds, context);
+      }
+    } catch (error) {
+      logger.debug(`_checkAndClearRejectedTxs non-fatal error: ${error.message}`);
+    }
+  }
+
+  /**
    * Push data to stores sequentially with a short delay between each.
    *
    * Calls pushChangeListToDataLayer directly, bypassing the hasUnconfirmedTransactions
@@ -702,8 +724,9 @@ class Organization extends Model {
           await saveCreationState(state, Meta);
         } else {
           // Push was accepted by the function but returned false (RPC-level failure).
-          // Schedule a background retry and report failure for this store.
+          // Check for rejected txs before scheduling background retry.
           logState(state, `Push to ${storeType} store ${storeId} failed, background retry scheduled`, 'error');
+          await Organization._checkAndClearRejectedTxs(storeType, storeId);
           datalayer.pushDataLayerChangeList(storeId, changeList, () => {
             logState(state, `Background retry for ${storeType} store ${storeId} gave up`, 'error');
           });
@@ -712,7 +735,7 @@ class Organization extends Model {
       } catch (error) {
         logState(state, `Push to ${storeType} store ${storeId} threw: ${error.message}`, 'error');
         if (!USE_SIMULATOR) {
-          // Schedule a background retry via the normal path (which includes the unconfirmed-tx gate)
+          await Organization._checkAndClearRejectedTxs(storeType, storeId);
           datalayer.pushDataLayerChangeList(storeId, changeList, () => {
             logState(state, `Background retry for ${storeType} store ${storeId} gave up`, 'error');
           });

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -230,8 +230,20 @@ class Organization extends Model {
       logger.error(
         `[v1]: create organization process failed. Error: ${error.message}`,
       );
-      // Clean up PENDING record but preserve state for potential recovery
       await Organization.destroy({ where: { orgUid: 'PENDING' } });
+      // Mark state as FAILED so the 409 guard in the controller doesn't
+      // permanently block new creation attempts within the same session.
+      // The startup recovery task only runs once, so mid-session failures
+      // would otherwise leave orphaned STORES_CREATING state in Meta.
+      try {
+        let failedState = await loadCreationState(Meta, 'v1');
+        if (failedState && failedState.state !== ORG_CREATION_STATES.COMPLETE) {
+          failedState = markAsFailed(failedState, error.message);
+          await saveCreationState(failedState, Meta);
+        }
+      } catch (stateError) {
+        logger.error(`[v1]: Failed to mark creation state as FAILED: ${stateError.message}`);
+      }
       throw error;
     }
   }

--- a/src/models/v2/filestore-v2.model.js
+++ b/src/models/v2/filestore-v2.model.js
@@ -141,13 +141,16 @@ class FilestoreV2 extends Model {
     const fileStoreId = myOrganization.file_store_subscribed;
 
     if (myOrganization && !fileStoreId) {
-      // Create new file store
-      datalayer.createDataLayerStore().then((newFileStoreId) => {
+      datalayer.waitForSpendableCoins(1).then(() =>
+        datalayer.createDataLayerStoreWithRetry()
+      ).then((newFileStoreId) => {
         datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId: newFileStoreId });
         OrganizationsV2.update(
           { file_store_subscribed: newFileStoreId },
           { where: { org_uid: myOrganization.org_uid } },
         );
+      }).catch((error) => {
+        loggerV2.error(`[v2]: Failed to create file store: ${error.message}`);
       });
 
       throw new Error('New File store being created, please try again later.');
@@ -195,13 +198,16 @@ class FilestoreV2 extends Model {
     const fileStoreId = myOrganization.file_store_subscribed;
 
     if (!fileStoreId) {
-      // Create new file store
-      datalayer.createDataLayerStore().then((newFileStoreId) => {
+      datalayer.waitForSpendableCoins(1).then(() =>
+        datalayer.createDataLayerStoreWithRetry()
+      ).then((newFileStoreId) => {
         datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId: newFileStoreId });
         OrganizationsV2.update(
           { file_store_subscribed: newFileStoreId },
           { where: { org_uid: myOrganization.org_uid } },
         );
+      }).catch((error) => {
+        loggerV2.error(`[v2]: Failed to create file store: ${error.message}`);
       });
       throw new Error('New File store being created, please try again later.');
     }
@@ -260,13 +266,16 @@ class FilestoreV2 extends Model {
     const fileStoreId = myOrganization.file_store_subscribed;
 
     if (!fileStoreId) {
-      // Create new file store
-      datalayer.createDataLayerStore().then((newFileStoreId) => {
+      datalayer.waitForSpendableCoins(1).then(() =>
+        datalayer.createDataLayerStoreWithRetry()
+      ).then((newFileStoreId) => {
         datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId: newFileStoreId });
         OrganizationsV2.update(
           { file_store_subscribed: newFileStoreId },
           { where: { org_uid: myOrganization.org_uid } },
         );
+      }).catch((error) => {
+        loggerV2.error(`[v2]: Failed to create file store: ${error.message}`);
       });
       throw new Error('New File store being created, please try again later.');
     }
@@ -302,7 +311,8 @@ class FilestoreV2 extends Model {
     let fileStoreId = myOrganization.file_store_subscribed;
 
     if (!fileStoreId) {
-      fileStoreId = await datalayer.createDataLayerStore();
+      await datalayer.waitForSpendableCoins(1);
+      fileStoreId = await datalayer.createDataLayerStoreWithRetry();
       datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId });
       await OrganizationsV2.update(
         { file_store_subscribed: fileStoreId },

--- a/src/models/v2/governance-v2.model.js
+++ b/src/models/v2/governance-v2.model.js
@@ -260,7 +260,9 @@ class GovernanceV2 extends Model {
 
       if (existingV1Governance) {
         loggerV2.info('[v2]: Existing V1 governance body detected, adding V2 support...');
-        return await GovernanceV2.addV2ToExistingGovernanceBody();
+        const result = await GovernanceV2.addV2ToExistingGovernanceBody();
+        await GovernanceV2._setCreationStatus('completed');
+        return result;
       }
     } catch (error) {
       if (error.message && error.message.includes('no such table')) {

--- a/src/models/v2/governance-v2.model.js
+++ b/src/models/v2/governance-v2.model.js
@@ -165,7 +165,7 @@ class GovernanceV2 extends Model {
 
     // Create new V2-specific governance store
     await datalayer.waitForSpendableCoins(1);
-    const governanceVersionId = await datalayer.createDataLayerStore();
+    const governanceVersionId = await datalayer.createDataLayerStoreWithRetry();
     loggerV2.info(`[v2]: Created new V2 governance store: ${governanceVersionId}`);
 
     // Only insert the new version key; existing keys (e.g. v1) are already in the store.
@@ -225,53 +225,65 @@ class GovernanceV2 extends Model {
    * @returns {Promise<string>} The V2 governance version store ID
    * @throws {Error} If already listening to another governance body or if V1 governance exists
    */
+  static async _setCreationStatus(status, error = null) {
+    try {
+      await MetaV2.upsert({ meta_key: 'governanceCreationStatus', meta_value: status });
+      await MetaV2.upsert({ meta_key: 'governanceCreationStartedAt', meta_value: GovernanceV2._creationStartedAt || new Date().toISOString() });
+      if (error) {
+        await MetaV2.upsert({ meta_key: 'governanceCreationError', meta_value: String(error) });
+      } else {
+        await MetaV2.destroy({ where: { meta_key: 'governanceCreationError' } });
+      }
+    } catch (e) {
+      loggerV2.error(`[v2]: Failed to update governance creation status: ${e.message}`);
+    }
+  }
+
   static async createGoveranceBody() {
     const { GOVERNANCE_BODY_ID } = getConfigV2().GOVERNANCE;
     const { USE_SIMULATOR } = getConfig().APP;
 
-    // Check if already listening to another governance body
     if (GOVERNANCE_BODY_ID && GOVERNANCE_BODY_ID !== '') {
       throw new Error(
         'You are already listening to another governance body. Please clear GOVERNANCE_BODY_ID from your V2 config and try again',
       );
     }
 
+    GovernanceV2._creationStartedAt = new Date().toISOString();
+    await GovernanceV2._setCreationStatus('creating_stores');
+
     // Check if this node is already a V1 governance body
-    // Try to query V1 Meta table - if it doesn't exist, proceed with new V2 governance body
     try {
       const existingV1Governance = await Meta.findOne({
         where: { metaKey: 'mainGoveranceBodyId' },
       });
 
       if (existingV1Governance) {
-        // Node is already a V1 governance body - add V2 support instead
         loggerV2.info('[v2]: Existing V1 governance body detected, adding V2 support...');
         return await GovernanceV2.addV2ToExistingGovernanceBody();
       }
     } catch (error) {
-      // V1 Meta table doesn't exist - this is OK, proceed with creating new V2 governance body
       if (error.message && error.message.includes('no such table')) {
         loggerV2.debug('[v2]: V1 Meta table does not exist, proceeding with new V2 governance body creation');
       } else {
-        // Re-throw if it's a different error
+        await GovernanceV2._setCreationStatus('failed', error.message);
         throw error;
       }
     }
 
-    // Create new governance body from scratch
-    const dataModelVersion = 'v2'; // CRITICAL: Hardcode 'v2', not getDataModelVersion()
+    const dataModelVersion = 'v2';
     await datalayer.waitForSpendableCoins(2);
-    // Create stores sequentially to avoid "DataLayer Wallet already exists"
-    // race condition when both calls try to initialize the wallet in parallel
-    const governanceBodyId = await datalayer.createDataLayerStore();
-    const governanceVersionId = await datalayer.createDataLayerStore();
+    const governanceBodyId = await datalayer.createDataLayerStoreWithRetry();
+    const governanceVersionId = await datalayer.createDataLayerStoreWithRetry();
+
+    await GovernanceV2._setCreationStatus('waiting_for_confirmation');
 
     const revertIfFailed = async () => {
       loggerV2.warn('[v2]: Reverting Failed Governance Body Creation');
       await MetaV2.destroy({ where: { meta_key: 'governanceBodyId' } });
+      await GovernanceV2._setCreationStatus('failed', 'Governance body creation reverted');
     };
 
-    // Sync the governance store with version mapping
     await datalayer.syncDataLayer(
       governanceBodyId,
       {
@@ -279,6 +291,8 @@ class GovernanceV2 extends Model {
       },
       revertIfFailed,
     );
+
+    await GovernanceV2._setCreationStatus('syncing_data');
 
     const onConfirm = async () => {
       await MetaV2.upsert({
@@ -289,6 +303,7 @@ class GovernanceV2 extends Model {
         meta_key: 'mainGoveranceBodyId',
         meta_value: governanceBodyId,
       });
+      await GovernanceV2._setCreationStatus('completed');
       loggerV2.info('[v2]: V2 Governance body confirmed, you are ready to go');
     };
 

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -523,7 +523,7 @@ class OrganizationsV2 extends Model {
       for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
           logState(state, `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
-          const storeId = await datalayer.createDataLayerStore();
+          const storeId = await datalayer.createDataLayerStoreWithRetry();
           logState(state, `Created ${storeType} store: ${storeId}`);
           return { storeType, storeId, success: true };
         } catch (error) {
@@ -922,7 +922,7 @@ class OrganizationsV2 extends Model {
         for (let attempt = 1; attempt <= maxStoreCreateRetries; attempt++) {
           try {
             await wallet.waitForSpendableCoins(1);
-            newV2RegistryStoreId = await datalayer.createDataLayerStore();
+            newV2RegistryStoreId = await datalayer.createDataLayerStoreWithRetry();
             break;
           } catch (error) {
             if (isTransientWalletError(error) && attempt < maxStoreCreateRetries) {

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -277,8 +277,20 @@ class OrganizationsV2 extends Model {
       loggerV2.error(
         `[v2]: create V2 organization process failed. Error: ${error.message}`,
       );
-      // Clean up PENDING record but preserve state for potential recovery
       await OrganizationsV2.destroy({ where: { org_uid: 'PENDING' } });
+      // Mark state as FAILED so the 409 guard in the controller doesn't
+      // permanently block new creation attempts within the same session.
+      // The startup recovery task only runs once, so mid-session failures
+      // would otherwise leave orphaned STORES_CREATING state in Meta.
+      try {
+        let failedState = await loadCreationState(MetaV2, 'v2');
+        if (failedState && failedState.state !== ORG_CREATION_STATES.COMPLETE) {
+          failedState = markAsFailed(failedState, error.message);
+          await saveCreationState(failedState, MetaV2);
+        }
+      } catch (stateError) {
+        loggerV2.error(`[v2]: Failed to mark creation state as FAILED: ${stateError.message}`);
+      }
       throw error;
     }
   }
@@ -639,6 +651,28 @@ class OrganizationsV2 extends Model {
   }
 
   /**
+   * Detect rejected txs in the DL wallet and auto-clear them.
+   * Non-blocking and best-effort — failures are logged but don't propagate.
+   * @private
+   */
+  static async _checkAndClearRejectedTxs(storeType, storeId) {
+    try {
+      const dlWalletId = await wallet.getDLWalletId();
+      if (!dlWalletId) return;
+
+      const health = await wallet.getTransactionHealth(dlWalletId);
+      if (health.rejected.length > 0) {
+        const txIds = health.rejected.map((tx) => tx.name);
+        const context =
+          `V2 _pushDataInParallel failed for ${storeType} store ${storeId}, scheduling retry`;
+        await wallet.clearRejectedTransactions(dlWalletId, txIds, context);
+      }
+    } catch (error) {
+      loggerV2.debug(`[v2]: _checkAndClearRejectedTxs non-fatal error: ${error.message}`);
+    }
+  }
+
+  /**
    * Push data to stores in parallel
    * @param {Object} state - Current state
    * @param {Object} MetaV2 - The MetaV2 model
@@ -680,6 +714,7 @@ class OrganizationsV2 extends Model {
             );
             return { storeType: STORE_TYPES.ORG_UID, success: true };
           } catch (error) {
+            await OrganizationsV2._checkAndClearRejectedTxs(STORE_TYPES.ORG_UID, orgUidStoreId);
             return { storeType: STORE_TYPES.ORG_UID, success: false, error: error.message };
           }
         })(),
@@ -701,6 +736,7 @@ class OrganizationsV2 extends Model {
             );
             return { storeType: STORE_TYPES.DATA_MODEL_VERSION, success: true };
           } catch (error) {
+            await OrganizationsV2._checkAndClearRejectedTxs(STORE_TYPES.DATA_MODEL_VERSION, dataModelVersionStoreId);
             return { storeType: STORE_TYPES.DATA_MODEL_VERSION, success: false, error: error.message };
           }
         })(),

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -30,7 +30,7 @@ V1Router.get('/health/wallet', async (req, res) => {
     const wallet = (await import('../../datalayer/wallet.js')).default;
     const config = getConfig();
     const result = await getWalletHealthResponse(wallet, {
-      readOnly: config.READ_ONLY || false,
+      readOnly: config.READ_ONLY === true,
     });
     res.status(200).json(result);
   } catch (error) {

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 import express from 'express';
+import { getWalletHealthResponse } from '../wallet-health.js';
+import { getConfig } from '../../utils/config-loader';
 const V1Router = express.Router();
 
 import {
@@ -16,13 +18,28 @@ import {
   OfferRouter,
 } from './resources';
 
-// Simple health check for V1 - doesn't require wallet or datalayer to be synced
-// This allows tests to verify V1 API is enabled without waiting for Chia services
 V1Router.get('/health', (req, res) => {
   res.status(200).json({
     message: 'V1 API is running',
     timestamp: new Date().toISOString(),
   });
+});
+
+V1Router.get('/health/wallet', async (req, res) => {
+  try {
+    const wallet = (await import('../../datalayer/wallet.js')).default;
+    const config = getConfig();
+    const result = await getWalletHealthResponse(wallet, {
+      readOnly: config.READ_ONLY || false,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(200).json({
+      synced: false,
+      error: `Wallet health check failed: ${error.message}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
 });
 
 V1Router.use('/projects', ProjectRouter);

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -43,7 +43,7 @@ V2Router.get('/health/wallet', async (req, res) => {
     const wallet = (await import('../../datalayer/wallet.js')).default;
     const config = getConfigV2();
     const result = await getWalletHealthResponse(wallet, {
-      readOnly: config.READ_ONLY || false,
+      readOnly: config.READ_ONLY === true,
     });
     res.status(200).json(result);
   } catch (error) {

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -1,4 +1,6 @@
 import express from 'express';
+import { getWalletHealthResponse } from '../wallet-health.js';
+import { getConfigV2 } from '../../utils/config-loader';
 import { MethodologyV2Router } from './resources/methodology-v2.js';
 import { ProgramV2Router } from './resources/program-v2.js';
 import { ProjectV2Router } from './resources/project-v2.js';
@@ -29,12 +31,28 @@ import { FilestoreV2Router } from './resources/filestore-v2.js';
 
 const V2Router = express.Router();
 
-// Basic health check for V2
 V2Router.get('/health', (req, res) => {
   res.status(200).json({
     message: 'V2 API is running',
     timestamp: new Date().toISOString(),
   });
+});
+
+V2Router.get('/health/wallet', async (req, res) => {
+  try {
+    const wallet = (await import('../../datalayer/wallet.js')).default;
+    const config = getConfigV2();
+    const result = await getWalletHealthResponse(wallet, {
+      readOnly: config.READ_ONLY || false,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(200).json({
+      synced: false,
+      error: `Wallet health check failed: ${error.message}`,
+      timestamp: new Date().toISOString(),
+    });
+  }
 });
 
 // V2 API routes

--- a/src/routes/wallet-health.js
+++ b/src/routes/wallet-health.js
@@ -1,3 +1,7 @@
+import walletModule from '../datalayer/wallet.js';
+
+const { formatDuration } = walletModule;
+
 /**
  * Build a wallet health diagnostic response.
  * Gracefully degrades if wallet or RPC is unreachable.
@@ -92,13 +96,6 @@ const truncateTxId = (txId) => {
 
 const formatTxSummary = (tx) => ({
   txId: truncateTxId(tx.name),
-  age: wallet_formatDuration(tx.age),
+  age: formatDuration(tx.age),
   error: tx.rejectionReason || null,
 });
-
-const wallet_formatDuration = (seconds) => {
-  if (seconds == null) return 'unknown';
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
-  return m > 0 ? `${m}m ${s}s` : `${s}s`;
-};

--- a/src/routes/wallet-health.js
+++ b/src/routes/wallet-health.js
@@ -1,0 +1,104 @@
+/**
+ * Build a wallet health diagnostic response.
+ * Gracefully degrades if wallet or RPC is unreachable.
+ *
+ * When readOnly is true (public observer node), only sync status is returned
+ * to avoid exposing transaction IDs, peer details, and wallet internals on
+ * unauthenticated public endpoints.
+ *
+ * @param {Object} wallet - The wallet module from datalayer/wallet.js
+ * @param {Object} [options]
+ * @param {boolean} [options.readOnly=false] - If true, omit transaction details
+ * @returns {Promise<Object>} Wallet health status
+ */
+export const getWalletHealthResponse = async (wallet, { readOnly = false } = {}) => {
+  const timestamp = new Date().toISOString();
+
+  let synced = false;
+  try {
+    synced = await wallet.walletIsSynced();
+  } catch {
+    synced = false;
+  }
+
+  if (readOnly) {
+    return {
+      synced,
+      timestamp,
+      readOnly: true,
+      message: 'Transaction details are not available on read-only nodes',
+    };
+  }
+
+  const result = {
+    synced,
+    timestamp,
+    standardWallet: {
+      walletId: 1,
+      unconfirmedCount: 0,
+      rejected: [],
+      stuck: [],
+    },
+    dataLayerWallet: {
+      walletId: null,
+      available: false,
+      unconfirmedCount: 0,
+      rejected: [],
+      stuck: [],
+    },
+  };
+
+  // Standard wallet (id 1)
+  try {
+    const health = await wallet.getTransactionHealth('1');
+    result.standardWallet.unconfirmedCount =
+      health.rejected.length + health.inMempool.length + health.pending.length;
+    result.standardWallet.rejected = health.rejected.map(formatTxSummary);
+    result.standardWallet.stuck = [
+      ...health.inMempool.filter((tx) => tx.age && tx.age > 900),
+      ...health.pending.filter((tx) => tx.age && tx.age > 900),
+    ].map(formatTxSummary);
+  } catch {
+    result.standardWallet.error = 'Could not retrieve standard wallet health';
+  }
+
+  // DataLayer wallet
+  try {
+    const dlWalletId = await wallet.getDLWalletId();
+    if (dlWalletId) {
+      result.dataLayerWallet.walletId = Number(dlWalletId);
+      result.dataLayerWallet.available = true;
+
+      const health = await wallet.getTransactionHealth(dlWalletId);
+      result.dataLayerWallet.unconfirmedCount =
+        health.rejected.length + health.inMempool.length + health.pending.length;
+      result.dataLayerWallet.rejected = health.rejected.map(formatTxSummary);
+      result.dataLayerWallet.stuck = [
+        ...health.inMempool.filter((tx) => tx.age && tx.age > 900),
+        ...health.pending.filter((tx) => tx.age && tx.age > 900),
+      ].map(formatTxSummary);
+    }
+  } catch {
+    result.dataLayerWallet.error = 'Could not retrieve DataLayer wallet health';
+  }
+
+  return result;
+};
+
+const truncateTxId = (txId) => {
+  if (!txId || txId.length <= 16) return txId;
+  return `${txId.slice(0, 10)}...${txId.slice(-4)}`;
+};
+
+const formatTxSummary = (tx) => ({
+  txId: truncateTxId(tx.name),
+  age: wallet_formatDuration(tx.age),
+  error: tx.rejectionReason || null,
+});
+
+const wallet_formatDuration = (seconds) => {
+  if (seconds == null) return 'unknown';
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+};

--- a/src/routes/wallet-health.js
+++ b/src/routes/wallet-health.js
@@ -1,7 +1,3 @@
-import walletModule from '../datalayer/wallet.js';
-
-const { formatDuration } = walletModule;
-
 /**
  * Build a wallet health diagnostic response.
  * Gracefully degrades if wallet or RPC is unreachable.
@@ -33,6 +29,12 @@ export const getWalletHealthResponse = async (wallet, { readOnly = false } = {})
       message: 'Transaction details are not available on read-only nodes',
     };
   }
+
+  const formatTxSummary = (tx) => ({
+    txId: truncateTxId(tx.name),
+    age: wallet.formatDuration(tx.age),
+    error: tx.rejectionReason || null,
+  });
 
   const result = {
     synced,
@@ -93,9 +95,3 @@ const truncateTxId = (txId) => {
   if (!txId || txId.length <= 16) return txId;
   return `${txId.slice(0, 10)}...${txId.slice(-4)}`;
 };
-
-const formatTxSummary = (tx) => ({
-  txId: truncateTxId(tx.name),
-  age: formatDuration(tx.age),
-  error: tx.rejectionReason || null,
-});

--- a/tests/governance/live-api/helpers/governance-helpers.js
+++ b/tests/governance/live-api/helpers/governance-helpers.js
@@ -8,6 +8,11 @@ import {
   createLiveApiRequest,
   waitForServer,
 } from '../../../v2/live-api/helpers/live-api-helpers.js';
+import {
+  getWalletDiagnostics,
+  formatWalletStatus,
+  createRecoveryStuckTracker,
+} from '../../../v2/live-api/helpers/wallet-diagnostics.js';
 
 const getTimestamp = () => {
   const now = new Date();
@@ -99,6 +104,7 @@ export const waitForGovernanceCreated = async (request, apiVersion, maxWaitMs = 
   const startTime = Date.now();
   const interval = 10000;
   const endpoint = `/${apiVersion}/governance/exists`;
+  const recoveryTracker = createRecoveryStuckTracker();
 
   console.log(`[${getTimestamp()}] Waiting for ${apiVersion} governance body to be created...`);
 
@@ -109,18 +115,37 @@ export const waitForGovernanceCreated = async (request, apiVersion, maxWaitMs = 
       const response = await request.get(endpoint);
 
       if (response.status === 200 && response.body) {
-        const { created, governanceBodyId } = response.body;
+        const { created, governanceBodyId, creationStatus, creationError, creationStartedAt } = response.body;
 
         if (created === true && governanceBodyId) {
           console.log(`[${getTimestamp()}] ${apiVersion} governance body created: ${governanceBodyId}`);
           return governanceBodyId;
         }
 
-        console.log(`  [${elapsed}s] ${apiVersion} governance not created yet (created=${created})`);
+        if (creationStatus === 'failed') {
+          throw new Error(
+            `${apiVersion} governance creation failed after ${elapsed}s. ` +
+            `Error: ${creationError || 'unknown'}`,
+          );
+        }
+
+        const statusParts = [`created=${created}`];
+        if (creationStatus) statusParts.push(`status=${creationStatus}`);
+        if (creationStartedAt) statusParts.push(`started=${creationStartedAt}`);
+
+        const health = await getWalletDiagnostics(request, apiVersion);
+        const walletInfo = formatWalletStatus(health);
+        console.log(`  [${elapsed}s] ${apiVersion} governance: ${statusParts.join(', ')} | wallet: ${walletInfo}`);
+
+        recoveryTracker.update(health);
       } else {
         console.log(`  [${elapsed}s] ${endpoint} returned status ${response.status}`);
       }
     } catch (error) {
+      if (error.message.includes('governance creation failed') ||
+          error.message.includes('recovery appears stuck')) {
+        throw error;
+      }
       console.log(`  [${elapsed}s] Error checking governance exists: ${error.message}`);
     }
 
@@ -199,7 +224,9 @@ export const waitForGovernanceDataConfirmed = async (request, apiVersion, keys, 
           return records.filter(r => keys.includes(r[keyField]));
         }
 
-        console.log(`  [${elapsed}s] Pending: ${pendingKeys.join(', ')}`);
+        const health = await getWalletDiagnostics(request, apiVersion);
+        const walletInfo = formatWalletStatus(health);
+        console.log(`  [${elapsed}s] Pending: ${pendingKeys.join(', ')} | wallet: ${walletInfo}`);
       } else {
         console.log(`  [${elapsed}s] ${endpoint} returned status ${response.status}`);
       }

--- a/tests/v2/integration/transaction-health.spec.js
+++ b/tests/v2/integration/transaction-health.spec.js
@@ -1,0 +1,567 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import superagent from 'superagent';
+import fs from 'fs';
+
+import '../../../src/datalayer/index.js';
+import wallet from '../../../src/datalayer/wallet.js';
+import { getWalletHealthResponse } from '../../../src/routes/wallet-health.js';
+
+function createSuperagentMock(responseBody) {
+  const responseObj = { body: responseBody, text: JSON.stringify(responseBody) };
+  const chain = {
+    key: sinon.stub().callsFake(function () { return this; }),
+    cert: sinon.stub().callsFake(function () { return this; }),
+    timeout: sinon.stub().callsFake(function () { return this; }),
+    send: sinon.stub().callsFake(function () { return this; }),
+    then: function (resolve) { return Promise.resolve(responseObj).then(resolve); },
+  };
+  return chain;
+}
+
+describe('Transaction Health Monitoring', function () {
+  this.timeout(30000);
+
+  let superagentPostStub;
+  let fsReadFileSyncStub;
+
+  beforeEach(function () {
+    fsReadFileSyncStub = sinon.stub(fs, 'readFileSync').returns(Buffer.from('fake-cert'));
+    superagentPostStub = sinon.stub(superagent, 'post');
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('getTransactionHealth', function () {
+    it('should classify transactions as rejected when all peers FAILED', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_rejected_1',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 600,
+            sent_to: [
+              ['peer1', 3, 'INVALID_SPEND_BUNDLE'],
+              ['peer2', 3, 'INVALID_SPEND_BUNDLE'],
+            ],
+          },
+        ],
+      }));
+
+      const health = await wallet.getTransactionHealth('2');
+
+      expect(health.rejected).to.have.lengthOf(1);
+      expect(health.rejected[0].name).to.equal('0xtx_rejected_1');
+      expect(health.rejected[0].rejectionReason).to.include('FAILED');
+      expect(health.inMempool).to.have.lengthOf(0);
+      expect(health.pending).to.have.lengthOf(0);
+    });
+
+    it('should classify transactions as in_mempool when any peer returned SUCCESS', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_mempool_1',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 30,
+            sent_to: [
+              ['peer1', 1, null],
+              ['peer2', 2, null],
+            ],
+          },
+        ],
+      }));
+
+      const health = await wallet.getTransactionHealth('2');
+
+      expect(health.inMempool).to.have.lengthOf(1);
+      expect(health.inMempool[0].name).to.equal('0xtx_mempool_1');
+      expect(health.rejected).to.have.lengthOf(0);
+    });
+
+    it('should classify transactions as pending when only PENDING status', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_pending_1',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 10,
+            sent_to: [
+              ['peer1', 2, null],
+            ],
+          },
+        ],
+      }));
+
+      const health = await wallet.getTransactionHealth('2');
+
+      expect(health.pending).to.have.lengthOf(1);
+      expect(health.pending[0].name).to.equal('0xtx_pending_1');
+    });
+
+    it('should classify transactions as pending when sent_to is empty', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_new',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000),
+            sent_to: [],
+          },
+        ],
+      }));
+
+      const health = await wallet.getTransactionHealth('2');
+
+      expect(health.pending).to.have.lengthOf(1);
+    });
+
+    it('should filter out confirmed transactions', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: true,
+            name: '0xtx_confirmed',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 3600,
+            sent_to: [['peer1', 1, null]],
+          },
+          {
+            confirmed: false,
+            name: '0xtx_unconfirmed',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 60,
+            sent_to: [['peer1', 1, null]],
+          },
+        ],
+      }));
+
+      const health = await wallet.getTransactionHealth('1');
+
+      const totalUnconfirmed = health.rejected.length + health.inMempool.length + health.pending.length;
+      expect(totalUnconfirmed).to.equal(1);
+      expect(health.inMempool[0].name).to.equal('0xtx_unconfirmed');
+    });
+
+    it('should calculate stuckCount for txs older than 10 minutes', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_stuck',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 900,
+            sent_to: [['peer1', 2, null]],
+          },
+          {
+            confirmed: false,
+            name: '0xtx_fresh',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 30,
+            sent_to: [['peer1', 2, null]],
+          },
+        ],
+      }));
+
+      const health = await wallet.getTransactionHealth('1');
+
+      expect(health.stuckCount).to.equal(1);
+    });
+
+    it('should track oldestUnconfirmedAge', async function () {
+      const now = Math.floor(Date.now() / 1000);
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_old',
+            type: 1,
+            amount: 3000,
+            created_at_time: now - 1200,
+            sent_to: [['peer1', 1, null]],
+          },
+          {
+            confirmed: false,
+            name: '0xtx_new',
+            type: 1,
+            amount: 3000,
+            created_at_time: now - 60,
+            sent_to: [['peer1', 1, null]],
+          },
+        ],
+      }));
+
+      const health = await wallet.getTransactionHealth('1');
+
+      expect(health.oldestUnconfirmedAge).to.be.at.least(1190);
+      expect(health.oldestUnconfirmedAge).to.be.at.most(1210);
+    });
+  });
+
+  describe('clearRejectedTransactions', function () {
+    it('should refuse to clear when non-rejected txs exist', async function () {
+      // First call: getTransactionHealth (inside clearRejectedTransactions)
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_rejected',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 300,
+            sent_to: [['peer1', 3, 'INVALID']],
+          },
+          {
+            confirmed: false,
+            name: '0xtx_in_mempool',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 60,
+            sent_to: [['peer1', 1, null]],
+          },
+        ],
+      }));
+
+      const result = await wallet.clearRejectedTransactions(
+        '2',
+        ['0xtx_rejected'],
+        'test context',
+      );
+
+      expect(result.cleared).to.be.false;
+      expect(result.reason).to.include('Refusing to clear');
+      expect(result.reason).to.include('in-mempool');
+    });
+
+    it('should clear when ALL unconfirmed txs are rejected', async function () {
+      const healthResponse = {
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_rejected_1',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 600,
+            sent_to: [['peer1', 3, 'INVALID_SPEND_BUNDLE']],
+          },
+          {
+            confirmed: false,
+            name: '0xtx_rejected_2',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 500,
+            sent_to: [['peer1', 3, 'DOUBLE_SPEND']],
+          },
+        ],
+      };
+      const deleteResponse = { success: true };
+
+      // First call is get_transactions, second is delete_unconfirmed_transactions
+      superagentPostStub.onFirstCall().returns(createSuperagentMock(healthResponse));
+      superagentPostStub.onSecondCall().returns(createSuperagentMock(deleteResponse));
+
+      const result = await wallet.clearRejectedTransactions(
+        '2',
+        ['0xtx_rejected_1'],
+        'test: clearing rejected for retry',
+      );
+
+      expect(result.cleared).to.be.true;
+      expect(result.reason).to.include('Cleared 2 rejected');
+    });
+
+    it('should return not-cleared when no rejected transactions exist', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [],
+      }));
+
+      const result = await wallet.clearRejectedTransactions(
+        '2',
+        ['0xtx_nonexistent'],
+        'test context',
+      );
+
+      expect(result.cleared).to.be.false;
+      expect(result.reason).to.include('No rejected transactions');
+    });
+
+    it('should produce a warn-level audit log when clearing', async function () {
+      const healthResponse = {
+        success: true,
+        transactions: [
+          {
+            confirmed: false,
+            name: '0xtx_rejected',
+            type: 1,
+            amount: 3000,
+            created_at_time: Math.floor(Date.now() / 1000) - 300,
+            sent_to: [['peer1', 3, 'INVALID_SPEND_BUNDLE']],
+          },
+        ],
+      };
+
+      superagentPostStub.onFirstCall().returns(createSuperagentMock(healthResponse));
+      superagentPostStub.onSecondCall().returns(createSuperagentMock({ success: true }));
+
+      const result = await wallet.clearRejectedTransactions(
+        '2',
+        ['0xtx_rejected'],
+        'audit log test context',
+      );
+
+      // Verify the clear succeeded (the audit log is produced by logger.warn internally)
+      expect(result.cleared).to.be.true;
+      expect(result.reason).to.include('Cleared 1 rejected');
+    });
+  });
+
+  describe('getDLWalletId', function () {
+    it('should discover DL wallet by type 14', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        wallets: [
+          { id: 1, type: 0, name: 'Chia Wallet' },
+          { id: 2, type: 14, name: 'DataLayer Wallet' },
+        ],
+      }));
+
+      // Reset cached value
+      wallet.__test_resetDLWalletCache?.();
+
+      const walletId = await wallet.getDLWalletId();
+      expect(walletId).to.equal('2');
+    });
+  });
+
+  describe('hasUnconfirmedTransactions', function () {
+    it('should accept optional walletId parameter', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        transactions: [
+          { confirmed: false, name: 'tx1' },
+        ],
+      }));
+
+      const result = await wallet.hasUnconfirmedTransactions('2');
+      expect(result).to.be.true;
+
+      // Verify the wallet_id was sent in the request
+      const sendCall = superagentPostStub.returnValues[0].send;
+      expect(sendCall.calledOnce).to.be.true;
+      const sentData = sendCall.firstCall.args[0];
+      expect(sentData.wallet_id).to.equal('2');
+    });
+  });
+
+  describe('formatDuration', function () {
+    it('should format seconds correctly', function () {
+      expect(wallet.formatDuration(0)).to.equal('0s');
+      expect(wallet.formatDuration(45)).to.equal('45s');
+      expect(wallet.formatDuration(60)).to.equal('1m 0s');
+      expect(wallet.formatDuration(754)).to.equal('12m 34s');
+      expect(wallet.formatDuration(null)).to.equal('unknown');
+      expect(wallet.formatDuration(undefined)).to.equal('unknown');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Wallet health endpoint response shaping (getWalletHealthResponse)
+  //
+  // SECURITY INTENT: Public observer nodes (READ_ONLY=true, no API key) must
+  // never expose transaction IDs, wallet IDs, peer details, or rejection
+  // reasons through the /health/wallet endpoint. These tests exist to prevent
+  // accidental exposure if the response format is changed in the future.
+  // ---------------------------------------------------------------------------
+  describe('getWalletHealthResponse', function () {
+    const FULL_TX_ID = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+    function createMockWallet({ synced = true, hasTransactions = true } = {}) {
+      return {
+        walletIsSynced: sinon.stub().resolves(synced),
+        getDLWalletId: sinon.stub().resolves('2'),
+        getTransactionHealth: sinon.stub().resolves(
+          hasTransactions
+            ? {
+              rejected: [
+                {
+                  name: FULL_TX_ID,
+                  age: 600,
+                  rejectionReason: 'FAILED on 1/1 peers: peer abc123...: INVALID_SPEND_BUNDLE',
+                },
+              ],
+              inMempool: [
+                { name: '0x1111111111222222222233333333334444444444555555555566666666667777', age: 30 },
+              ],
+              pending: [],
+              stuckCount: 0,
+              oldestUnconfirmedAge: 600,
+            }
+            : { rejected: [], inMempool: [], pending: [], stuckCount: 0, oldestUnconfirmedAge: 0 },
+        ),
+      };
+    }
+
+    describe('read-only mode (public observer node protection)', function () {
+      it('should return ONLY synced status and timestamp when readOnly=true', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet, { readOnly: true });
+
+        expect(result).to.have.property('synced', true);
+        expect(result).to.have.property('timestamp').that.is.a('string');
+        expect(result).to.have.property('readOnly', true);
+        expect(result).to.have.property('message').that.includes('not available');
+      });
+
+      it('should NOT contain standardWallet in read-only mode', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet, { readOnly: true });
+
+        expect(result).to.not.have.property('standardWallet');
+      });
+
+      it('should NOT contain dataLayerWallet in read-only mode', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet, { readOnly: true });
+
+        expect(result).to.not.have.property('dataLayerWallet');
+      });
+
+      it('should NOT contain any transaction IDs in read-only mode', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet, { readOnly: true });
+
+        const serialized = JSON.stringify(result);
+        expect(serialized).to.not.include('0x');
+        expect(serialized).to.not.include('txId');
+        expect(serialized).to.not.include('walletId');
+        expect(serialized).to.not.include('rejected');
+        expect(serialized).to.not.include('stuck');
+        expect(serialized).to.not.include('unconfirmedCount');
+      });
+
+      it('should NOT call getTransactionHealth in read-only mode', async function () {
+        const mockWallet = createMockWallet();
+        await getWalletHealthResponse(mockWallet, { readOnly: true });
+
+        expect(mockWallet.getTransactionHealth.called).to.be.false;
+        expect(mockWallet.getDLWalletId.called).to.be.false;
+      });
+
+      it('should still report synced=false when wallet is unreachable in read-only mode', async function () {
+        const mockWallet = createMockWallet();
+        mockWallet.walletIsSynced.rejects(new Error('connection refused'));
+
+        const result = await getWalletHealthResponse(mockWallet, { readOnly: true });
+
+        expect(result).to.have.property('synced', false);
+        expect(result).to.have.property('readOnly', true);
+        expect(result).to.not.have.property('standardWallet');
+      });
+    });
+
+    describe('non-read-only mode (write node with API key)', function () {
+      it('should return full wallet health details', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet);
+
+        expect(result).to.have.property('synced', true);
+        expect(result).to.have.property('timestamp');
+        expect(result).to.not.have.property('readOnly');
+        expect(result).to.have.property('standardWallet');
+        expect(result).to.have.property('dataLayerWallet');
+      });
+
+      it('should include transaction counts and rejected/stuck arrays', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet);
+
+        expect(result.standardWallet).to.have.property('unconfirmedCount').that.is.a('number');
+        expect(result.standardWallet).to.have.property('rejected').that.is.an('array');
+        expect(result.standardWallet).to.have.property('stuck').that.is.an('array');
+        expect(result.dataLayerWallet).to.have.property('unconfirmedCount').that.is.a('number');
+      });
+
+      it('should truncate transaction IDs to prevent full hash exposure', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet);
+
+        const serialized = JSON.stringify(result);
+
+        expect(serialized).to.not.include(FULL_TX_ID);
+
+        const rejectedTx = result.standardWallet.rejected[0];
+        expect(rejectedTx.txId).to.have.lengthOf.at.most(17);
+        expect(rejectedTx.txId).to.include('...');
+        expect(rejectedTx.txId).to.match(/^0x.{8}\.\.\..{4}$/);
+      });
+
+      it('should include rejection reason and age for debugging', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet);
+
+        const rejectedTx = result.standardWallet.rejected[0];
+        expect(rejectedTx).to.have.property('error').that.includes('INVALID_SPEND_BUNDLE');
+        expect(rejectedTx).to.have.property('age').that.is.a('string');
+      });
+
+      it('should default to readOnly=false when no options provided', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet);
+
+        expect(result).to.have.property('standardWallet');
+        expect(result).to.not.have.property('readOnly');
+      });
+
+      it('should report DataLayer wallet availability', async function () {
+        const mockWallet = createMockWallet();
+        const result = await getWalletHealthResponse(mockWallet);
+
+        expect(result.dataLayerWallet).to.have.property('available', true);
+        expect(result.dataLayerWallet).to.have.property('walletId', 2);
+      });
+
+      it('should gracefully handle wallet RPC failure for standard wallet', async function () {
+        const mockWallet = createMockWallet();
+        mockWallet.getTransactionHealth.rejects(new Error('RPC timeout'));
+
+        const result = await getWalletHealthResponse(mockWallet);
+
+        expect(result.standardWallet).to.have.property('error').that.is.a('string');
+      });
+
+      it('should gracefully handle DL wallet discovery failure', async function () {
+        const mockWallet = createMockWallet();
+        mockWallet.getDLWalletId.rejects(new Error('connection refused'));
+
+        const result = await getWalletHealthResponse(mockWallet);
+
+        expect(result.dataLayerWallet).to.have.property('error').that.is.a('string');
+        expect(result.dataLayerWallet).to.have.property('available', false);
+      });
+    });
+  });
+});

--- a/tests/v2/integration/transaction-health.spec.js
+++ b/tests/v2/integration/transaction-health.spec.js
@@ -403,6 +403,7 @@ describe('Transaction Health Monitoring', function () {
       return {
         walletIsSynced: sinon.stub().resolves(synced),
         getDLWalletId: sinon.stub().resolves('2'),
+        formatDuration: wallet.formatDuration,
         getTransactionHealth: sinon.stub().resolves(
           hasTransactions
             ? {

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -4,6 +4,11 @@ import fs from 'fs';
 import path from 'path';
 import { getChiaRoot } from '../../../../src/utils/chia-root.js';
 import { shouldAutoCommit, trackTestEndpoint } from './shared-state.js';
+import {
+  getWalletDiagnostics,
+  formatWalletStatus,
+  createRecoveryStuckTracker,
+} from './wallet-diagnostics.js';
 
 /**
  * Format current timestamp as YYYY-MM-DD HH:mm:ss
@@ -563,8 +568,9 @@ export const checkOrganizationSynced = async (request) => {
  */
 export const waitForPendingCommits = async (request, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  const interval = 10000; // Check every 10 seconds (longer interval for blockchain)
+  const interval = 10000;
   const timestamp = new Date().toISOString();
+  const recoveryTracker = createRecoveryStuckTracker();
 
   console.log(`[${timestamp}] Waiting for organization sync to complete...`);
 
@@ -577,12 +583,16 @@ export const waitForPendingCommits = async (request, maxWaitTime = 600000) => {
     }
 
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
-    console.log(`  Organization not synced yet, waiting... (${elapsed}s elapsed)`);
+
+    const health = await getWalletDiagnostics(request);
+    const walletInfo = formatWalletStatus(health);
+    console.log(`  Organization not synced yet (${elapsed}s) | wallet: ${walletInfo}`);
+
+    recoveryTracker.update(health);
 
     await new Promise(resolve => setTimeout(resolve, interval));
   }
 
-  // Timeout reached - this is a problem, sync is taking too long
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
   console.error(`❌ Timeout waiting for organization sync to complete after ${elapsed}s`);
   throw new Error(`Timeout waiting for organization sync to complete after ${maxWaitTime}ms. Blockchain sync may be taking longer than expected.`);
@@ -596,7 +606,8 @@ export const waitForPendingCommits = async (request, maxWaitTime = 600000) => {
  */
 export const waitForStagingEmpty = async (request, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  const interval = 10000; // Check every 10 seconds
+  const interval = 10000;
+  const recoveryTracker = createRecoveryStuckTracker();
 
   console.log('Waiting for staging table to be empty...');
 
@@ -611,7 +622,12 @@ export const waitForStagingEmpty = async (request, maxWaitTime = 600000) => {
       }
 
       const elapsed = Math.floor((Date.now() - startTime) / 1000);
-      console.log(`  Staging table still has ${records.length} record(s), waiting... (${elapsed}s elapsed)`);
+
+      const health = await getWalletDiagnostics(request);
+      const walletInfo = formatWalletStatus(health);
+      console.log(`  Staging: ${records.length} record(s) remaining (${elapsed}s) | wallet: ${walletInfo}`);
+
+      recoveryTracker.update(health);
     } catch (error) {
       console.warn(`  Error checking staging table: ${error.message}`);
     }
@@ -629,29 +645,36 @@ export const waitForStagingEmpty = async (request, maxWaitTime = 600000) => {
  */
 export const waitForDataToAppear = async (request, type, id, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  let pollInterval = 5000; // Start with 5 seconds
-  const maxInterval = 30000; // Max 30 seconds
+  let pollInterval = 5000;
+  const maxInterval = 30000;
+  const recoveryTracker = createRecoveryStuckTracker();
+  let lastDiagAt = 0;
 
   while (Date.now() - startTime < maxWaitTime) {
     try {
-      // All tables now use UUID primary keys
       const endpoint = `/v2/${type}/${id}`;
 
       const response = await request.get(endpoint);
       if (response.status === 200 && response.body) {
-        // Record exists!
         return response.body;
       }
     } catch (error) {
-      // Record doesn't exist yet, continue polling
       const status = error.response?.status || error.status;
       if (status && status !== 404) {
-        // Some other error occurred
         console.warn(`  Error checking ${type}/${JSON.stringify(id)}: ${error.message} (status: ${status})`);
       }
     }
 
-    // Exponential backoff: increase interval after 2 minutes
+    const now = Date.now();
+    if (now - lastDiagAt > 30000) {
+      lastDiagAt = now;
+      const elapsed = Math.floor((now - startTime) / 1000);
+      const health = await getWalletDiagnostics(request);
+      const walletInfo = formatWalletStatus(health);
+      console.log(`  Waiting for ${type}/${JSON.stringify(id)} (${elapsed}s) | wallet: ${walletInfo}`);
+      recoveryTracker.update(health);
+    }
+
     if (Date.now() - startTime > 120000) {
       pollInterval = Math.min(pollInterval * 1.5, maxInterval);
     }
@@ -668,9 +691,10 @@ export const waitForDataToAppear = async (request, type, id, maxWaitTime = 60000
  */
 export const waitForBatchToAppear = async (request, records, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  let pollInterval = 5000; // Start with 5 seconds
-  const maxInterval = 30000; // Max 30 seconds
+  let pollInterval = 5000;
+  const maxInterval = 30000;
   const foundRecords = new Set();
+  const recoveryTracker = createRecoveryStuckTracker();
 
   const timestamp = new Date().toISOString();
   console.log(`[${timestamp}] 🔍 Waiting for ${records.length} record(s) to appear: ${records.map(r => `${r.type}/${JSON.stringify(r.id)}`).join(', ')}`);
@@ -705,7 +729,6 @@ export const waitForBatchToAppear = async (request, records, maxWaitTime = 60000
     await Promise.all(promises);
 
     if (foundRecords.size === records.length) {
-      // All records found!
       console.log(`✓ All ${records.length} record(s) found!`);
       return records.map(record => {
         const key = `${record.type}/${JSON.stringify(record.id)}`;
@@ -714,9 +737,12 @@ export const waitForBatchToAppear = async (request, records, maxWaitTime = 60000
     }
 
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
-    console.log(`  Still waiting... Found ${foundRecords.size}/${records.length} (${elapsed}s elapsed)`);
 
-    // Exponential backoff: increase interval after 2 minutes
+    const health = await getWalletDiagnostics(request);
+    const walletInfo = formatWalletStatus(health);
+    console.log(`  Found ${foundRecords.size}/${records.length} (${elapsed}s) | wallet: ${walletInfo}`);
+    recoveryTracker.update(health);
+
     if (Date.now() - startTime > 120000) {
       pollInterval = Math.min(pollInterval * 1.5, maxInterval);
     }
@@ -1053,7 +1079,9 @@ export const waitForWalletReadyForTransactions = async (request, maxWaitMs = 600
 
       if (response.status === 200) {
         consecutiveSuccess++;
-        console.log(`[${getTimestamp()}] ✓ Wallet available (${consecutiveSuccess}/${consecutiveSuccessRequired} consecutive, ${elapsed}s elapsed)`);
+        const health = await getWalletDiagnostics(request, 'v1');
+        const walletInfo = formatWalletStatus(health);
+        console.log(`[${getTimestamp()}] ✓ Wallet available (${consecutiveSuccess}/${consecutiveSuccessRequired}, ${elapsed}s) | ${walletInfo}`);
         if (consecutiveSuccess >= consecutiveSuccessRequired) {
           console.log(`[${getTimestamp()}] ✓ Wallet confirmed stable and available for transactions`);
           return;
@@ -1140,8 +1168,10 @@ export const getLiveApiRequest = async (options = {}) => {
 export const waitForV2OrganizationReady = async (request, orgName = null, maxWaitTime = 900000, options = {}) => {
   const { isUpgrade = false } = options;
   const startTime = Date.now();
-  const interval = 10000; // Check every 10 seconds
+  const interval = 10000;
   const timestamp = getTimestamp();
+  const recoveryTracker = createRecoveryStuckTracker();
+  let lastDiagAt = 0;
 
   console.log(`[${timestamp}] Waiting for V2 organization to be ready...`);
   if (orgName) {
@@ -1153,16 +1183,12 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
     console.log(`  (Upgrade mode: will wait for org to appear without fast-fail)`);
   }
 
-  // Track if we've seen a PENDING org - if it disappears, creation failed
   let sawPendingOrg = false;
-  // Track consecutive polls with no orgs and no creation in progress
   let noProgressCount = 0;
-  // For upgrades, use a much higher threshold since the process is fully async with no status feedback
-  const noProgressThreshold = isUpgrade ? 60 : 6; // 10 minutes for upgrade, 60 seconds for normal creation
-  // Track stuck state - if we're in the same state for too long, fail
+  const noProgressThreshold = isUpgrade ? 60 : 6;
   let lastState = null;
   let lastStateChangeTime = Date.now();
-  const stuckStateThresholdMs = 300000; // 5 minutes stuck in same state = fail
+  const stuckStateThresholdMs = 300000;
 
   while (Date.now() - startTime < maxWaitTime) {
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
@@ -1372,15 +1398,24 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
         }
       }
     } catch (error) {
-      // Re-throw fatal errors (like PENDING org disappeared, no progress, or stuck state) - don't swallow them
       if (error.message.includes('PENDING organization was cleaned up') ||
           error.message.includes('Organization creation failed') ||
           error.message.includes('Organization creation appears to have failed') ||
           error.message.includes('appears stuck') ||
-          error.message.includes('creation FAILED')) {
+          error.message.includes('creation FAILED') ||
+          error.message.includes('recovery appears stuck')) {
         throw error;
       }
       console.log(`  [${elapsed}s] Error checking organizations: ${error.message}`);
+    }
+
+    const now = Date.now();
+    if (now - lastDiagAt > 30000) {
+      lastDiagAt = now;
+      const health = await getWalletDiagnostics(request);
+      const elapsedSec = Math.floor((now - startTime) / 1000);
+      console.log(`  [${elapsedSec}s] wallet: ${formatWalletStatus(health)}`);
+      recoveryTracker.update(health);
     }
 
     await new Promise(resolve => setTimeout(resolve, interval));
@@ -1430,8 +1465,10 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
  */
 export const waitForV1OrganizationReady = async (request, orgName = null, maxWaitTime = 900000) => {
   const startTime = Date.now();
-  const interval = 10000; // Check every 10 seconds
+  const interval = 10000;
   const timestamp = getTimestamp();
+  const recoveryTracker = createRecoveryStuckTracker();
+  let lastDiagAt = 0;
 
   console.log(`[${timestamp}] Waiting for V1 organization to be ready...`);
   if (orgName) {
@@ -1440,15 +1477,12 @@ export const waitForV1OrganizationReady = async (request, orgName = null, maxWai
     console.log(`  Looking for home organization`);
   }
 
-  // Track if we've seen a PENDING org - if it disappears, creation failed
   let sawPendingOrg = false;
-  // Track consecutive polls with no orgs and no creation in progress
   let noProgressCount = 0;
-  const noProgressThreshold = 6; // After 60 seconds (6 x 10s interval) with no progress, fail fast
-  // Track stuck state - if we're in the same state for too long, fail
+  const noProgressThreshold = 6;
   let lastState = null;
   let lastStateChangeTime = Date.now();
-  const stuckStateThresholdMs = 300000; // 5 minutes stuck in same state = fail
+  const stuckStateThresholdMs = 300000;
 
   while (Date.now() - startTime < maxWaitTime) {
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
@@ -1698,15 +1732,24 @@ export const waitForV1OrganizationReady = async (request, orgName = null, maxWai
         }
       }
     } catch (error) {
-      // Re-throw fatal errors (like PENDING org disappeared, no progress, or stuck state) - don't swallow them
       if (error.message.includes('PENDING organization was cleaned up') ||
           error.message.includes('Organization creation failed') ||
           error.message.includes('Organization creation appears to have failed') ||
           error.message.includes('appears stuck') ||
-          error.message.includes('creation FAILED')) {
+          error.message.includes('creation FAILED') ||
+          error.message.includes('recovery appears stuck')) {
         throw error;
       }
       console.log(`  [${elapsed}s] Error checking organizations: ${error.message}`);
+    }
+
+    const now = Date.now();
+    if (now - lastDiagAt > 30000) {
+      lastDiagAt = now;
+      const health = await getWalletDiagnostics(request, 'v1');
+      const elapsedSec = Math.floor((now - startTime) / 1000);
+      console.log(`  [${elapsedSec}s] wallet: ${formatWalletStatus(health)}`);
+      recoveryTracker.update(health);
     }
 
     await new Promise(resolve => setTimeout(resolve, interval));

--- a/tests/v2/live-api/helpers/wallet-diagnostics.js
+++ b/tests/v2/live-api/helpers/wallet-diagnostics.js
@@ -1,0 +1,120 @@
+/**
+ * Wallet health diagnostics for live API tests.
+ *
+ * Polls /health/wallet to provide:
+ * - Rich diagnostic logging during blockchain waits
+ * - Detection of stuck recovery (rejected txs that persist across polls)
+ *
+ * The CADT server handles rejected transactions internally via
+ * createDataLayerStoreWithRetry and pushChangesWhenStoreIsAvailable.
+ * Tests should NOT fast-fail on seeing rejected txs — they indicate
+ * the server's recovery mechanism is active. Tests only fail fast
+ * if the recovery appears stuck (same rejected txs for 2+ minutes).
+ */
+
+const RECOVERY_STUCK_THRESHOLD_MS = 120000; // 2 minutes
+
+/**
+ * Fetch wallet health from the /health/wallet endpoint.
+ * Returns null on any failure (non-fatal).
+ */
+export const getWalletDiagnostics = async (request, apiVersion = 'v2') => {
+  try {
+    const res = await request.get(`/${apiVersion}/health/wallet`);
+    if (res.status === 200 && res.body) {
+      return res.body;
+    }
+  } catch {
+    // Health endpoint unreachable — not fatal
+  }
+  return null;
+};
+
+/**
+ * Extract rejected transaction IDs from a wallet health response.
+ * Returns a sorted array of txId strings, or null if none.
+ */
+export const getRejectedTxIds = (walletHealth) => {
+  if (!walletHealth) return null;
+  const ids = [
+    ...(walletHealth.standardWallet?.rejected || []),
+    ...(walletHealth.dataLayerWallet?.rejected || []),
+  ].map((tx) => tx.txId);
+  return ids.length > 0 ? ids.sort() : null;
+};
+
+/**
+ * Format a one-line wallet status summary for log output.
+ */
+export const formatWalletStatus = (walletHealth) => {
+  if (!walletHealth) return 'wallet health unavailable';
+  if (walletHealth.readOnly) return `synced: ${walletHealth.synced} (read-only)`;
+
+  const parts = [`synced: ${walletHealth.synced}`];
+  const sw = walletHealth.standardWallet;
+  const dl = walletHealth.dataLayerWallet;
+
+  if (sw) parts.push(`std: ${sw.unconfirmedCount} unconfirmed`);
+  if (dl?.available) parts.push(`dl: ${dl.unconfirmedCount} unconfirmed`);
+
+  const totalRejected =
+    (sw?.rejected?.length || 0) + (dl?.rejected?.length || 0);
+  const totalStuck = (sw?.stuck?.length || 0) + (dl?.stuck?.length || 0);
+
+  if (totalRejected > 0) parts.push(`⚠ ${totalRejected} REJECTED (recovery in progress)`);
+  if (totalStuck > 0) parts.push(`⏳ ${totalStuck} stuck`);
+
+  return parts.join(', ');
+};
+
+/**
+ * Stateful tracker that detects when rejected transactions persist
+ * without being cleared by the server's recovery mechanism.
+ *
+ * Usage:
+ *   const tracker = createRecoveryStuckTracker();
+ *   // In poll loop:
+ *   tracker.update(walletHealth);  // throws if stuck
+ */
+export const createRecoveryStuckTracker = () => {
+  let lastRejectedKey = null;
+  let firstSeenAt = null;
+
+  return {
+    /**
+     * Update tracker with the latest wallet health.
+     * Throws if the same rejected txs persist for > RECOVERY_STUCK_THRESHOLD_MS.
+     */
+    update(walletHealth) {
+      const rejected = getRejectedTxIds(walletHealth);
+
+      if (!rejected) {
+        lastRejectedKey = null;
+        firstSeenAt = null;
+        return;
+      }
+
+      const key = rejected.join(',');
+
+      if (key !== lastRejectedKey) {
+        lastRejectedKey = key;
+        firstSeenAt = Date.now();
+        return;
+      }
+
+      const elapsed = Date.now() - firstSeenAt;
+      if (elapsed > RECOVERY_STUCK_THRESHOLD_MS) {
+        const details = [
+          ...(walletHealth.standardWallet?.rejected || []),
+          ...(walletHealth.dataLayerWallet?.rejected || []),
+        ];
+        throw new Error(
+          `Transaction recovery appears stuck: ${rejected.length} rejected tx(s) ` +
+          `have persisted for ${Math.round(elapsed / 1000)}s without being cleared. ` +
+          `The server's auto-clear/retry mechanism may not be working.\n` +
+          `Rejected: ${JSON.stringify(details, null, 2)}`,
+        );
+      }
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- Add wallet-level transaction health classification (`rejected`, `in_mempool`, `pending`) and safe auto-clearing of rejected transactions via `clearRejectedTransactions` — which refuses to clear unless **all** unconfirmed txs in the wallet are rejected (because `delete_unconfirmed_transactions` is wallet-wide)
- Implement `createDataLayerStoreWithRetry` with `verbose: true` for tx_id correlation, enabling early rejection detection in `waitForNewStoreToBeConfirmed` and automatic retry on rejected store creation
- Harden all major write paths: `writeService.pushChangesWhenStoreIsAvailable`, `organizations._pushDataInParallel`, filestore/governance store creation — all now detect and recover from rejected transactions
- Add governance creation status tracking (`governanceCreationStatus`, `governanceCreationError`, `governanceCreationStartedAt`) exposed through `/governance/exists`
- Add `/v1/health/wallet` and `/v2/health/wallet` diagnostic endpoints with:
  - **Read-only guard**: observer nodes (`READ_ONLY=true`) return only `{ synced, timestamp }` — no tx IDs, wallet IDs, or peer details exposed on public unauthenticated endpoints
  - **Truncated tx IDs**: write nodes show `0xabcdef12...7890` instead of full hashes
  - Middleware bypass via `HEALTH_ENDPOINTS` set for consistent exemption from startup/rate-limit checks
- Mandatory audit logging (`warn` level) for every transaction clear/delete operation with structured context (wallet_id, tx_ids, reason, age, caller)
- 28 unit tests covering health classification, safety guards, and explicit read-only vs non-read-only endpoint response contracts

## Files changed

| Area | Files | What |
|------|-------|------|
| Core | `wallet.js` | `getTransactionHealth`, `clearRejectedTransactions`, `getDLWalletId`, `hasAnyUnconfirmedTransactions`, `formatDuration` |
| Core | `writeService.js` | `createDataLayerStoreWithRetry`, enhanced `pushChangesWhenStoreIsAvailable` and `waitForNewStoreToBeConfirmed` |
| Core | `persistance.js` | `verbose: true` in `create_data_store` RPC, return `{ storeId, txIds }` |
| Governance | `governance.model.js`, `governance-v2.model.js`, controllers | Creation status tracking, `createDataLayerStoreWithRetry` migration |
| Organizations | `organizations.model.js`, `organizations-v2.model.js` | `_checkAndClearRejectedTxs` in push paths |
| Filestore | `file-store.model.js`, `filestore-v2.model.js` | `createDataLayerStoreWithRetry` migration, `waitForSpendableCoins` |
| Endpoints | `wallet-health.js`, `v1/index.js`, `v2/index.js` | New `/health/wallet` endpoints with read-only guard |
| Middleware | `middleware.js` | `HEALTH_ENDPOINTS` set for bypass |
| Tests | `transaction-health.spec.js` | 28 tests |

## Test plan

- [x] All 28 unit tests pass (`transaction-health.spec.js`)
- [ ] Manual verification on a write node: `/v1/health/wallet` returns full diagnostics with truncated tx IDs
- [ ] Manual verification on a read-only node: `/v1/health/wallet` returns only `{ synced, timestamp, readOnly, message }`
- [ ] Verify rejected transaction auto-clearing in `pushChangesWhenStoreIsAvailable` produces `warn`-level audit logs
- [ ] Verify governance creation status tracking through `/governance/exists`
- [ ] Verify store creation retry on rejection works end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core wallet/DataLayer write paths and adds automatic clearing of rejected transactions; mistakes could delay writes or clear transactions unexpectedly (guarded but still operationally sensitive). Scope is broad across governance/org creation and persistence flows.
> 
> **Overview**
> Adds transaction-health monitoring to the wallet layer (classifying unconfirmed txs as *rejected/in-mempool/pending*), DL wallet discovery, and a safety-guarded `clearRejectedTransactions` path with mandatory audit logging.
> 
> Updates DataLayer store creation and write flows to be rejection-aware: `create_data_store` now requests `verbose` tx records, store creation can retry via `createDataLayerStoreWithRetry`, and push logic periodically diagnoses/auto-clears rejected txs while improving timeout diagnostics.
> 
> Introduces new `/v1/health/wallet` and `/v2/health/wallet` endpoints (with read-only redaction and truncated tx IDs) and expands middleware health endpoint exemptions. Governance and org creation now track and expose creation status in Meta, and tests are extended with a new transaction-health suite plus richer live-test diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cbb37f1eda4601028ba56ba9cfcb2bb44146cd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->