### PR TITLE
test: add error recovery regression tests for org creation

### DIFF
--- a/tests/v2/integration/organization-creation-status-v2.spec.js
+++ b/tests/v2/integration/organization-creation-status-v2.spec.js
@@ -422,6 +422,7 @@ describe('Organization Creation Status Tests', function () {
 
       try {
         await OrganizationsV2.createHomeOrganization('FailTest V2', '', 'v2');
+        expect.fail('createHomeOrganization should have thrown');
       } catch (e) {
         expect(e.message).to.equal('simulated store creation failure');
       }
@@ -444,6 +445,7 @@ describe('Organization Creation Status Tests', function () {
 
       try {
         await Organization.createHomeOrganization('FailTest V1', '', 'v1');
+        expect.fail('createHomeOrganization should have thrown');
       } catch (e) {
         expect(e.message).to.equal('simulated V1 store failure');
       }

--- a/tests/v2/integration/organization-creation-status-v2.spec.js
+++ b/tests/v2/integration/organization-creation-status-v2.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db, sequelizeV2 } from '../../../src/database/v2/index.js';
@@ -407,6 +408,155 @@ describe('Organization Creation Status Tests', function () {
       state.state = ORG_CREATION_STATES.FAILED;
       summary = getStatusSummary(state);
       expect(summary.progress).to.equal(-1);
+    });
+  });
+
+  describe('Error Recovery - State marked FAILED on failure', function () {
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('should mark V2 state as FAILED when _executeOrganizationCreation throws', async function () {
+      sinon.stub(OrganizationsV2, '_executeOrganizationCreation')
+        .rejects(new Error('simulated store creation failure'));
+
+      try {
+        await OrganizationsV2.createHomeOrganization('FailTest V2', '', 'v2');
+      } catch (e) {
+        expect(e.message).to.equal('simulated store creation failure');
+      }
+
+      const failedState = await loadCreationState(MetaV2, 'v2');
+      expect(failedState).to.exist;
+      expect(failedState.state).to.equal(ORG_CREATION_STATES.FAILED);
+      expect(failedState.error).to.include('simulated store creation failure');
+
+      const pendingOrg = await OrganizationsV2.findOne({
+        where: { org_uid: 'PENDING' },
+        raw: true,
+      });
+      expect(pendingOrg).to.be.null;
+    });
+
+    it('should mark V1 state as FAILED when _executeOrganizationCreation throws', async function () {
+      sinon.stub(Organization, '_executeOrganizationCreation')
+        .rejects(new Error('simulated V1 store failure'));
+
+      try {
+        await Organization.createHomeOrganization('FailTest V1', '', 'v1');
+      } catch (e) {
+        expect(e.message).to.equal('simulated V1 store failure');
+      }
+
+      const failedState = await loadCreationState(Meta, 'v1');
+      expect(failedState).to.exist;
+      expect(failedState.state).to.equal(ORG_CREATION_STATES.FAILED);
+      expect(failedState.error).to.include('simulated V1 store failure');
+
+      const pendingOrg = await Organization.findOne({
+        where: { orgUid: 'PENDING' },
+        raw: true,
+      });
+      expect(pendingOrg).to.be.null;
+    });
+  });
+
+  describe('Error Recovery - getStatusSummary stale detection', function () {
+    it('should report timed-out INITIALIZING state as not in progress', function () {
+      const state = createInitialState('Stale Org', '', 'v2', 'v2');
+      state.startedAt = new Date(
+        Date.now() - ORG_CREATION_CONFIG.STORE_CONFIRMATION_TIMEOUT_MS - 60000,
+      ).toISOString();
+
+      const summary = getStatusSummary(state);
+      expect(summary.inProgress).to.be.false;
+      expect(summary.progress).to.equal(-1);
+      expect(summary.message).to.include('stale');
+    });
+
+    it('should report timed-out STORES_CREATING state as not in progress', function () {
+      const state = createInitialState('Stale Org', '', 'v2', 'v2');
+      state.state = ORG_CREATION_STATES.STORES_CREATING;
+      state.startedAt = new Date(
+        Date.now() - ORG_CREATION_CONFIG.STORE_CONFIRMATION_TIMEOUT_MS - 60000,
+      ).toISOString();
+
+      const summary = getStatusSummary(state);
+      expect(summary.inProgress).to.be.false;
+      expect(summary.progress).to.equal(-1);
+      expect(summary.state).to.equal(ORG_CREATION_STATES.STORES_CREATING);
+    });
+
+    it('should NOT report FAILED state as stale even if timed out', function () {
+      const state = createInitialState('Failed Org', '', 'v2', 'v2');
+      state.state = ORG_CREATION_STATES.FAILED;
+      state.error = 'Previous failure';
+      state.startedAt = new Date(
+        Date.now() - ORG_CREATION_CONFIG.STORE_CONFIRMATION_TIMEOUT_MS - 60000,
+      ).toISOString();
+
+      const summary = getStatusSummary(state);
+      expect(summary.inProgress).to.be.false;
+      expect(summary.message).to.not.include('stale');
+      expect(summary.message).to.include('failed');
+    });
+  });
+
+  describe('Error Recovery - Creation after previous failure', function () {
+    it('should create V2 org after previous FAILED state', async function () {
+      if (!USE_SIMULATOR) {
+        this.skip();
+      }
+
+      const failedState = createInitialState('Old Failed Org', '', 'v2', 'v2');
+      failedState.state = ORG_CREATION_STATES.FAILED;
+      failedState.error = 'Previous attempt failed';
+      await saveCreationState(failedState, MetaV2);
+
+      const response = await supertest(app)
+        .post('/v2/organizations')
+        .send({ name: 'Recovery Org V2', icon: '' })
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.orgUid).to.exist;
+
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const org = await OrganizationsV2.findOne({ where: { is_home: true }, raw: true });
+      expect(org).to.exist;
+      expect(org.name).to.equal('Recovery Org V2');
+    });
+
+    it('should create V1 org after previous FAILED state', async function () {
+      if (!USE_SIMULATOR) {
+        this.skip();
+      }
+
+      const failedState = createInitialState('Old Failed Org', '', 'v1', 'v1');
+      failedState.state = ORG_CREATION_STATES.FAILED;
+      failedState.error = 'Previous attempt failed';
+      await saveCreationState(failedState, Meta);
+
+      const response = await supertest(app)
+        .post('/v1/organizations')
+        .send({ name: 'Recovery Org V1', icon: '' });
+
+      expect(response.status).to.not.equal(409);
+      expect(response.body.success).to.be.true;
+
+      let org = null;
+      for (let attempt = 1; attempt <= 40; attempt++) {
+        const candidate = await Organization.findOne({ where: { isHome: true }, raw: true });
+        if (candidate && candidate.orgUid !== 'PENDING') {
+          org = candidate;
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 250));
+      }
+
+      expect(org).to.exist;
+      expect(org.name).to.equal('Recovery Org V1');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add 7 regression tests for the three bugs fixed in #1546 (state not marked FAILED on error, stale state permanently blocking new attempts, `getStatusSummary` inconsistency for timed-out states)
- **Sinon stub tests** verify the `createHomeOrganization` catch block correctly marks Meta state as FAILED and cleans up the PENDING record (V1 + V2)
- **Pure function tests** verify `getStatusSummary` reports timed-out states as `inProgress: false` and distinguishes stale from genuinely failed states
- **API round-trip tests** verify organization creation succeeds after a previous FAILED state is seeded (V1 + V2)

## Test plan

- [x] All 1321 v2 integration tests pass (`npm run test:v2`)
- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds/extends integration tests only; no production logic changes, with low risk beyond potential test flakiness due to async/polling behavior.
> 
> **Overview**
> Adds new regression coverage around organization-creation error recovery in `organization-creation-status-v2.spec.js`.
> 
> Tests now verify that when `createHomeOrganization` fails (V1 and V2), the creation state is persisted as `FAILED`, the error is recorded, and any `PENDING` org record is cleaned up; `getStatusSummary` also treats timed-out states as *not in progress* while not mislabeling genuine `FAILED` states as stale. Finally, API-level tests confirm a new org creation attempt succeeds after seeding a previous `FAILED` state (V1 and V2, simulator mode).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a19db538fb4a76ef111731f098ab809879d3219a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->