### PR TITLE
fix(CI): increase faucet funding timeout from 5 to 10 minutes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -269,7 +269,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30  # 30 attempts * 10 seconds = 5 minutes
+          MAX_ATTEMPTS=60  # 60 attempts * 10 seconds = 10 minutes
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -281,7 +281,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."
@@ -699,7 +699,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -711,7 +711,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."
@@ -1300,7 +1300,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -1312,7 +1312,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."
@@ -1655,7 +1655,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -1667,7 +1667,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."
@@ -2869,7 +2869,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -2881,7 +2881,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."
@@ -3759,7 +3759,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -3771,7 +3771,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."
@@ -4084,7 +4084,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -4096,7 +4096,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."
@@ -4410,7 +4410,7 @@ jobs:
           fi
 
           echo "Waiting for wallet to receive funds..."
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
           while true; do
             BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
@@ -4422,7 +4422,7 @@ jobs:
             fi
             ATTEMPT=$((ATTEMPT + 1))
             if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-              echo "ERROR: Timeout waiting for wallet to be funded after 5 minutes"
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
               exit 1
             fi
             echo "Balance still zero, waiting 10 seconds..."


### PR DESCRIPTION
## Summary

- Increase wallet funding polling timeout from 5 minutes (30 attempts) to 10 minutes (60 attempts) across all 8 CI jobs that request testnet faucet funds
- Update corresponding error messages to reflect the new 10-minute window

## Context

In [run #2427](https://github.com/Chia-Network/cadt/actions/runs/24052799580?pr=1564), the `v1 to v2 upgrade test` failed because the faucet-funded transaction didn't confirm within 5 minutes. All 8 jobs received identical HTTP 202 faucet responses on the first attempt, but testnet confirmation times ranged from ~3 to 5+ minutes — the `v2 governance` job barely made it at attempt 27 (~5m14s), and the upgrade test timed out at attempt 30.

## Test plan

- [ ] CI jobs that use faucet funding should pass with the increased timeout
- [ ] CADT API health check timeouts (lines 1729, 2943) remain unchanged at 30 attempts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just increases the wait window for testnet faucet funding; main impact is potentially longer CI runtime on slow confirmations.
> 
> **Overview**
> **Improves CI resilience to slow testnet confirmations** by doubling the faucet-funding balance polling window from 30 to 60 attempts (5m → 10m) across the workflow’s faucet-funded jobs.
> 
> Updates the corresponding timeout error messages to reflect the new 10-minute limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b7fadc47f3623b44e4fdfa1cb28436d1c95b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->