### PR TITLE
docs: add V2 pagination requirements to cursor rule

### DIFF
--- a/.cursor/rules/v2.mdc
+++ b/.cursor/rules/v2.mdc
@@ -35,6 +35,9 @@ alwaysApply: false
 - PUT requests: MUST include ALL fields, not just changed ones
 - POST requests: include all required fields
 - Same validation schema for CREATE and UPDATE
+- **Most list endpoints require `page` and `limit`**: Entity data endpoints (`program`, `methodology`, `issuance`, `label`, `stakeholder`, `stakeholder-projects`, `unit-label`, `project-methodology`, `estimation`, `location`, `rating`, `co-benefit`, `validation`, `verification`, `staging`, `audit`, and all `aef-*` tables) enforce `paginationSchema` — omitting `page`/`limit` returns 400 (`"page is required","limit is required"`). Always include `.query({ page: 1, limit: <N> })`.
+- **`project` and `unit`** require `page`/`limit` UNLESS `xls=true` is also passed (XLS export mode skips pagination).
+- **Endpoints that do NOT require pagination**: `organizations`, `governance`, `offer`, `filestore`, and `health/*` endpoints return all results without `page`/`limit`.
 
 ## Migration Patterns (CRITICAL)
 - Data table PK: `{ type: Sequelize.STRING(36), primaryKey: true, allowNull: false, unique: true }`


### PR DESCRIPTION
## Summary
- Documents which V2 list endpoints require `page` and `limit` query parameters in the `.cursor/rules/v2.mdc` rule
- Covers the three cases: always required (most entity endpoints), conditionally required (`project`/`unit` skip when `xls=true`), and not required (`organizations`, `governance`, `offer`, `filestore`, `health/*`)
- Prevents a recurring CI failure where API calls without pagination params silently returned 400

## Test plan
- [ ] N/A — cursor rule only, no code changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies which V2 list endpoints require `page`/`limit`, with no runtime behavior or data-handling impact.
> 
> **Overview**
> Clarifies V2 API list pagination expectations in `.cursor/rules/v2.mdc`, explicitly calling out which entity endpoints enforce `paginationSchema`, the `project`/`unit` exception when `xls=true`, and which endpoints do not require `page`/`limit`. This is intended to prevent recurring 400s/CI failures from missing pagination query params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3f8f38a9159738ed914322bd30843dbccb49a36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->