### PR TITLE
fix: add pre-flight ownership checks and rollback wiring to governance push

### DIFF
--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -860,6 +860,19 @@ const pushChangeListToDataLayer = async (storeId, changelist, { skipTransactionW
         return false;
       }
 
+      if (data.error && data.error.includes('is not owned by DL Wallet')) {
+        logger.error(
+          `Store ${storeId} is not owned by this wallet's DL Wallet. ` +
+            `This is a permanent error — push will never succeed until store ownership is restored. ` +
+            `This typically happens when the node was redeployed with a new wallet.`,
+        );
+        const err = new Error(
+          `Store ${storeId} is not owned by this wallet's DL Wallet`,
+        );
+        err.permanent = true;
+        throw err;
+      }
+
       logger.error(
         `There was an error pushing your changes to the datalayer, ${JSON.stringify(
           data,
@@ -867,6 +880,9 @@ const pushChangeListToDataLayer = async (storeId, changelist, { skipTransactionW
       );
       return false;
     } catch (error) {
+      if (error.permanent) {
+        throw error;
+      }
       logger.error(error.message);
       logger.info('There was an error pushing your changes to the datalayer');
       return false;

--- a/src/datalayer/writeService.js
+++ b/src/datalayer/writeService.js
@@ -307,7 +307,7 @@ export const pushChangesWhenStoreIsAvailable = async (
             `Permanent push failure for store ${storeId}: ${pushError.message}. ` +
               `Invoking failedCallback and aborting retries.`,
           );
-          failedCallback();
+          await failedCallback();
           throw pushError;
         }
         throw pushError;

--- a/src/datalayer/writeService.js
+++ b/src/datalayer/writeService.js
@@ -236,36 +236,9 @@ const upsertDataLayer = async (storeId, data) => {
   await pushChangesWhenStoreIsAvailable(storeId, finalChangeList);
 };
 
-/**
- * Schedule a retry after 30s (fire-and-forget). Does not block the caller.
- * Caller should throw so we don't mark "data written" until the push actually succeeds.
- */
-const retryPushToStore = (
-  storeId,
-  changeList,
-  failedCallback,
-  retryAttempts,
-) => {
-  logger.info(`Retrying pushing to store ${storeId} in 30s (attempt ${retryAttempts + 1})`);
-  if (retryAttempts >= 60) {
-    logger.info(
-      'Could not push changelist to datalayer after retrying 60 times',
-    );
-    failedCallback();
-    return;
-  }
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-  setTimeout(() => {
-    pushChangesWhenStoreIsAvailable(
-      storeId,
-      changeList,
-      failedCallback,
-      retryAttempts + 1,
-    ).catch((error) => {
-      logger.error(`Retry push to store ${storeId} failed: ${error.message}`);
-    });
-  }, 30000);
-};
+const MAX_PUSH_RETRIES = 60;
 
 export const pushChangesWhenStoreIsAvailable = async (
   storeId,
@@ -275,9 +248,10 @@ export const pushChangesWhenStoreIsAvailable = async (
 ) => {
   if (USE_SIMULATOR) {
     return simulator.pushChangeListToDataLayer(storeId, changeList);
-  } else {
-    const syncResult =
-      await dataLayer.getDataLayerStoreSyncStatus(storeId);
+  }
+
+  for (let attempt = retryAttempts; attempt <= MAX_PUSH_RETRIES; attempt++) {
+    const syncResult = await dataLayer.getDataLayerStoreSyncStatus(storeId);
     const syncStatus = syncResult?.sync_status;
     if (syncStatus && isOwnedStoreLocalDataMissing(syncStatus)) {
       throw new Error(
@@ -289,7 +263,6 @@ export const pushChangesWhenStoreIsAvailable = async (
     }
 
     const hasUnconfirmed = await wallet.hasAnyUnconfirmedTransactions();
-
     const { confirmed } = await dataLayer.getRoot(storeId);
 
     if (!hasUnconfirmed && confirmed) {
@@ -313,23 +286,17 @@ export const pushChangesWhenStoreIsAvailable = async (
         throw pushError;
       }
 
-      if (!success) {
-        logger.error(
-          `RPC failed when pushing to store ${storeId}, scheduling retry in 30s.`,
-        );
-        retryPushToStore(
-          storeId,
-          changeList,
-          failedCallback,
-          retryAttempts,
-        );
-        throw new Error(
-          `Push to store ${storeId} failed (spendable/blockchain). Retry scheduled in 30s.`,
-        );
+      if (success) {
+        return;
       }
+
+      logger.error(
+        `RPC failed when pushing to store ${storeId}, retrying in 30s.`,
+      );
     } else {
-      // After 5 consecutive blocked retries, diagnose transaction health
-      if (retryAttempts > 0 && retryAttempts % 5 === 0) {
+      // Diagnose transaction health every 5 retries
+      let clearedRejectedTxs = false;
+      if (attempt > 0 && attempt % 5 === 0) {
         try {
           const dlWalletId = await wallet.getDLWalletId();
           const walletIds = dlWalletId ? ['1', dlWalletId] : ['1'];
@@ -340,15 +307,16 @@ export const pushChangesWhenStoreIsAvailable = async (
               const txIds = health.rejected.map((tx) => tx.name);
               const context =
                 `pushChangesWhenStoreIsAvailable for store ${storeId}, ` +
-                `retry ${retryAttempts}: detected ${health.rejected.length} rejected tx(s) in wallet ${wid}`;
+                `retry ${attempt}: detected ${health.rejected.length} rejected tx(s) in wallet ${wid}`;
 
               const clearResult = await wallet.clearRejectedTransactions(wid, txIds, context);
               if (clearResult.cleared) {
                 logger.info(
                   `Auto-cleared rejected txs in wallet ${wid} during push to ${storeId}. ` +
-                  `Resuming with incremented retry to prevent unbounded recursion.`,
+                  `Re-checking readiness immediately.`,
                 );
-                return pushChangesWhenStoreIsAvailable(storeId, changeList, failedCallback, retryAttempts + 1);
+                clearedRejectedTxs = true;
+                break;
               }
             }
 
@@ -365,33 +333,29 @@ export const pushChangesWhenStoreIsAvailable = async (
         }
       }
 
-      // Final retry exhaustion with diagnostic message
-      if (retryAttempts >= 60) {
-        const diagnosticMsg =
-          `Changes could not be pushed to store ${storeId} after ${retryAttempts} retries. ` +
-          `Your wallet may have unconfirmed transactions that are stuck. ` +
-          `Run 'chia wallet delete_unconfirmed_transactions -i <wallet_id>' to clear stuck transactions, then retry.`;
-        logger.error(diagnosticMsg);
+      if (clearedRejectedTxs) {
+        continue;
       }
+    }
 
-      retryPushToStore(
-        storeId,
-        changeList,
-        failedCallback,
-        retryAttempts,
-      );
-      throw new Error(
-        `Store ${storeId} not ready for push (unconfirmed tx or root). Retry scheduled in 30s.`,
-      );
+    if (attempt < MAX_PUSH_RETRIES) {
+      logger.info(`Retrying push to store ${storeId} in 30s (attempt ${attempt + 1}/${MAX_PUSH_RETRIES})`);
+      await delay(30000);
     }
   }
+
+  const diagnosticMsg =
+    `Changes could not be pushed to store ${storeId} after ${MAX_PUSH_RETRIES} retries. ` +
+    `Your wallet may have unconfirmed transactions that are stuck. ` +
+    `Run 'chia wallet delete_unconfirmed_transactions -i <wallet_id>' to clear stuck transactions, then retry.`;
+  logger.error(diagnosticMsg);
+  await failedCallback();
+  throw new Error(diagnosticMsg);
 };
 
 const pushDataLayerChangeList = (storeId, changeList, failedCallback) => {
   pushChangesWhenStoreIsAvailable(storeId, changeList, failedCallback).catch((error) => {
-    // Fire-and-forget callers don't await this, so catch here to avoid unhandled rejections.
-    // The retry is already scheduled inside pushChangesWhenStoreIsAvailable.
-    logger.debug(`pushDataLayerChangeList: push to ${storeId} deferred to retry: ${error.message}`);
+    logger.error(`pushDataLayerChangeList: push to ${storeId} failed after all retries: ${error.message}`);
   });
 };
 

--- a/src/datalayer/writeService.js
+++ b/src/datalayer/writeService.js
@@ -295,10 +295,23 @@ export const pushChangesWhenStoreIsAvailable = async (
     if (!hasUnconfirmed && confirmed) {
       logger.info(`pushing to datalayer ${storeId}`);
 
-      const success = await dataLayer.pushChangeListToDataLayer(
-        storeId,
-        changeList,
-      );
+      let success;
+      try {
+        success = await dataLayer.pushChangeListToDataLayer(
+          storeId,
+          changeList,
+        );
+      } catch (pushError) {
+        if (pushError.permanent) {
+          logger.error(
+            `Permanent push failure for store ${storeId}: ${pushError.message}. ` +
+              `Invoking failedCallback and aborting retries.`,
+          );
+          failedCallback();
+          throw pushError;
+        }
+        throw pushError;
+      }
 
       if (!success) {
         logger.error(

--- a/src/models/governance/governance.model.js
+++ b/src/models/governance/governance.model.js
@@ -7,6 +7,10 @@ import datalayer from '../../datalayer';
 import { keyValueToChangeList } from '../../utils/datalayer-utils';
 import { getConfig } from '../../utils/config-loader';
 import { logger } from '../../config/logger.js';
+import {
+  assertStoreIsOwned,
+  assertOwnedStoreLocalDataIntact,
+} from '../../utils/data-assertions';
 import PickListStub from './governance.stub.js';
 
 const { GOVERNANCE_BODY_ID } = getConfig().GOVERNANCE;
@@ -243,6 +247,13 @@ class Governance extends Model {
       );
     }
 
+    const storeId = governanceBodyId.metaValue;
+
+    await assertStoreIsOwned(storeId);
+    if (!USE_SIMULATOR) {
+      await assertOwnedStoreLocalDataIntact(storeId);
+    }
+
     const existingRecords = await Governance.findAll({ raw: true });
 
     const changeList = [];
@@ -294,12 +305,13 @@ class Governance extends Model {
     };
 
     await datalayer.pushDataLayerChangeList(
-      governanceBodyId.metaValue,
+      storeId,
       changeList,
+      rollbackChangesIfFailed,
     );
 
     datalayer.getStoreData(
-      governanceBodyId.metaValue,
+      storeId,
       onConfirm,
       rollbackChangesIfFailed,
     );

--- a/src/models/v2/governance-v2.model.js
+++ b/src/models/v2/governance-v2.model.js
@@ -9,6 +9,10 @@ import datalayer from '../../datalayer/index.js';
 import { getConfig, getConfigV2 } from '../../utils/config-loader.js';
 import { loggerV2 } from '../../config/logger.js';
 import { keyValueToChangeList } from '../../utils/datalayer-utils.js';
+import {
+  assertStoreIsOwned,
+  assertOwnedStoreLocalDataIntact,
+} from '../../utils/data-assertions.js';
 import PickListStub from '../governance/governance-v2.stub.js';
 
 import ModelTypes from './governance-v2.modeltypes.cjs';
@@ -342,6 +346,14 @@ class GovernanceV2 extends Model {
       );
     }
 
+    const storeId = governanceBodyId.meta_value;
+    const { USE_SIMULATOR } = getConfig().APP;
+
+    await assertStoreIsOwned(storeId);
+    if (!USE_SIMULATOR) {
+      await assertOwnedStoreLocalDataIntact(storeId);
+    }
+
     const existingRecords = await GovernanceV2.findAll({ raw: true });
 
     const changeList = [];
@@ -392,25 +404,23 @@ class GovernanceV2 extends Model {
       );
     };
 
-    const { USE_SIMULATOR } = getConfig().APP;
-
     if (!USE_SIMULATOR) {
       await datalayer.waitForAllTransactionsToConfirm();
     }
 
     await datalayer.pushDataLayerChangeList(
-      governanceBodyId.meta_value,
+      storeId,
       changeList,
+      rollbackChangesIfFailed,
     );
 
     if (!USE_SIMULATOR) {
       datalayer.getStoreData(
-        governanceBodyId.meta_value,
+        storeId,
         onConfirm,
         rollbackChangesIfFailed,
       );
     } else {
-      // In simulator mode, immediately confirm
       onConfirm();
     }
   }

--- a/tests/v2/integration/datalayer-push-error-handling.spec.js
+++ b/tests/v2/integration/datalayer-push-error-handling.spec.js
@@ -142,4 +142,25 @@ describe('pushChangeListToDataLayer - error handling', function () {
     // Should have called post twice (initial + retry)
     expect(superagentPostStub.callCount).to.equal(2);
   });
+
+  it('should throw a permanent error for "not owned by DL Wallet"', async function () {
+    const mock = createSuperagentMock({
+      success: false,
+      error: `Singleton with launcher ID ${testStoreId} is not owned by DL Wallet`,
+      structuredError: {
+        code: 'UNKNOWN',
+        data: {},
+        message: `Singleton with launcher ID ${testStoreId} is not owned by DL Wallet`,
+      },
+    });
+    superagentPostStub.returns(mock);
+
+    try {
+      await pushChangeListToDataLayer(testStoreId, testChangelist);
+      expect.fail('Should have thrown a permanent error');
+    } catch (error) {
+      expect(error.message).to.include('not owned');
+      expect(error.permanent).to.be.true;
+    }
+  });
 });

--- a/tests/v2/integration/governance-v2.spec.js
+++ b/tests/v2/integration/governance-v2.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
@@ -1343,6 +1344,147 @@ describe('V2 Governance Model Tests', function () {
       });
       expect(metaRecord).to.exist;
       expect(metaRecord.meta_value).to.equal(governanceBodyId);
+    });
+  });
+
+  describe('Governance Store Ownership Validation', function () {
+    beforeEach(async function () {
+      await GovernanceV2.destroy({ where: {} });
+      await MetaV2.destroy({ where: {} });
+      const { Meta } = await import('../../../src/models/index.js');
+      await Meta.destroy({ where: { metaKey: 'mainGoveranceBodyId' } });
+      await Meta.destroy({ where: { metaKey: 'governanceBodyId' } });
+    });
+
+    it('should reject update when governance store is not owned', async function () {
+      // Set a fake governanceBodyId in MetaV2 that was never created via simulator
+      await MetaV2.upsert({
+        meta_key: 'governanceBodyId',
+        meta_value: 'fake-unowned-store-id-that-does-not-exist',
+      });
+
+      // Seed existing confirmed governance data to verify it is NOT modified
+      await GovernanceV2.upsert({
+        meta_key: 'orgList',
+        meta_value: JSON.stringify([{ orgUid: 'original-org' }]),
+        confirmed: true,
+      });
+
+      let threwOwnershipError = false;
+      try {
+        await GovernanceV2.updateGoveranceBodyData([
+          { key: 'orgList', value: JSON.stringify([{ orgUid: 'new-org' }]) },
+        ]);
+      } catch (error) {
+        expect(error.message).to.include('not owned');
+        threwOwnershipError = true;
+      }
+      expect(threwOwnershipError, 'Expected ownership check to throw').to.be.true;
+
+      // Verify existing data was NOT modified
+      const orgListRecord = await GovernanceV2.findOne({
+        where: { meta_key: 'orgList' },
+      });
+      expect(orgListRecord).to.exist;
+      expect(orgListRecord.confirmed).to.be.true;
+      const parsed = JSON.parse(orgListRecord.meta_value);
+      expect(parsed).to.deep.equal([{ orgUid: 'original-org' }]);
+    });
+
+    it('should reject update via HTTP when governance store is not owned', async function () {
+      // Set up governance body with a fake store ID
+      await MetaV2.upsert({
+        meta_key: 'governanceBodyId',
+        meta_value: 'fake-unowned-store-id-that-does-not-exist',
+      });
+
+      await withConfigOverride(
+        async () => {
+          const response = await supertest(app)
+            .post('/v2/governance/meta/orgList')
+            .send([{ orgUid: 'test-org' }]);
+
+          expect(response.status).to.equal(400);
+          expect(response.body).to.have.property('success', false);
+          expect(response.body.error).to.include('not owned');
+        },
+        {
+          V2: {
+            GOVERNANCE: { GOVERNANCE_BODY_ID: '' },
+            IS_GOVERNANCE_BODY: true,
+          },
+        },
+      );
+    });
+
+    it('should succeed when governance store is owned', async function () {
+      const { Meta } = await import('../../../src/models/index.js');
+      await Meta.destroy({ where: { metaKey: 'mainGoveranceBodyId' } });
+
+      await withConfigOverride(
+        async () => {
+          // Create governance body (creates owned stores via simulator)
+          await GovernanceV2.createGoveranceBody();
+
+          // Update orgList -- should succeed because the store is owned
+          await GovernanceV2.updateGoveranceBodyData([
+            { key: 'orgList', value: JSON.stringify([{ orgUid: 'test-org' }]) },
+          ]);
+
+          const record = await GovernanceV2.findOne({
+            where: { meta_key: 'orgList' },
+          });
+          expect(record).to.exist;
+          const parsed = JSON.parse(record.meta_value);
+          expect(parsed).to.deep.equal([{ orgUid: 'test-org' }]);
+        },
+        {
+          V2: { GOVERNANCE: { GOVERNANCE_BODY_ID: '' } },
+          APP: { USE_SIMULATOR: true },
+        },
+      );
+    });
+
+    it('should pass rollback callback to pushDataLayerChangeList', async function () {
+      const { Meta } = await import('../../../src/models/index.js');
+      await Meta.destroy({ where: { metaKey: 'mainGoveranceBodyId' } });
+
+      await withConfigOverride(
+        async () => {
+          // Create governance body first
+          await GovernanceV2.createGoveranceBody();
+
+          // Seed confirmed orgList data
+          await GovernanceV2.upsert({
+            meta_key: 'orgList',
+            meta_value: JSON.stringify([{ orgUid: 'confirmed-org' }]),
+            confirmed: true,
+          });
+
+          // Stub the datalayer push to capture arguments
+          const datalayerModule = await import('../../../src/datalayer/index.js');
+          const pushStub = sinon.stub(datalayerModule.default, 'pushDataLayerChangeList');
+
+          try {
+            await GovernanceV2.updateGoveranceBodyData([
+              { key: 'orgList', value: JSON.stringify([{ orgUid: 'new-org' }]) },
+            ]);
+
+            // Verify pushDataLayerChangeList was called with a failedCallback (3rd arg)
+            expect(pushStub.calledOnce).to.be.true;
+            const [storeId, changeList, failedCallback] = pushStub.firstCall.args;
+            expect(storeId).to.be.a('string');
+            expect(changeList).to.be.an('array');
+            expect(failedCallback).to.be.a('function');
+          } finally {
+            pushStub.restore();
+          }
+        },
+        {
+          V2: { GOVERNANCE: { GOVERNANCE_BODY_ID: '' } },
+          APP: { USE_SIMULATOR: true },
+        },
+      );
     });
   });
 });

--- a/tests/v2/integration/v2-data-assertions.spec.js
+++ b/tests/v2/integration/v2-data-assertions.spec.js
@@ -12,6 +12,7 @@ import {
   assertIsActiveGovernanceBodyV2,
 } from '../../../src/utils/v2-data-assertions.js';
 import { withConfigOverride } from '../utils/v2-test-helpers.js';
+import TaskManager from '../../../src/tasks/index.js';
 
 describe('V2 Data Assertions - Utility Functions Test', function () {
   this.timeout(10000);
@@ -19,6 +20,11 @@ describe('V2 Data Assertions - Utility Functions Test', function () {
   before(async function () {
     console.log('Setting up V2 test environment...');
     await prepareV2Db();
+    TaskManager.stopAll();
+  });
+
+  after(async function () {
+    TaskManager.start(true, true);
   });
 
   describe('assertRecordExistanceOrStaged', function () {
@@ -288,24 +294,20 @@ describe('V2 Data Assertions - Utility Functions Test', function () {
     });
 
     describe('assertIsActiveGovernanceBodyV2', function () {
+      beforeEach(async function () {
+        await MetaV2.destroy({ where: { meta_key: 'governanceBodyId' } });
+      });
+
       it('should pass when governanceBodyId exists in MetaV2', async function () {
-        // Create governanceBodyId in MetaV2
         await MetaV2.create({
           meta_key: 'governanceBodyId',
           meta_value: 'test-governance-body-id-123',
         });
 
-        // Should not throw
         await assertIsActiveGovernanceBodyV2();
-
-        // Clean up
-        await MetaV2.destroy({ where: { meta_key: 'governanceBodyId' } });
       });
 
       it('should throw error when governanceBodyId does not exist in MetaV2', async function () {
-        // Ensure governanceBodyId doesn't exist
-        await MetaV2.destroy({ where: { meta_key: 'governanceBodyId' } });
-
         try {
           await assertIsActiveGovernanceBodyV2();
           expect.fail('Should have thrown an error');


### PR DESCRIPTION
## Summary

- Adds synchronous `assertStoreIsOwned` pre-flight check to both V1 and V2 governance update endpoints (`updateGoveranceBodyData`), causing an immediate HTTP 400 if the wallet doesn't own the DataLayer store — instead of silently failing in background retries
- Wires `rollbackChangesIfFailed` as `failedCallback` to `pushDataLayerChangeList` so push exhaustion restores prior governance state instead of leaving stale `confirmed: false` rows
- Detects "not owned by DL Wallet" permanent errors in `persistance.js` and short-circuits the 60-retry loop by invoking `failedCallback` immediately via `writeService.js`
- Adds integration tests for ownership rejection, callback wiring, and permanent error detection

## Context

Discovered during CI debugging that `POST /v1/governance/meta/orgList` was returning HTTP 200 and updating the local SQLite DB, but the background DataLayer push was silently failing 60 times with "Singleton not owned by DL Wallet" — leaving the system in an inconsistent state with no rollback or error surfaced to the caller.

## Files Changed

| File | Change |
|------|--------|
| `src/models/governance/governance.model.js` | Pre-flight ownership check + rollback callback wiring |
| `src/models/v2/governance-v2.model.js` | Pre-flight ownership check + rollback callback wiring |
| `src/datalayer/persistance.js` | Permanent error detection for "not owned by DL Wallet" |
| `src/datalayer/writeService.js` | Handle permanent errors without retrying |
| `tests/v2/integration/governance-v2.spec.js` | 4 new ownership validation tests |
| `tests/v2/integration/datalayer-push-error-handling.spec.js` | 1 new permanent error test |

## Test plan

- [x] V1 integration tests pass (112 passing)
- [x] V2 integration tests pass (1310 passing)
- [x] New tests verify: ownership rejection at model level, ownership rejection via HTTP, success when owned, callback wiring to push, permanent error detection and flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes modify DataLayer push/retry behavior and governance write paths, affecting how failures surface and how local DB state is rolled back. Risk is moderate due to altered retry flow and new permanent-error short-circuiting, but scope is limited to governance updates and push error handling.
> 
> **Overview**
> Governance updates (V1 and V2) now perform *pre-flight* DataLayer checks (`assertStoreIsOwned` and, outside simulator, `assertOwnedStoreLocalDataIntact`) before staging local changes, so unowned/misconfigured stores fail immediately instead of silently retrying in the background.
> 
> Push handling now propagates a **permanent** "not owned by DL Wallet" failure from `persistance.pushChangeListToDataLayer` and aborts the 60x retry loop in `writeService.pushChangesWhenStoreIsAvailable`, invoking the provided `failedCallback` for rollback. Governance update flows also now pass their rollback function into `pushDataLayerChangeList`, ensuring exhausted pushes restore prior confirmed governance rows.
> 
> Adds/updates integration tests covering permanent error detection, ownership rejection (model + HTTP), and verifying rollback callback wiring; test harness also stops/restarts background tasks to reduce flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a8b2bb69bd7602d96d8ef516b577428a41dcbe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->