### PR TITLE
refactor: enhance the addJobToScheduler

### DIFF
--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -91,8 +91,19 @@ const addJobToScheduler = (job) => {
     }
   }
 
-  jobRegistry[job.id] = job;
-  scheduler.addSimpleIntervalJob(job);
+  try {
+    scheduler.addSimpleIntervalJob(job);
+    jobRegistry[job.id] = job;
+  } catch (error) {
+    // If we get here it almost always means the cleanup above did not
+    // fully drain the prior entry from toad-scheduler's internal registry
+    // (so registerJob() re-threw "already registered"). Warn so an
+    // operator notices the job is missing instead of failing startup for
+    // the whole batch.
+    logger.warn(
+      `[SCHEDULER] failed to register job ${job.id}: ${error.message}; this task will not run on this process until restart`,
+    );
+  }
 };
 
 const start = async (enableV1 = true, enableV2 = true) => {

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -80,6 +80,7 @@ const addJobToScheduler = (job) => {
   if (scheduler.existsById(job.id)) {
     scheduler.stopById(job.id);
     scheduler.removeById(job.id);
+    logger.info(`[SCHEDULER] Job ID conflict: Stopping and replacing existing job ${job.id}`);
   }
 
   jobRegistry[job.id] = job;
@@ -124,7 +125,6 @@ const start = async (enableV1 = true, enableV2 = true) => {
       cleanUpFailedOrg,
     ];
     defaultJobs.forEach(addJobToScheduler);
-    });
   } else {
     logger.info('[v1]: V1 is disabled in config - skipping V1 scheduler tasks');
   }

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -77,10 +77,14 @@ const waitForDataLayerAvailable = async (maxWaitMs = 300000, pollIntervalMs = 50
 const jobRegistry = {};
 
 const addJobToScheduler = (job) => {
-  if (scheduler.existsById(job.id)) {
-    scheduler.stopById(job.id);
-    scheduler.removeById(job.id);
-    logger.info(`[SCHEDULER] Job ID conflict: Stopping and replacing existing job ${job.id}`);
+  try {
+    if (scheduler.existsById(job.id)) {
+      scheduler.stopById(job.id);
+      scheduler.removeById(job.id);
+      logger.debug(`[SCHEDULER] Stopping and replacing existing job ${job.id}`);
+    }
+  } catch (error) {
+    // ignore the job stopping fail
   }
 
   jobRegistry[job.id] = job;

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -77,16 +77,16 @@ const waitForDataLayerAvailable = async (maxWaitMs = 300000, pollIntervalMs = 50
 const jobRegistry = {};
 
 const addJobToScheduler = (job) => {
-  try {
-    if (scheduler.existsById(job.id)) {
+  if (scheduler.existsById(job.id)) {
+    logger.debug(`[SCHEDULER] Stopping and replacing existing job ${job.id}`);
+    try {
       scheduler.stopById(job.id);
-      scheduler.removeById(job.id);
-      logger.debug(`[SCHEDULER] Stopping and replacing existing job ${job.id}`);
+    } catch (error) {
+      logger.info(`[SCHEDULER] fail to stop job ${job.id}: ${error.message}, force to replace it`);
     }
-  } catch (error) {
-    // ignore the job stopping fail
+    scheduler.removeById(job.id);
   }
-
+  
   jobRegistry[job.id] = job;
   scheduler.addSimpleIntervalJob(job);
 };

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -77,6 +77,11 @@ const waitForDataLayerAvailable = async (maxWaitMs = 300000, pollIntervalMs = 50
 const jobRegistry = {};
 
 const addJobToScheduler = (job) => {
+  if (scheduler.existsById(job.id)) {
+    scheduler.stopById(job.id);
+    scheduler.removeById(job.id);
+  }
+
   jobRegistry[job.id] = job;
   scheduler.addSimpleIntervalJob(job);
 };
@@ -101,12 +106,7 @@ const start = async (enableV1 = true, enableV2 = true) => {
     }
 
     // Now register the scheduled job for future runs
-    if (scheduler.existsById(coinManagement.id)) {
-      scheduler.stopById(coinManagement.id);
-      scheduler.removeById(coinManagement.id);
-    }
-    jobRegistry[coinManagement.id] = coinManagement;
-    scheduler.addSimpleIntervalJob(coinManagement);
+    addJobToScheduler(coinManagement);
     logger.info('[COIN_MANAGEMENT] Coin management task registered for periodic runs');
   }
 
@@ -123,14 +123,7 @@ const start = async (enableV1 = true, enableV2 = true) => {
       validateOrganizationTableAndSubscriptions,
       cleanUpFailedOrg,
     ];
-    defaultJobs.forEach((defaultJob) => {
-      // Remove job if it already exists (for testing)
-      if (scheduler.existsById(defaultJob.id)) {
-        scheduler.stopById(defaultJob.id);
-        scheduler.removeById(defaultJob.id);
-      }
-      jobRegistry[defaultJob.id] = defaultJob;
-      scheduler.addSimpleIntervalJob(defaultJob);
+    defaultJobs.forEach(addJobToScheduler);
     });
   } else {
     logger.info('[v1]: V1 is disabled in config - skipping V1 scheduler tasks');
@@ -148,15 +141,7 @@ const start = async (enableV1 = true, enableV2 = true) => {
       syncPicklistsV2,
       cleanUpFailedOrgV2,
     ];
-    v2Jobs.forEach((v2Job) => {
-      // Remove job if it already exists (for testing)
-      if (scheduler.existsById(v2Job.id)) {
-        scheduler.stopById(v2Job.id);
-        scheduler.removeById(v2Job.id);
-      }
-      jobRegistry[v2Job.id] = v2Job;
-      scheduler.addSimpleIntervalJob(v2Job);
-    });
+    v2Jobs.forEach(addJobToScheduler);
   } else {
     loggerV2.info('[v2]: V2 is disabled in config - skipping V2 scheduler tasks');
   }

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -79,14 +79,18 @@ const jobRegistry = {};
 const addJobToScheduler = (job) => {
   if (scheduler.existsById(job.id)) {
     logger.debug(`[SCHEDULER] Stopping and replacing existing job ${job.id}`);
+    // Mirror stopAll(): tolerate either call throwing on a job in a bad
+    // state so the replacement registration below always wins.
     try {
       scheduler.stopById(job.id);
+      scheduler.removeById(job.id);
     } catch (error) {
-      logger.info(`[SCHEDULER] fail to stop job ${job.id}: ${error.message}, force to replace it`);
+      logger.debug(
+        `[SCHEDULER] failed to clear existing job ${job.id}: ${error.message}; continuing with replacement`,
+      );
     }
-    scheduler.removeById(job.id);
   }
-  
+
   jobRegistry[job.id] = job;
   scheduler.addSimpleIntervalJob(job);
 };

--- a/tests/v2/integration/enable-disable-versions.spec.js
+++ b/tests/v2/integration/enable-disable-versions.spec.js
@@ -349,14 +349,14 @@ describe('V1/V2 Enable/Disable Functionality Tests', function () {
       expect(Object.keys(scheduler.jobRegistry)).to.have.length(0);
     });
 
-    it('register override old once task id collision happend', async function () {
+    it('should replace existing job when job ID collides', async function () {
       await scheduler.start(true, true);
       const { SimpleIntervalJob, Task } = await import('toad-scheduler');
       const newtask = new Task('new-mirror-check', async () => {});
       const job = new SimpleIntervalJob(
         {
           seconds: 300,
-          runImmediately: true,
+          runImmediately: false,
         },
         newtask,
         { id: 'mirror-check', preventOverrun: true },
@@ -368,7 +368,7 @@ describe('V1/V2 Enable/Disable Functionality Tests', function () {
       expect(newjob).not.to.equal(oldjob);
       expect(newjob).to.equal(job);
       // since the old job should be stopped before removed from jobRegistry, should check status
-      expect(oldjob.getStatus()).to.equal('stopped'); 
+      expect(oldjob.getStatus()).to.equal('stopped');
       expect(newjob.getStatus()).to.equal('running');
     });
   });

--- a/tests/v2/integration/enable-disable-versions.spec.js
+++ b/tests/v2/integration/enable-disable-versions.spec.js
@@ -348,6 +348,29 @@ describe('V1/V2 Enable/Disable Functionality Tests', function () {
       // Check that no tasks are registered
       expect(Object.keys(scheduler.jobRegistry)).to.have.length(0);
     });
+
+    it('register override old once task id collision happend', async function () {
+      await scheduler.start(true, true);
+      const { SimpleIntervalJob, Task } = await import('toad-scheduler');
+      const newtask = new Task('new-mirror-check', async () => {});
+      const job = new SimpleIntervalJob(
+        {
+          seconds: 300,
+          runImmediately: true,
+        },
+        newtask,
+        { id: 'mirror-check', preventOverrun: true },
+      );
+
+      const oldjob = scheduler.jobRegistry['mirror-check'];
+      scheduler.addJobToScheduler(job);
+      const newjob = scheduler.jobRegistry['mirror-check'];
+      expect(newjob).not.to.equal(oldjob);
+      expect(newjob).to.equal(job);
+      // since the old job should be stopped before removed from jobRegistry, should check status
+      expect(oldjob.getStatus()).to.equal('stopped'); 
+      expect(newjob.getStatus()).to.equal('running');
+    });
   });
 
   describe('API Endpoint Behavior', function () {

--- a/tests/v2/integration/enable-disable-versions.spec.js
+++ b/tests/v2/integration/enable-disable-versions.spec.js
@@ -3,6 +3,7 @@ import supertest from 'supertest';
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
+import { SimpleIntervalJob, Task } from 'toad-scheduler';
 import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
 import { initializeDatabases } from '../../../src/routes/index.js';
 import scheduler from '../../../src/tasks/index.js';
@@ -351,25 +352,25 @@ describe('V1/V2 Enable/Disable Functionality Tests', function () {
 
     it('should replace existing job when job ID collides', async function () {
       await scheduler.start(true, true);
-      const { SimpleIntervalJob, Task } = await import('toad-scheduler');
-      const newtask = new Task('new-mirror-check', async () => {});
+      const newTask = new Task('new-mirror-check', async () => {});
       const job = new SimpleIntervalJob(
         {
           seconds: 300,
           runImmediately: false,
         },
-        newtask,
+        newTask,
         { id: 'mirror-check', preventOverrun: true },
       );
 
-      const oldjob = scheduler.jobRegistry['mirror-check'];
+      const oldJob = scheduler.jobRegistry['mirror-check'];
       scheduler.addJobToScheduler(job);
-      const newjob = scheduler.jobRegistry['mirror-check'];
-      expect(newjob).not.to.equal(oldjob);
-      expect(newjob).to.equal(job);
-      // since the old job should be stopped before removed from jobRegistry, should check status
-      expect(oldjob.getStatus()).to.equal('stopped');
-      expect(newjob.getStatus()).to.equal('running');
+      const newJob = scheduler.jobRegistry['mirror-check'];
+      expect(newJob).not.to.equal(oldJob);
+      expect(newJob).to.equal(job);
+      // Old job is stopped before being removed from jobRegistry; verify both
+      // the replacement and the prior job's resulting status.
+      expect(oldJob.getStatus()).to.equal('stopped');
+      expect(newJob.getStatus()).to.equal('running');
     });
   });
 


### PR DESCRIPTION
refactor: enhance the addJobToScheduler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core background-task scheduling by changing how jobs are replaced and how registration failures are handled, which could cause a task to not run on a process if the scheduler registry gets into a bad state. Mitigated by explicit stop/remove attempts and warning logs, but behavior changes are runtime-critical.
> 
> **Overview**
> **Scheduler job registration is now collision-tolerant.** `addJobToScheduler` stops/removes any existing job with the same ID (with best-effort error handling) before registering the replacement.
> 
> **Startup is made more resilient.** If job registration still fails (e.g., `toad-scheduler` thinks the ID is already registered), the code now logs a warning and continues, meaning the affected task won’t run on that process until restart rather than failing the whole startup.
> 
> **Tests updated/expanded.** Scheduler startup now consistently uses `addJobToScheduler`, and an integration test was added to assert that a colliding job ID is replaced and the old job ends in `stopped` state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ceea37336096a39006a8e9b5cc05422ffc6abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->