### PR TITLE
fix(V2): correct XLSX Content-Type and add export download docs

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -83,6 +83,24 @@ The XLSX workflow follows the standard CADT staging paradigm:
 4. **Review** staged changes using the [staging](#staging) endpoints
 5. **Commit** when ready using `POST /v2/staging/commit`
 
+#### Downloading the Export
+
+The export endpoints return an XLSX file as a binary download with a `Content-Disposition: attachment` header.
+
+**Browser**: Navigating to the URL directly (e.g., `http://localhost:31310/v2/project?xls=true`) will automatically trigger a file download.
+
+**cURL**:
+
+```bash
+# Save with an explicit filename
+curl -o projects.xlsx "http://localhost:31310/v2/project?xls=true"
+
+# Or use the server-suggested filename (projects.xlsx)
+curl -J -O "http://localhost:31310/v2/project?xls=true"
+```
+
+**Postman**: Send the GET request, then click **Save Response → Save to a file** in the response pane. Postman will suggest the filename from the response headers.
+
 #### File Format
 
 Each XLSX file contains a **main sheet** plus optional **child sheets** for associated data:

--- a/src/utils/xls.js
+++ b/src/utils/xls.js
@@ -30,7 +30,10 @@ export const sendXls = (name, bytes, response) => {
     'Content-disposition',
     'attachment; filename=' + name + 's' + '.xlsx',
   );
-  response.set('Content-Type', 'text/plain');
+  response.set(
+    'Content-Type',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  );
 
   readStream.on('error', (error) => {
     logger.error('Stream error while sending XLS file:', error);


### PR DESCRIPTION
## Summary

- Fix the `Content-Type` header for XLSX export endpoints from `text/plain` to `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
- Add a "Downloading the Export" section to the V2 API docs with instructions for downloading XLSX exports via browser, cURL, and Postman

## Test plan

- [ ] Verify `GET /v2/project?xls=true` returns the correct `Content-Type` header
- [ ] Verify the downloaded file opens correctly in Excel/LibreOffice
- [ ] Review the new docs section renders correctly in GitHub markdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to HTTP response headers for XLSX downloads and documentation updates, with no business logic or data mutations affected.
> 
> **Overview**
> **XLSX exports now return the correct MIME type.** `sendXls` sets `Content-Type` to `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (instead of `text/plain`) while keeping the attachment download behavior.
> 
> **V2 API docs now explain how to download exports.** Adds a *Downloading the Export* section with browser, `curl`, and Postman instructions for `GET /v2/project?xls=true` and `GET /v2/unit?xls=true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a1b2900c9215e9a5b209d07d1217e032f99ae05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->