### PR TITLE
fix: scope mirror check to subscribed stores and prevent concurrent runs

### DIFF
--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -52,7 +52,7 @@ import {
   clearCreationState,
   hasInProgressCreation,
 } from '../../utils/organization-creation-state.js';
-import { runMirrorCheck } from '../../tasks/mirror-check.js';
+import { mirrorOrgStores } from '../../tasks/mirror-check.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
 const { isTransientWalletError } = wallet;
@@ -448,9 +448,15 @@ class Organization extends Model {
 
       logState(state, `Organization creation complete. orgUid: ${orgUid}`);
 
-      // Fire-and-forget: the periodic mirror-check task will also handle this.
-      runMirrorCheck().catch((mirrorError) => {
-        logState(state, `Mirror check failed (will be retried by periodic task): ${mirrorError.message}`, 'warn');
+      // Fire-and-forget: mirror only this org's stores rather than running
+      // a full mirror check across all orgs. The periodic task handles the rest.
+      mirrorOrgStores({
+        orgUid,
+        registryId,
+        dataModelVersionStoreId,
+        fileStoreId,
+      }).catch((mirrorError) => {
+        logState(state, `Mirror creation failed (will be retried by periodic task): ${mirrorError.message}`, 'warn');
       });
 
       return orgUid;

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -73,7 +73,7 @@ import {
 } from '../../utils/organization-creation-state.js';
 
 import ModelTypes from './organizations-v2.modeltypes.cjs';
-import { runMirrorCheckV2 } from '../../tasks/mirror-check-v2.js';
+import { mirrorOrgStoresV2 } from '../../tasks/mirror-check-v2.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
 const { isTransientWalletError } = wallet;
@@ -480,9 +480,15 @@ class OrganizationsV2 extends Model {
 
       logState(state, `Organization creation complete. orgUid: ${orgUid}`);
 
-      // Fire-and-forget: the periodic mirror-check task will also handle this.
-      runMirrorCheckV2().catch((mirrorError) => {
-        logState(state, `Mirror check failed (will be retried by periodic task): ${mirrorError.message}`, 'warn');
+      // Fire-and-forget: mirror only this org's stores rather than running
+      // a full mirror check across all orgs. The periodic task handles the rest.
+      mirrorOrgStoresV2({
+        orgUid,
+        registryId,
+        dataModelVersionStoreId,
+        fileStoreId,
+      }).catch((mirrorError) => {
+        logState(state, `Mirror creation failed (will be retried by periodic task): ${mirrorError.message}`, 'warn');
       });
 
       return orgUid;
@@ -1097,9 +1103,15 @@ class OrganizationsV2 extends Model {
           { where: { org_uid: v1OrgUid } },
         );
 
-        // Fire-and-forget: the periodic mirror-check task will also handle this.
-        runMirrorCheckV2().catch((mirrorError) => {
-          loggerV2.warn(`[v2]: Mirror check failed (will be retried by periodic task): ${mirrorError.message}`);
+        // Fire-and-forget: mirror only this org's stores rather than running
+        // a full mirror check across all orgs. The periodic task handles the rest.
+        mirrorOrgStoresV2({
+          orgUid: v1OrgUid,
+          registryId: newV2RegistryStoreId,
+          dataModelVersionStoreId: sharedDataModelVersionStoreId,
+          fileStoreId: v1FileStoreId,
+        }).catch((mirrorError) => {
+          loggerV2.warn(`[v2]: Mirror creation failed (will be retried by periodic task): ${mirrorError.message}`);
         });
       };
 

--- a/src/tasks/mirror-check-v2.js
+++ b/src/tasks/mirror-check-v2.js
@@ -12,45 +12,29 @@ import {
   decodeHex,
 } from '../utils/datalayer-utils.js';
 import datalayer from '../datalayer/index.js';
+import { getSubscriptions } from '../datalayer/persistance.js';
 import dotenv from 'dotenv';
 
 const APP_CONFIG = getConfig().APP;
 dotenv.config({ quiet: true });
 
-// This task checks if there are any mirrors that have not been properly mirrored and then mirrors them if not
-
 let mirrorCheckInProgress = false;
 
 const task = new Task('mirror-check-v2', async () => {
-  loggerV2.silly('[v2]: [MIRROR_DEBUG] Mirror-check V2 task started');
-
   try {
-    loggerV2.silly('[v2]: [MIRROR_DEBUG] Checking data layer availability');
     await assertDataLayerAvailable();
-    loggerV2.silly('[v2]: [MIRROR_DEBUG] Data layer is available');
-
-    loggerV2.silly('[v2]: [MIRROR_DEBUG] Checking wallet sync status');
     await assertWalletIsSynced();
-    loggerV2.silly('[v2]: [MIRROR_DEBUG] Wallet is synced');
 
-    // Default AUTO_MIRROR_EXTERNAL_STORES to true if it is null or undefined
     const shouldMirror = APP_CONFIG?.AUTO_MIRROR_EXTERNAL_STORES ?? true;
-    loggerV2.debug(
-      `[v2]: [MIRROR_DEBUG] AUTO_MIRROR_EXTERNAL_STORES: ${shouldMirror}, USE_SIMULATOR: ${APP_CONFIG.USE_SIMULATOR}`,
-    );
 
     if (!APP_CONFIG.USE_SIMULATOR && shouldMirror) {
-      loggerV2.silly('[v2]: [MIRROR_DEBUG] Conditions met, running mirror check');
       await runMirrorCheckV2();
-    } else {
-      loggerV2.silly('[v2]: [MIRROR_DEBUG] Skipping mirror check - conditions not met');
     }
   } catch (error) {
     loggerV2.error(
-      `[v2]: Retrying in ${APP_CONFIG?.TASKS?.MIRROR_CHECK_TASK_INTERVAL || 300} seconds`,
+      `[v2]: Mirror check failed. Retrying in ${APP_CONFIG?.TASKS?.MIRROR_CHECK_TASK_INTERVAL || 300} seconds`,
       error,
     );
-    loggerV2.silly(`[v2]: [MIRROR_DEBUG] Mirror-check V2 task error: ${error.message}`);
   }
 });
 
@@ -64,21 +48,16 @@ const job = new SimpleIntervalJob(
 );
 
 const runMirrorCheckV2Inner = async () => {
-  loggerV2.silly('[v2]: [MIRROR_DEBUG] Starting runMirrorCheckV2 function');
-
   const mirrorUrl = await getMirrorUrl();
-  loggerV2.silly(`[v2]: [MIRROR_DEBUG] Retrieved mirror URL: ${mirrorUrl}`);
 
   if (!mirrorUrl) {
     loggerV2.info(
       '[v2]: DATALAYER_FILE_SERVER_URL not set, skipping mirror announcements',
     );
-    loggerV2.silly('[v2]: [MIRROR_DEBUG] Exiting runMirrorCheckV2 - no mirror URL');
     return;
   }
 
-  // get governance info if governance node
-  loggerV2.silly('[v2]: [MIRROR_DEBUG] Checking for V2 governance organization info');
+  // Mirror governance stores
   const governanceOrgUidResult = await MetaV2.findOne({
     where: { meta_key: 'governanceBodyId' },
     attributes: ['meta_value'],
@@ -90,20 +69,10 @@ const runMirrorCheckV2Inner = async () => {
     raw: true,
   });
 
-  loggerV2.debug(
-    `[v2]: [MIRROR_DEBUG] Governance org UID result: ${governanceOrgUidResult?.meta_value || 'null'}`,
-  );
-  loggerV2.debug(
-    `[v2]: [MIRROR_DEBUG] Governance registry ID result: ${governanceRegistryIdResult?.meta_value || 'null'}`,
-  );
-
   if (
     governanceOrgUidResult?.meta_value &&
     governanceRegistryIdResult?.meta_value
   ) {
-    loggerV2.silly('[v2]: [MIRROR_DEBUG] Adding governance mirrors');
-    // add governance mirrors if instance is governance
-    // There is logic within the addMirror function to check if the mirror already exists
     await OrganizationsV2.addMirror(
       governanceOrgUidResult?.meta_value,
       mirrorUrl,
@@ -114,30 +83,20 @@ const runMirrorCheckV2Inner = async () => {
       mirrorUrl,
       true,
     );
-    loggerV2.silly('[v2]: [MIRROR_DEBUG] Completed governance mirror additions');
   } else {
-    // Mirror governance stores for subscriber nodes that have a configured
-    // GOVERNANCE_BODY_ID but are not governance body owners (no meta entries).
     const configGovernanceBodyId =
       getConfigV2().GOVERNANCE?.GOVERNANCE_BODY_ID;
 
     if (configGovernanceBodyId) {
-      loggerV2.debug(
-        `[v2]: [MIRROR_DEBUG] Subscriber node with v2 GOVERNANCE_BODY_ID: ${configGovernanceBodyId}, mirroring governance stores`,
-      );
-
       try {
         await OrganizationsV2.addMirror(
           configGovernanceBodyId,
           mirrorUrl,
           true,
         );
-        loggerV2.debug(
-          `[v2]: [MIRROR_DEBUG] Mirror ensured for v2 governance body: ${configGovernanceBodyId}`,
-        );
       } catch (error) {
         loggerV2.error(
-          `[v2]: [MIRROR_DEBUG] Failed to mirror v2 governance body ${configGovernanceBodyId}: ${error.message}`,
+          `[v2]: Failed to mirror governance body ${configGovernanceBodyId}: ${error.message}`,
         );
       }
 
@@ -150,134 +109,69 @@ const runMirrorCheckV2Inner = async () => {
           const versionStoreId = decodeHex(versionStoreIdHex);
           if (versionStoreId) {
             await OrganizationsV2.addMirror(versionStoreId, mirrorUrl, true);
-            loggerV2.debug(
-              `[v2]: [MIRROR_DEBUG] Mirror ensured for v2 governance version store: ${versionStoreId}`,
-            );
           }
-        } else {
-          loggerV2.debug(
-            `[v2]: [MIRROR_DEBUG] Could not resolve v2 governance version store from ${configGovernanceBodyId}`,
-          );
         }
       } catch (error) {
         loggerV2.error(
-          `[v2]: [MIRROR_DEBUG] Failed to resolve/mirror v2 governance version store: ${error.message}`,
+          `[v2]: Failed to resolve/mirror governance version store: ${error.message}`,
         );
       }
-    } else {
-      loggerV2.debug(
-        '[v2]: [MIRROR_DEBUG] Skipping governance mirrors - no governance data and no GOVERNANCE_BODY_ID configured',
-      );
     }
   }
 
-  loggerV2.silly('[v2]: [MIRROR_DEBUG] Retrieving V2 organizations map');
-  const organizations = await OrganizationsV2.getOrgsMap();
-  loggerV2.debug(
-    `[v2]: [MIRROR_DEBUG] Retrieved ${Object.keys(organizations).length} organizations from getOrgsMap()`,
-  );
-  loggerV2.debug(
-    `[v2]: [MIRROR_DEBUG] Organizations: ${JSON.stringify(Object.keys(organizations))}`,
-  );
+  // Fetch DataLayer subscriptions to avoid mirroring unsubscribed stores.
+  // Owned stores appear in this list too, so it covers both home and external orgs.
+  const { storeIds: subscribedStoreIds, success: subsSuccess } =
+    await getSubscriptions();
+  const subscribedSet = subsSuccess ? new Set(subscribedStoreIds) : null;
 
+  if (!subsSuccess) {
+    loggerV2.warn(
+      '[v2]: Could not fetch DataLayer subscriptions; will attempt mirrors for all stores',
+    );
+  }
+
+  const organizations = await OrganizationsV2.getOrgsMap();
   const orgs = Object.keys(organizations);
-  loggerV2.silly(`[v2]: [MIRROR_DEBUG] Processing ${orgs.length} organizations`);
+  loggerV2.info(`[v2]: Mirror check processing ${orgs.length} organizations`);
 
   for (const org of orgs) {
-    loggerV2.silly(`[v2]: [MIRROR_DEBUG] Processing organization: ${org}`);
     const orgData = organizations[org];
-    loggerV2.debug(
-      `[v2]: [MIRROR_DEBUG] Organization data: ${JSON.stringify({
-        name: orgData.name,
-        subscribed: orgData.subscribed,
-        org_uid: orgData.org_uid,
-        data_model_version_store_id: orgData.data_model_version_store_id,
-        registry_id: orgData.registry_id,
-        file_store_subscribed: orgData.file_store_subscribed,
-      })}`,
-    );
 
-    if (orgData.subscribed) {
-      loggerV2.debug(
-        `[v2]: [MIRROR_DEBUG] Organization ${org} is subscribed, adding mirrors`,
-      );
-      try {
-        await OrganizationsV2.addMirror(orgData.org_uid, mirrorUrl, true);
+    if (!orgData.subscribed) {
+      continue;
+    }
+
+    const storesToMirror = [
+      { label: 'org_uid', id: orgData.org_uid },
+      { label: 'data_model_version_store_id', id: orgData.data_model_version_store_id },
+      { label: 'registry_id', id: orgData.registry_id },
+      { label: 'file_store', id: orgData.file_store_subscribed },
+    ];
+
+    for (const { label, id } of storesToMirror) {
+      if (!id) {
+        continue;
+      }
+
+      if (subscribedSet && !subscribedSet.has(id)) {
         loggerV2.debug(
-          `[v2]: [MIRROR_DEBUG] Mirror ensured for org_uid: ${orgData.org_uid}`,
+          `[v2]: Skipping mirror for ${label} ${id} (${orgData.name}) - not subscribed in DataLayer`,
         );
+        continue;
+      }
+
+      try {
+        await OrganizationsV2.addMirror(id, mirrorUrl, true);
       } catch (error) {
         loggerV2.error(
-          `[v2]: [MIRROR_DEBUG] Failed to ensure mirror for org_uid ${orgData.org_uid}: ${error.message}`,
+          `[v2]: Failed to ensure mirror for ${label} ${id} (${orgData.name}): ${error.message}`,
         );
       }
-
-      if (orgData.data_model_version_store_id) {
-        try {
-          await OrganizationsV2.addMirror(
-            orgData.data_model_version_store_id,
-            mirrorUrl,
-            true,
-          );
-          loggerV2.debug(
-            `[v2]: [MIRROR_DEBUG] Mirror ensured for data_model_version_store_id: ${orgData.data_model_version_store_id}`,
-          );
-        } catch (error) {
-          loggerV2.error(
-            `[v2]: [MIRROR_DEBUG] Failed to ensure mirror for data_model_version_store_id ${orgData.data_model_version_store_id}: ${error.message}`,
-          );
-        }
-      } else {
-        loggerV2.debug(
-          `[v2]: [MIRROR_DEBUG] Skipping data_model_version_store_id mirror - value is null/undefined`,
-        );
-      }
-
-      if (orgData.registry_id) {
-        try {
-          await OrganizationsV2.addMirror(orgData.registry_id, mirrorUrl, true);
-          loggerV2.debug(
-            `[v2]: [MIRROR_DEBUG] Mirror ensured for registry_id: ${orgData.registry_id}`,
-          );
-        } catch (error) {
-          loggerV2.error(
-            `[v2]: [MIRROR_DEBUG] Failed to ensure mirror for registry_id ${orgData.registry_id}: ${error.message}`,
-          );
-        }
-      } else {
-        loggerV2.debug(
-          `[v2]: [MIRROR_DEBUG] Skipping registry_id mirror - value is null/undefined`,
-        );
-      }
-
-      if (orgData.file_store_subscribed) {
-        try {
-          await OrganizationsV2.addMirror(
-            orgData.file_store_subscribed,
-            mirrorUrl,
-            true,
-          );
-          loggerV2.debug(
-            `[v2]: [MIRROR_DEBUG] Mirror ensured for file_store: ${orgData.file_store_subscribed}`,
-          );
-        } catch (error) {
-          loggerV2.error(
-            `[v2]: [MIRROR_DEBUG] Failed to ensure mirror for file_store ${orgData.file_store_subscribed}: ${error.message}`,
-          );
-        }
-      } else {
-        loggerV2.debug(
-          `[v2]: [MIRROR_DEBUG] Skipping file_store mirror - value is null/undefined`,
-        );
-      }
-    } else {
-      loggerV2.debug(
-        `[v2]: [MIRROR_DEBUG] Organization ${org} is not subscribed, skipping`,
-      );
     }
   }
 
-  loggerV2.silly('[v2]: [MIRROR_DEBUG] Completed runMirrorCheckV2 function');
+  loggerV2.info('[v2]: Mirror check complete');
 };
 
 const runMirrorCheckV2 = async () => {
@@ -293,6 +187,34 @@ const runMirrorCheckV2 = async () => {
   }
 };
 
+/**
+ * Mirror only the stores belonging to a specific organization.
+ * Used by org creation / upgrade finalization to avoid running a full mirror
+ * check across all orgs, which is slow and can conflict with the periodic task.
+ * @param {Object} storeIds - Map of store labels to store IDs
+ * @param {string} storeIds.orgUid
+ * @param {string} [storeIds.registryId]
+ * @param {string} [storeIds.dataModelVersionStoreId]
+ * @param {string} [storeIds.fileStoreId]
+ */
+const mirrorOrgStoresV2 = async (storeIds) => {
+  const mirrorUrl = await getMirrorUrl();
+  if (!mirrorUrl) {
+    return;
+  }
+
+  const entries = Object.entries(storeIds).filter(([, id]) => id);
+  for (const [label, id] of entries) {
+    try {
+      await OrganizationsV2.addMirror(id, mirrorUrl, true);
+    } catch (error) {
+      loggerV2.warn(
+        `[v2]: Failed to mirror ${label} ${id} (will be retried by periodic task): ${error.message}`,
+      );
+    }
+  }
+};
+
 export default job;
-export { runMirrorCheckV2 };
+export { runMirrorCheckV2, mirrorOrgStoresV2 };
 

--- a/src/tasks/mirror-check.js
+++ b/src/tasks/mirror-check.js
@@ -8,43 +8,29 @@ import { logger } from '../config/logger.js';
 import { getConfig } from '../utils/config-loader';
 import { getMirrorUrl, encodeHex, decodeHex } from '../utils/datalayer-utils';
 import datalayer from '../datalayer';
+import { getSubscriptions } from '../datalayer/persistance';
 import dotenv from 'dotenv';
 
 const APP_CONFIG = getConfig().APP;
 dotenv.config({ quiet: true });
 
-// This task checks if there are any mirrors that have not been properly mirrored and then mirrors them if not
+let mirrorCheckInProgress = false;
 
 const task = new Task('mirror-check', async () => {
-  logger.silly('[v1]: [MIRROR_DEBUG] Mirror-check task started');
-
   try {
-    logger.silly('[v1]: [MIRROR_DEBUG] Checking data layer availability');
     await assertDataLayerAvailable();
-    logger.silly('[v1]: [MIRROR_DEBUG] Data layer is available');
-
-    logger.silly('[v1]: [MIRROR_DEBUG] Checking wallet sync status');
     await assertWalletIsSynced();
-    logger.silly('[v1]: [MIRROR_DEBUG] Wallet is synced');
 
-    // Default AUTO_MIRROR_EXTERNAL_STORES to true if it is null or undefined
     const shouldMirror = APP_CONFIG?.AUTO_MIRROR_EXTERNAL_STORES ?? true;
-    logger.debug(
-      `[MIRROR_DEBUG] AUTO_MIRROR_EXTERNAL_STORES: ${shouldMirror}, USE_SIMULATOR: ${APP_CONFIG.USE_SIMULATOR}`,
-    );
 
     if (!APP_CONFIG.USE_SIMULATOR && shouldMirror) {
-      logger.silly('[v1]: [MIRROR_DEBUG] Conditions met, running mirror check');
       await runMirrorCheck();
-    } else {
-      logger.silly('[v1]: [MIRROR_DEBUG] Skipping mirror check - conditions not met');
     }
   } catch (error) {
     logger.error(
-      `Retrying in ${APP_CONFIG?.TASKS?.MIRROR_CHECK_TASK_INTERVAL || 300} seconds`,
+      `[v1]: Mirror check failed. Retrying in ${APP_CONFIG?.TASKS?.MIRROR_CHECK_TASK_INTERVAL || 300} seconds`,
       error,
     );
-    logger.silly(`[v1]: [MIRROR_DEBUG] Mirror-check task error: ${error.message}`);
   }
 });
 
@@ -57,22 +43,17 @@ const job = new SimpleIntervalJob(
   { id: 'mirror-check', preventOverrun: true },
 );
 
-const runMirrorCheck = async () => {
-  logger.silly('[v1]: [MIRROR_DEBUG] Starting runMirrorCheck function');
-
+const runMirrorCheckInner = async () => {
   const mirrorUrl = await getMirrorUrl();
-  logger.silly(`[v1]: [MIRROR_DEBUG] Retrieved mirror URL: ${mirrorUrl}`);
 
   if (!mirrorUrl) {
     logger.info(
-      'DATALAYER_FILE_SERVER_URL not set, skipping mirror announcements',
+      '[v1]: DATALAYER_FILE_SERVER_URL not set, skipping mirror announcements',
     );
-    logger.silly('[v1]: [MIRROR_DEBUG] Exiting runMirrorCheck - no mirror URL');
     return;
   }
 
-  // get governance info if governance node
-  logger.silly('[v1]: [MIRROR_DEBUG] Checking for governance organization info');
+  // Mirror governance stores
   const governanceOrgUidResult = await Meta.findOne({
     where: { metaKey: 'governanceBodyId' },
     attributes: ['metaValue'],
@@ -84,20 +65,10 @@ const runMirrorCheck = async () => {
     raw: true,
   });
 
-  logger.debug(
-    `[MIRROR_DEBUG] Governance org UID result: ${governanceOrgUidResult?.metaValue || 'null'}`,
-  );
-  logger.debug(
-    `[MIRROR_DEBUG] Governance registry ID result: ${governanceRegistryIdResult?.metaValue || 'null'}`,
-  );
-
   if (
     governanceOrgUidResult?.metaValue &&
     governanceRegistryIdResult?.metaValue
   ) {
-    logger.silly('[v1]: [MIRROR_DEBUG] Adding governance mirrors');
-    // add governance mirrors if instance is governance
-    // There is logic within the addMirror function to check if the mirror already exists
     await Organization.addMirror(
       governanceOrgUidResult?.metaValue,
       mirrorUrl,
@@ -108,26 +79,16 @@ const runMirrorCheck = async () => {
       mirrorUrl,
       true,
     );
-    logger.silly('[v1]: [MIRROR_DEBUG] Completed governance mirror additions');
   } else {
-    // Mirror governance stores for subscriber nodes that have a configured
-    // GOVERNANCE_BODY_ID but are not governance body owners (no meta entries).
     const configGovernanceBodyId =
       getConfig().GOVERNANCE?.GOVERNANCE_BODY_ID;
 
     if (configGovernanceBodyId) {
-      logger.debug(
-        `[MIRROR_DEBUG] Subscriber node with v1 GOVERNANCE_BODY_ID: ${configGovernanceBodyId}, mirroring governance stores`,
-      );
-
       try {
         await Organization.addMirror(configGovernanceBodyId, mirrorUrl, true);
-        logger.debug(
-          `[MIRROR_DEBUG] Mirror ensured for v1 governance body: ${configGovernanceBodyId}`,
-        );
       } catch (error) {
         logger.error(
-          `[MIRROR_DEBUG] Failed to mirror v1 governance body ${configGovernanceBodyId}: ${error.message}`,
+          `[v1]: Failed to mirror governance body ${configGovernanceBodyId}: ${error.message}`,
         );
       }
 
@@ -140,131 +101,111 @@ const runMirrorCheck = async () => {
           const versionStoreId = decodeHex(versionStoreIdHex);
           if (versionStoreId) {
             await Organization.addMirror(versionStoreId, mirrorUrl, true);
-            logger.debug(
-              `[MIRROR_DEBUG] Mirror ensured for v1 governance version store: ${versionStoreId}`,
-            );
           }
-        } else {
-          logger.debug(
-            `[MIRROR_DEBUG] Could not resolve v1 governance version store from ${configGovernanceBodyId}`,
-          );
         }
       } catch (error) {
         logger.error(
-          `[MIRROR_DEBUG] Failed to resolve/mirror v1 governance version store: ${error.message}`,
+          `[v1]: Failed to resolve/mirror governance version store: ${error.message}`,
         );
       }
-    } else {
-      logger.debug(
-        '[MIRROR_DEBUG] Skipping governance mirrors - no governance data and no GOVERNANCE_BODY_ID configured',
-      );
     }
   }
 
-  logger.silly('[v1]: [MIRROR_DEBUG] Retrieving organizations map');
-  const organizations = await Organization.getOrgsMap();
-  logger.debug(
-    `[MIRROR_DEBUG] Retrieved ${Object.keys(organizations).length} organizations from getOrgsMap()`,
-  );
-  logger.debug(
-    `[MIRROR_DEBUG] Organizations: ${JSON.stringify(Object.keys(organizations))}`,
-  );
+  // Fetch DataLayer subscriptions to avoid mirroring unsubscribed stores.
+  // Owned stores appear in this list too, so it covers both home and external orgs.
+  const { storeIds: subscribedStoreIds, success: subsSuccess } =
+    await getSubscriptions();
+  const subscribedSet = subsSuccess ? new Set(subscribedStoreIds) : null;
 
+  if (!subsSuccess) {
+    logger.warn(
+      '[v1]: Could not fetch DataLayer subscriptions; will attempt mirrors for all stores',
+    );
+  }
+
+  const organizations = await Organization.getOrgsMap();
   const orgs = Object.keys(organizations);
-  logger.silly(`[v1]: [MIRROR_DEBUG] Processing ${orgs.length} organizations`);
+  logger.info(`[v1]: Mirror check processing ${orgs.length} organizations`);
 
   for (const org of orgs) {
-    logger.silly(`[v1]: [MIRROR_DEBUG] Processing organization: ${org}`);
     const orgData = organizations[org];
-    logger.debug(
-      `[MIRROR_DEBUG] Organization data: ${JSON.stringify({
-        name: orgData.name,
-        subscribed: orgData.subscribed,
-        orgUid: orgData.orgUid,
-        dataModelVersionStoreId: orgData.dataModelVersionStoreId,
-        registryId: orgData.registryId,
-        fileStoreId: orgData.fileStoreId,
-      })}`,
-    );
 
-    if (orgData.subscribed) {
-      logger.debug(
-        `[MIRROR_DEBUG] Organization ${org} is subscribed, adding mirrors`,
-      );
-      try {
-        await Organization.addMirror(orgData.orgUid, mirrorUrl, true);
+    if (!orgData.subscribed) {
+      continue;
+    }
+
+    const storesToMirror = [
+      { label: 'orgUid', id: orgData.orgUid },
+      { label: 'dataModelVersionStoreId', id: orgData.dataModelVersionStoreId },
+      { label: 'registryId', id: orgData.registryId },
+      { label: 'fileStoreId', id: orgData.fileStoreId },
+    ];
+
+    for (const { label, id } of storesToMirror) {
+      if (!id) {
+        continue;
+      }
+
+      if (subscribedSet && !subscribedSet.has(id)) {
         logger.debug(
-          `[MIRROR_DEBUG] Mirror ensured for orgUid: ${orgData.orgUid}`,
+          `[v1]: Skipping mirror for ${label} ${id} (${orgData.name}) - not subscribed in DataLayer`,
         );
+        continue;
+      }
+
+      try {
+        await Organization.addMirror(id, mirrorUrl, true);
       } catch (error) {
         logger.error(
-          `[MIRROR_DEBUG] Failed to ensure mirror for orgUid ${orgData.orgUid}: ${error.message}`,
+          `[v1]: Failed to ensure mirror for ${label} ${id} (${orgData.name}): ${error.message}`,
         );
       }
-
-      if (orgData.dataModelVersionStoreId) {
-        try {
-          await Organization.addMirror(
-            orgData.dataModelVersionStoreId,
-            mirrorUrl,
-            true,
-          );
-          logger.debug(
-            `[MIRROR_DEBUG] Mirror ensured for dataModelVersionStoreId: ${orgData.dataModelVersionStoreId}`,
-          );
-        } catch (error) {
-          logger.error(
-            `[MIRROR_DEBUG] Failed to ensure mirror for dataModelVersionStoreId ${orgData.dataModelVersionStoreId}: ${error.message}`,
-          );
-        }
-      } else {
-        logger.debug(
-          `[MIRROR_DEBUG] Skipping dataModelVersionStoreId mirror - value is null/undefined`,
-        );
-      }
-
-      if (orgData.registryId) {
-        try {
-          await Organization.addMirror(orgData.registryId, mirrorUrl, true);
-          logger.debug(
-            `[MIRROR_DEBUG] Mirror ensured for registryId: ${orgData.registryId}`,
-          );
-        } catch (error) {
-          logger.error(
-            `[MIRROR_DEBUG] Failed to ensure mirror for registryId ${orgData.registryId}: ${error.message}`,
-          );
-        }
-      } else {
-        logger.debug(
-          `[MIRROR_DEBUG] Skipping registryId mirror - value is null/undefined`,
-        );
-      }
-
-      if (orgData.fileStoreId) {
-        try {
-          await Organization.addMirror(orgData.fileStoreId, mirrorUrl, true);
-          logger.debug(
-            `[MIRROR_DEBUG] Mirror ensured for fileStoreId: ${orgData.fileStoreId}`,
-          );
-        } catch (error) {
-          logger.error(
-            `[MIRROR_DEBUG] Failed to ensure mirror for fileStoreId ${orgData.fileStoreId}: ${error.message}`,
-          );
-        }
-      } else {
-        logger.debug(
-          `[MIRROR_DEBUG] Skipping fileStoreId mirror - value is null/undefined`,
-        );
-      }
-    } else {
-      logger.debug(
-        `[MIRROR_DEBUG] Organization ${org} is not subscribed, skipping`,
-      );
     }
   }
 
-  logger.silly('[v1]: [MIRROR_DEBUG] Completed runMirrorCheck function');
+  logger.info('[v1]: Mirror check complete');
+};
+
+const runMirrorCheck = async () => {
+  if (mirrorCheckInProgress) {
+    logger.info('[v1]: Mirror check already in progress, skipping concurrent run');
+    return;
+  }
+  mirrorCheckInProgress = true;
+  try {
+    await runMirrorCheckInner();
+  } finally {
+    mirrorCheckInProgress = false;
+  }
+};
+
+/**
+ * Mirror only the stores belonging to a specific organization.
+ * Used by org creation finalization to avoid running a full mirror check
+ * across all orgs, which is slow and can conflict with the periodic task.
+ * @param {Object} storeIds - Map of store labels to store IDs
+ * @param {string} storeIds.orgUid
+ * @param {string} [storeIds.registryId]
+ * @param {string} [storeIds.dataModelVersionStoreId]
+ * @param {string} [storeIds.fileStoreId]
+ */
+const mirrorOrgStores = async (storeIds) => {
+  const mirrorUrl = await getMirrorUrl();
+  if (!mirrorUrl) {
+    return;
+  }
+
+  const entries = Object.entries(storeIds).filter(([, id]) => id);
+  for (const [label, id] of entries) {
+    try {
+      await Organization.addMirror(id, mirrorUrl, true);
+    } catch (error) {
+      logger.warn(
+        `[v1]: Failed to mirror ${label} ${id} (will be retried by periodic task): ${error.message}`,
+      );
+    }
+  }
 };
 
 export default job;
-export { runMirrorCheck };
+export { runMirrorCheck, mirrorOrgStores };


### PR DESCRIPTION
## Summary

- **Concurrency lock on V1 mirror check**: Added `mirrorCheckInProgress` guard to `runMirrorCheck` (V2 already had one) so the periodic task and org-creation fire-and-forget calls cannot run the full mirror check concurrently, preventing duplicate `add_mirror` RPC calls.
- **Skip unsubscribed stores**: Both V1 and V2 mirror checks now fetch the DataLayer subscription list at the start and skip any org store not present. This prevents wasted `add_mirror` calls (and blockchain fees) for stores the node hasn't subscribed to — most notably external orgs' `fileStoreId` fields that are recorded in CADT but not yet subscribed in DataLayer.
- **Targeted org creation mirroring**: Org creation finalization (V1, V2, and V1→V2 upgrade) now calls a new `mirrorOrgStores` / `mirrorOrgStoresV2` function that mirrors only the 4 stores belonging to the newly created home org, instead of triggering a full `runMirrorCheck` across all organizations.

### Problem observed

On `wbcats-dev` (dev1), after restarting CADT with a home org creation in progress:
1. `runMirrorCheck()` processed all 5 V1 orgs × 4 stores = 20+ store checks, when only the home org's 4 stores needed mirrors.
2. 4 external orgs' `fileStoreId` stores were **not subscribed** in DataLayer, yet CADT called `add_mirror` for them — the mirrors never confirmed and the fees were wasted.
3. Two concurrent `runMirrorCheck()` invocations (startup periodic task + org creation finalization) produced duplicate `add_mirror` calls for 3 stores before the first run's mirrors could confirm.

## Test plan

- [x] V1 integration tests pass (112 passing)
- [x] V2 integration tests pass (1314 passing)
- [ ] Verify on dev server: mirror check skips unsubscribed fileStoreId stores
- [ ] Verify org creation mirrors only the home org's 4 stores

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes background mirroring behavior for both v1/v2 and org creation/upgrade flows; could lead to missed mirrors if subscription detection is wrong or incomplete, but changes are scoped and have fallbacks.
> 
> **Overview**
> **Scopes and hardens mirror creation for both V1 and V2.** The periodic mirror-check tasks now (1) guard against concurrent executions, and (2) consult DataLayer `subscriptions` to *skip `addMirror` calls for stores the node isn’t subscribed to*, while still mirroring governance-related stores.
> 
> **Reduces org-creation/upgrade side effects.** Organization creation finalization (V1 + V2) and V1→V2 upgrade confirmation now fire-and-forget a new targeted `mirrorOrgStores`/`mirrorOrgStoresV2` helper to mirror only that org’s known store IDs instead of triggering a full `runMirrorCheck*()` across all orgs, with updated logging around mirror failures/retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaef253bc5d1a0a4a525b4a7abfc75156dc2a373. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->