### PR TITLE
fix(V2): keep primary worksheet first in xlsx exports

### DIFF
--- a/src/utils/v2-xls.js
+++ b/src/utils/v2-xls.js
@@ -58,7 +58,18 @@ export function createV2Xls(rows, model) {
     delete xlsData[schema.modelSheetKey];
   }
 
-  return xlsx.build(Object.values(xlsData));
+  const orderedSheets = [];
+  if (xlsData[schema.mainSheetName]) {
+    orderedSheets.push(xlsData[schema.mainSheetName]);
+  }
+
+  Object.entries(xlsData).forEach(([sheetName, sheetData]) => {
+    if (sheetName !== schema.mainSheetName) {
+      orderedSheets.push(sheetData);
+    }
+  });
+
+  return xlsx.build(orderedSheets);
 }
 
 /**

--- a/tests/v2/integration/v2-xls.spec.js
+++ b/tests/v2/integration/v2-xls.spec.js
@@ -400,6 +400,7 @@ describe('V2 XLS Utility Functions', function () {
 
       const parsed = xlsx.parse(buffer);
       const sheetNames = parsed.map((s) => s.name);
+      expect(sheetNames[0]).to.equal('projects');
       expect(sheetNames).to.include('projects');
 
       const mainSheet = parsed.find((s) => s.name === 'projects');
@@ -444,6 +445,7 @@ describe('V2 XLS Utility Functions', function () {
 
       const parsed = xlsx.parse(buffer);
       const sheetNames = parsed.map((s) => s.name);
+      expect(sheetNames[0]).to.equal('units');
       expect(sheetNames).to.include('units');
 
       const mainSheet = parsed.find((s) => s.name === 'units');


### PR DESCRIPTION
## Summary
- preserve the main V2 worksheet as the first worksheet in generated XLSX exports
- avoid object key reordering side effects when renaming the model sheet to `xlsSheetName`
- add integration assertions to verify `projects` and `units` are first tabs

## Test plan
- [x] `eval "$(fnm env)" && fnm use && bash tests/run-tests.sh npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js tests/v2/integration/v2-xls.spec.js --reporter spec --exit --timeout 300000`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only worksheet ordering during XLSX build and adds assertions in integration tests. No changes to parsing, staging, or data transformation logic.
> 
> **Overview**
> **V2 XLSX exports now preserve a deterministic sheet order** by explicitly building the workbook with the main sheet (e.g. `projects`/`units`) first, avoiding object key reordering side effects after renaming the model sheet.
> 
> Integration tests for `createV2Xls` are updated to assert the main worksheet is the first tab for both `ProjectV2` and `UnitV2` exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8a57c551cf8fc4fbe6d73dbd2082e7aa427f8e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->