### PR TITLE
fix(V2): add cascade deletes for mid-chain verification and issuance endpoints

### DIFF
--- a/src/controllers/v2/issuance-v2.controller.js
+++ b/src/controllers/v2/issuance-v2.controller.js
@@ -3,6 +3,8 @@
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { Sequelize } from 'sequelize';
+import { sequelizeV2 } from '../../database/v2/index.js';
+import { processingSyncRegistriesTransactionMutexV2 } from '../../utils/v2-mutex-utils.js';
 
 import { StagingV2, IssuanceV2, VerificationV2, ProjectMethodologyV2, OrganizationsV2, ProjectV2, LocationV2 } from '../../models/v2/index.js';
 
@@ -21,6 +23,7 @@ import { resolveOrgUid } from '../../utils/owner-utils.js';
 
 import { loggerV2 } from '../../config/logger.js';
 import { issuanceV2Schema } from '../../validations/v2/issuance-v2.validations.js';
+import { stageIssuanceChildDeletes } from '../../utils/v2-cascade-delete.js';
 
 export const create = async (req, res) => {
   try {
@@ -328,19 +331,32 @@ export const destroy = async (req, res) => {
       });
     }
 
-    // Stage the delete
-    await StagingV2.create({
-      uuid: uuidv4(),
-      table: 'issuance',
-      action: 'DELETE',
-      data: JSON.stringify([{ cad_trust_issuance_id: id }]), // Use UUID string directly
-      committed: false,
-      failed_commit: false,
-      is_transfer: false,
-    });
+    const releaseTransactionMutex =
+      await processingSyncRegistriesTransactionMutexV2.acquire();
+    let stagedChildDeletes;
+    try {
+      stagedChildDeletes = await sequelizeV2.transaction(async (transaction) => {
+        const childDeleteCount = await stageIssuanceChildDeletes(id, { transaction });
+
+        await StagingV2.create({
+          uuid: uuidv4(),
+          table: 'issuance',
+          action: 'DELETE',
+          data: JSON.stringify([{ cad_trust_issuance_id: id }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        }, { transaction });
+
+        return childDeleteCount;
+      });
+    } finally {
+      releaseTransactionMutex();
+    }
 
     res.json({
       message: 'Issuance delete staged successfully',
+      stagedChildDeletes,
       success: true,
     });
   } catch (err) {

--- a/src/controllers/v2/verification-v2.controller.js
+++ b/src/controllers/v2/verification-v2.controller.js
@@ -3,6 +3,8 @@
 import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { Sequelize } from 'sequelize';
+import { sequelizeV2 } from '../../database/v2/index.js';
+import { processingSyncRegistriesTransactionMutexV2 } from '../../utils/v2-mutex-utils.js';
 
 import { StagingV2, VerificationV2, ProjectV2, ValidationV2, OrganizationsV2 } from '../../models/v2/index.js';
 
@@ -21,6 +23,7 @@ import { resolveOrgUid } from '../../utils/owner-utils.js';
 
 import { loggerV2 } from '../../config/logger.js';
 import { verificationV2Schema } from '../../validations/v2/verification-v2.validations.js';
+import { stageVerificationChildDeletes } from '../../utils/v2-cascade-delete.js';
 
 export const create = async (req, res) => {
   try {
@@ -356,19 +359,32 @@ export const destroy = async (req, res) => {
       });
     }
 
-    // Stage the delete
-    await StagingV2.create({
-      uuid: uuidv4(),
-      table: 'verification',
-      action: 'DELETE',
-      data: JSON.stringify([{ cad_trust_verification_id: id }]), // Use UUID string directly
-      committed: false,
-      failed_commit: false,
-      is_transfer: false,
-    });
+    const releaseTransactionMutex =
+      await processingSyncRegistriesTransactionMutexV2.acquire();
+    let stagedChildDeletes;
+    try {
+      stagedChildDeletes = await sequelizeV2.transaction(async (transaction) => {
+        const childDeleteCount = await stageVerificationChildDeletes(id, { transaction });
+
+        await StagingV2.create({
+          uuid: uuidv4(),
+          table: 'verification',
+          action: 'DELETE',
+          data: JSON.stringify([{ cad_trust_verification_id: id }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        }, { transaction });
+
+        return childDeleteCount;
+      });
+    } finally {
+      releaseTransactionMutex();
+    }
 
     res.json({
       message: 'Verification delete staged successfully',
+      stagedChildDeletes,
       success: true,
     });
   } catch (err) {

--- a/src/utils/v2-cascade-delete.js
+++ b/src/utils/v2-cascade-delete.js
@@ -1,5 +1,54 @@
 'use strict';
 
+/**
+ * V2 Cascade Delete — Design Rationale
+ *
+ * CADT records fall into two categories with fundamentally different deletion
+ * strategies. Understanding this distinction is critical before modifying any
+ * delete logic.
+ *
+ * ## 1. Project-scoped records — CASCADE on delete
+ *
+ * These are exclusively owned by a single project (or by a single unit in the
+ * case of unit_label). No other project or registry can reference them, so they
+ * are safe to cascade-delete when their parent is removed.
+ *
+ *   project → location, estimation, rating, co_benefit, validation,
+ *             verification, project_methodology (link), stakeholder_projects (link)
+ *   verification → issuance
+ *   issuance → unit
+ *   unit → unit_label
+ *
+ * When a project is deleted, the full chain above is traversed and every child
+ * gets a staged DELETE entry. When a unit is deleted, its unit_label rows are
+ * cascade-staged. The same applies to mid-chain deletes of verification or
+ * issuance — their downstream children must also be staged.
+ *
+ * ## 2. Shared / standalone records — DO NOT cascade
+ *
+ * These exist independently with their own org_uid and can be cross-referenced
+ * by any registry on the network:
+ *
+ *   methodology  — referenced via project_methodology from any project
+ *   stakeholder  — referenced via stakeholder_projects from any project
+ *   program      — referenced via cad_trust_program_id from any project
+ *   label        — referenced via unit_label from any unit
+ *
+ * Hard-deleting a shared record propagates through DataLayer sync to every
+ * subscriber, silently breaking referential integrity for any registry that
+ * still references it. There is no mechanism to notify affected registries.
+ *
+ * These records intentionally do NOT cascade. The correct approaches (in order
+ * of priority) are:
+ *   - Tier 2: Block delete with 409 if local references exist (or allow with
+ *             ?force=true after showing impact)
+ *   - Tier 3: Soft delete / deprecation (the only truly safe distributed
+ *             systems answer — tombstones over hard deletes)
+ *   - Tier 4: Orphan cleanup endpoint for records with zero local references
+ *
+ * See: docs/orphaned-records-analysis.md for the full analysis.
+ */
+
 import { v4 as uuidv4 } from 'uuid';
 import {
   StagingV2,
@@ -45,6 +94,81 @@ const pushRowsForRecords = (rows, records, table, primaryKeyField) => {
     }
     rows.push(buildDeleteRow(table, primaryKeyField, primaryKeyValue));
   }
+};
+
+export const stageIssuanceChildDeletes = async (issuanceId, options = {}) => {
+  const { transaction } = options;
+  const rows = [];
+
+  const units = await UnitV2.findAll({
+    where: { cadTrustIssuanceId: issuanceId },
+    raw: true,
+    transaction,
+  });
+  pushRowsForRecords(rows, units, 'unit', 'cad_trust_unit_id');
+
+  const unitIds = units
+    .map((unit) => unit.cadTrustUnitId)
+    .filter(Boolean);
+
+  if (unitIds.length > 0) {
+    const unitLabels = await UnitLabelV2.findAll({
+      where: { cadTrustUnitId: unitIds },
+      raw: true,
+      transaction,
+    });
+    pushRowsForRecords(rows, unitLabels, 'unit_label', 'cad_trust_unit_label_id');
+  }
+
+  if (rows.length > 0) {
+    await StagingV2.bulkCreate(rows, { transaction });
+  }
+
+  return rows.length;
+};
+
+export const stageVerificationChildDeletes = async (verificationId, options = {}) => {
+  const { transaction } = options;
+  const rows = [];
+
+  const issuances = await IssuanceV2.findAll({
+    where: { cadTrustVerificationId: verificationId },
+    raw: true,
+    transaction,
+  });
+  pushRowsForRecords(rows, issuances, 'issuance', 'cad_trust_issuance_id');
+
+  const issuanceIds = issuances
+    .map((issuance) => issuance.cadTrustIssuanceId)
+    .filter(Boolean);
+
+  if (issuanceIds.length > 0) {
+    const units = await UnitV2.findAll({
+      where: { cadTrustIssuanceId: issuanceIds },
+      raw: true,
+      transaction,
+    });
+    pushRowsForRecords(rows, units, 'unit', 'cad_trust_unit_id');
+
+    const unitIds = units
+      .map((unit) => unit.cadTrustUnitId)
+      .filter(Boolean);
+
+    if (unitIds.length > 0) {
+      const unitLabels = await UnitLabelV2.findAll({
+        where: { cadTrustUnitId: unitIds },
+        raw: true,
+        transaction,
+      });
+      pushRowsForRecords(rows, unitLabels, 'unit_label', 'cad_trust_unit_label_id');
+    }
+  }
+
+  if (rows.length > 0) {
+    await StagingV2.bulkCreate(rows, { transaction });
+  }
+
+  return rows.length;
 };
 
 export const stageUnitChildDeletes = async (unitId, options = {}) => {

--- a/tests/v2/integration/issuance-v2.spec.js
+++ b/tests/v2/integration/issuance-v2.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StagingV2, IssuanceV2, VerificationV2, MethodologyV2, ProjectMethodologyV2, ProjectV2, ValidationV2, ProgramV2 } from '../../../src/models/v2/index.js';
+import { StagingV2, IssuanceV2, VerificationV2, MethodologyV2, ProjectMethodologyV2, ProjectV2, ValidationV2, ProgramV2, UnitV2, UnitLabelV2, LabelV2 } from '../../../src/models/v2/index.js';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -399,6 +399,112 @@ describe('V2 Issuance API - Basic CRUD Tests', function () {
 
       expect(response.body.message).to.equal('Issuance not found');
       expect(response.body.success).to.be.false;
+    });
+
+    it('should stage issuance deletion with no children', async function () {
+      await waitForV2DataLayerSync();
+      const issuance = await IssuanceV2.create(addUuidIfNeeded('IssuanceV2', {
+        issuanceId: 'ISS-DELETE-001',
+        issuanceDate: '2024-01-01',
+        cadTrustVerificationId: testVerification.cadTrustVerificationId,
+        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
+      }));
+
+      const response = await supertest(app)
+        .delete(`/v2/issuance/${issuance.cadTrustIssuanceId}`)
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.message).to.equal('Issuance delete staged successfully');
+      expect(response.body.stagedChildDeletes).to.equal(0);
+
+      const deleteRows = await StagingV2.findAll({ where: { action: 'DELETE' } });
+      expect(deleteRows).to.have.lengthOf(1);
+      expect(deleteRows[0].table).to.equal('issuance');
+    });
+
+    it('should cascade-stage unit and unit_label deletes when deleting an issuance', async function () {
+      await waitForV2DataLayerSync();
+      const homeOrgId = await getV2HomeOrgId();
+
+      const issuance = await IssuanceV2.create(addUuidIfNeeded('IssuanceV2', {
+        issuanceId: 'ISS-CASCADE-001',
+        issuanceDate: '2024-03-01',
+        cadTrustVerificationId: testVerification.cadTrustVerificationId,
+        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
+      }));
+
+      const unit1 = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: 'ISS-CASCADE-UNIT-001',
+        unitStartBlock: '100',
+        unitEndBlock: '200',
+        unitCount: 100,
+        unitType: 'Avoidance - nature',
+        unitVintageYear: 2024,
+        unitStatus: 'Issued',
+        unitMetric: 'tCO2e',
+        cadTrustIssuanceId: issuance.cadTrustIssuanceId,
+        orgUid: homeOrgId,
+      }));
+
+      const unit2 = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: 'ISS-CASCADE-UNIT-002',
+        unitStartBlock: '201',
+        unitEndBlock: '300',
+        unitCount: 100,
+        unitType: 'Avoidance - nature',
+        unitVintageYear: 2024,
+        unitStatus: 'Issued',
+        unitMetric: 'tCO2e',
+        cadTrustIssuanceId: issuance.cadTrustIssuanceId,
+        orgUid: homeOrgId,
+      }));
+
+      const label = await LabelV2.create({
+        cadTrustLabelId: uuidv4(),
+        labelName: 'Issuance Cascade Label',
+      });
+
+      const unitLabel1 = await UnitLabelV2.create({
+        cadTrustUnitLabelId: uuidv4(),
+        cadTrustUnitId: unit1.cadTrustUnitId,
+        cadTrustLabelId: label.cadTrustLabelId,
+      });
+
+      const unitLabel2 = await UnitLabelV2.create({
+        cadTrustUnitLabelId: uuidv4(),
+        cadTrustUnitId: unit2.cadTrustUnitId,
+        cadTrustLabelId: label.cadTrustLabelId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/issuance/${issuance.cadTrustIssuanceId}`)
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.stagedChildDeletes).to.equal(4);
+
+      const deleteRows = await StagingV2.findAll({
+        where: { action: 'DELETE' },
+        raw: true,
+      });
+
+      const expectedDeletes = [
+        ['issuance', 'cad_trust_issuance_id', issuance.cadTrustIssuanceId],
+        ['unit', 'cad_trust_unit_id', unit1.cadTrustUnitId],
+        ['unit', 'cad_trust_unit_id', unit2.cadTrustUnitId],
+        ['unit_label', 'cad_trust_unit_label_id', unitLabel1.cadTrustUnitLabelId],
+        ['unit_label', 'cad_trust_unit_label_id', unitLabel2.cadTrustUnitLabelId],
+      ];
+
+      for (const [table, key, id] of expectedDeletes) {
+        const matching = deleteRows.find((row) => {
+          if (row.table !== table) return false;
+          const data = JSON.parse(row.data);
+          return data[0]?.[key] === id;
+        });
+        expect(matching, `missing staged delete for ${table}:${id}`).to.exist;
+      }
     });
   });
 });

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -1130,6 +1130,119 @@ describe('V2 Project API - Basic CRUD Tests', function () {
       expect(deleteRows).to.have.lengthOf(1);
       expect(deleteRows[0].table).to.equal('project');
     });
+
+    it('should create duplicate staging rows on double delete before commit', async function () {
+      await waitForV2DataLayerSync();
+      const homeOrgId = await getV2HomeOrgId();
+      const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+        projectRegistryName: 'Double Delete Registry',
+        projectId: 'DOUBLE-DEL-001',
+        projectName: 'Double Delete Project',
+        orgUid: homeOrgId,
+      }));
+
+      const location = await LocationV2.create({
+        cadTrustLocationId: uuidv4(),
+        locationCountry: 'US',
+        cadTrustProjectId: project.cadTrustProjectId,
+      });
+
+      const res1 = await supertest(app)
+        .delete(`/v2/project/${project.cadTrustProjectId}`)
+        .expect(200);
+      expect(res1.body.success).to.be.true;
+      expect(res1.body.stagedChildDeletes).to.equal(1);
+
+      const res2 = await supertest(app)
+        .delete(`/v2/project/${project.cadTrustProjectId}`)
+        .expect(200);
+      expect(res2.body.success).to.be.true;
+      expect(res2.body.stagedChildDeletes).to.equal(1);
+
+      const deleteRows = await StagingV2.findAll({
+        where: { action: 'DELETE', table: 'project' },
+      });
+      expect(deleteRows).to.have.lengthOf(2);
+    });
+
+    it('should cascade multiple units per issuance', async function () {
+      const homeOrgId = await getV2HomeOrgId();
+      const chain = await createV2TestProgramChain({ testId: 'MULTI-UNIT-001' });
+
+      const unit1 = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: 'MULTI-UNIT-A',
+        unitStartBlock: '1',
+        unitEndBlock: '50',
+        unitCount: 50,
+        unitType: 'Avoidance - nature',
+        unitVintageYear: 2024,
+        unitStatus: 'Issued',
+        unitMetric: 'tCO2e',
+        cadTrustIssuanceId: chain.issuance.cadTrustIssuanceId,
+        orgUid: homeOrgId,
+      }));
+
+      const unit2 = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: 'MULTI-UNIT-B',
+        unitStartBlock: '51',
+        unitEndBlock: '100',
+        unitCount: 50,
+        unitType: 'Avoidance - nature',
+        unitVintageYear: 2024,
+        unitStatus: 'Issued',
+        unitMetric: 'tCO2e',
+        cadTrustIssuanceId: chain.issuance.cadTrustIssuanceId,
+        orgUid: homeOrgId,
+      }));
+
+      const label = await LabelV2.create({
+        cadTrustLabelId: uuidv4(),
+        labelName: 'Multi-Unit Label',
+      });
+
+      const unitLabel1 = await UnitLabelV2.create({
+        cadTrustUnitLabelId: uuidv4(),
+        cadTrustUnitId: unit1.cadTrustUnitId,
+        cadTrustLabelId: label.cadTrustLabelId,
+      });
+
+      const unitLabel2a = await UnitLabelV2.create({
+        cadTrustUnitLabelId: uuidv4(),
+        cadTrustUnitId: unit2.cadTrustUnitId,
+        cadTrustLabelId: label.cadTrustLabelId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/project/${chain.project.cadTrustProjectId}`)
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+
+      const deleteRows = await StagingV2.findAll({
+        where: { action: 'DELETE' },
+        raw: true,
+      });
+
+      const unitDeletes = deleteRows.filter((r) => r.table === 'unit');
+      const unitLabelDeletes = deleteRows.filter((r) => r.table === 'unit_label');
+
+      expect(unitDeletes).to.have.lengthOf(2);
+      expect(unitLabelDeletes).to.have.lengthOf(2);
+
+      for (const [table, key, id] of [
+        ['unit', 'cad_trust_unit_id', unit1.cadTrustUnitId],
+        ['unit', 'cad_trust_unit_id', unit2.cadTrustUnitId],
+        ['unit_label', 'cad_trust_unit_label_id', unitLabel1.cadTrustUnitLabelId],
+        ['unit_label', 'cad_trust_unit_label_id', unitLabel2a.cadTrustUnitLabelId],
+      ]) {
+        const matching = deleteRows.find((row) => {
+          if (row.table !== table) return false;
+          const data = JSON.parse(row.data);
+          return data[0]?.[key] === id;
+        });
+        expect(matching, `missing staged delete for ${table}:${id}`).to.exist;
+      }
+    });
   });
 
   describe('Phase 20.5: Advanced Features Tests', function () {

--- a/tests/v2/integration/verification-v2.spec.js
+++ b/tests/v2/integration/verification-v2.spec.js
@@ -3,7 +3,7 @@ import supertest from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StagingV2, VerificationV2, ProjectV2, ValidationV2, ProgramV2 } from '../../../src/models/v2/index.js';
+import { StagingV2, VerificationV2, ProjectV2, ValidationV2, ProgramV2, IssuanceV2, MethodologyV2, ProjectMethodologyV2, UnitV2, UnitLabelV2, LabelV2 } from '../../../src/models/v2/index.js';
 import {
   resetV2StagingTable,
   resetV2DataTables,
@@ -522,6 +522,7 @@ describe('V2 Verification API - Basic CRUD Tests', function () {
 
       expect(response.body.message).to.equal('Verification delete staged successfully');
       expect(response.body.success).to.be.true;
+      expect(response.body.stagedChildDeletes).to.equal(0);
 
       // Verify deletion was staged
       const stagingRecord = await StagingV2.findOne({
@@ -536,6 +537,89 @@ describe('V2 Verification API - Basic CRUD Tests', function () {
       // Verify staged deletion data
       const stagedData = JSON.parse(stagingRecord.data);
       expect(stagedData[0].cad_trust_verification_id).to.equal(verification.cadTrustVerificationId);
+    });
+
+    it('should cascade-stage issuance, unit, and unit_label deletes when deleting a verification', async function () {
+      const homeOrgId = await getV2HomeOrgId();
+
+      const verification = await VerificationV2.create(addUuidIfNeeded('VerificationV2', {
+        verificationId: 'VER-CASCADE-001',
+        verificationBody: 'Cascade Test Verifier',
+        cadTrustProjectId: testProject.cadTrustProjectId,
+        cadTrustValidationId: testValidation.cadTrustValidationId,
+      }));
+
+      const methodology = await MethodologyV2.create({
+        methodologyCode: 'CASCADE-METHOD-001',
+        methodologyName: 'Cascade Test Methodology',
+        methodologyType: 'Methodology for Afforestation and Reforestation',
+      });
+
+      const projectMethodology = await ProjectMethodologyV2.create(addUuidIfNeeded('ProjectMethodologyV2', {
+        cadTrustProjectId: testProject.cadTrustProjectId,
+        cadTrustMethodologyId: methodology.cadTrustMethodologyId,
+        projectMethodologyDate: '2024-01-01',
+      }));
+
+      const issuance = await IssuanceV2.create(addUuidIfNeeded('IssuanceV2', {
+        issuanceId: 'ISS-CASCADE-001',
+        issuanceDate: '2024-03-01',
+        cadTrustVerificationId: verification.cadTrustVerificationId,
+        cadTrustProjectMethodologyId: projectMethodology.cadTrustProjectMethodologyId,
+      }));
+
+      const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: 'VER-CASCADE-UNIT-001',
+        unitStartBlock: '100',
+        unitEndBlock: '200',
+        unitCount: 100,
+        unitType: 'Avoidance - nature',
+        unitVintageYear: 2024,
+        unitStatus: 'Issued',
+        unitStatusReason: 'Verification cascade test',
+        unitMetric: 'tCO2e',
+        cadTrustIssuanceId: issuance.cadTrustIssuanceId,
+        orgUid: homeOrgId,
+      }));
+
+      const label = await LabelV2.create({
+        cadTrustLabelId: uuidv4(),
+        labelName: 'Verification Cascade Label',
+      });
+
+      const unitLabel = await UnitLabelV2.create({
+        cadTrustUnitLabelId: uuidv4(),
+        cadTrustUnitId: unit.cadTrustUnitId,
+        cadTrustLabelId: label.cadTrustLabelId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/verification/${verification.cadTrustVerificationId}`)
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.stagedChildDeletes).to.equal(3);
+
+      const deleteRows = await StagingV2.findAll({
+        where: { action: 'DELETE' },
+        raw: true,
+      });
+
+      const expectedDeletes = [
+        ['verification', 'cad_trust_verification_id', verification.cadTrustVerificationId],
+        ['issuance', 'cad_trust_issuance_id', issuance.cadTrustIssuanceId],
+        ['unit', 'cad_trust_unit_id', unit.cadTrustUnitId],
+        ['unit_label', 'cad_trust_unit_label_id', unitLabel.cadTrustUnitLabelId],
+      ];
+
+      for (const [table, key, id] of expectedDeletes) {
+        const matching = deleteRows.find((row) => {
+          if (row.table !== table) return false;
+          const data = JSON.parse(row.data);
+          return data[0]?.[key] === id;
+        });
+        expect(matching, `missing staged delete for ${table}:${id}`).to.exist;
+      }
     });
   });
 });

--- a/tests/v2/live-api/cascade-delete.live.spec.js
+++ b/tests/v2/live-api/cascade-delete.live.spec.js
@@ -127,39 +127,103 @@ describe('Cascade Delete Live API Tests', function () {
     }
   });
 
-  it('should cascade delete unit_label rows when deleting a unit', async function () {
+  it('should cascade delete unit_label, issuance children, and verification children through commit', async function () {
+    // Build a shared entity graph once for three cascade-delete scenarios.
+    // This avoids three separate commit cycles that would each add ~2 minutes.
     const programId = await postAndGetId('/v2/program', generateProgram(), 'cadTrustProgramId');
     const projectId = await postAndGetId('/v2/project', generateProject(programId), 'cadTrustProjectId');
     const methodologyId = await postAndGetId('/v2/methodology', generateMethodology(), 'cadTrustMethodologyId');
-    const validationId = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
-    const verificationId = await postAndGetId('/v2/verification', generateVerification(projectId, validationId), 'cadTrustVerificationId');
-    const projectMethodologyId = await postAndGetId('/v2/project-methodology', generateProjectMethodology(projectId, methodologyId), 'cadTrustProjectMethodologyId');
-    const issuanceId = await postAndGetId('/v2/issuance', generateIssuance(verificationId, projectMethodologyId), 'cadTrustIssuanceId');
-    const unitId = await postAndGetId('/v2/unit', generateUnit(issuanceId), 'cadTrustUnitId');
-    const labelId = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
-    const unitLabelId = await postAndGetId('/v2/unit-label', generateUnitLabel(labelId, unitId), 'cadTrustUnitLabelId');
 
+    // Verification 1 — will be deleted as a mid-chain cascade test
+    const val1Id = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
+    const ver1Id = await postAndGetId('/v2/verification', generateVerification(projectId, val1Id), 'cadTrustVerificationId');
+    const pm1Id = await postAndGetId('/v2/project-methodology', generateProjectMethodology(projectId, methodologyId), 'cadTrustProjectMethodologyId');
+    const iss1Id = await postAndGetId('/v2/issuance', generateIssuance(ver1Id, pm1Id), 'cadTrustIssuanceId');
+    const unit1Id = await postAndGetId('/v2/unit', generateUnit(iss1Id), 'cadTrustUnitId');
+    const label1Id = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
+    const ul1Id = await postAndGetId('/v2/unit-label', generateUnitLabel(label1Id, unit1Id), 'cadTrustUnitLabelId');
+
+    // Issuance 2 — will be deleted standalone
+    const val2Id = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
+    const ver2Id = await postAndGetId('/v2/verification', generateVerification(projectId, val2Id), 'cadTrustVerificationId');
+    const iss2Id = await postAndGetId('/v2/issuance', generateIssuance(ver2Id, pm1Id), 'cadTrustIssuanceId');
+    const unit2Id = await postAndGetId('/v2/unit', generateUnit(iss2Id), 'cadTrustUnitId');
+    const label2Id = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
+    const ul2Id = await postAndGetId('/v2/unit-label', generateUnitLabel(label2Id, unit2Id), 'cadTrustUnitLabelId');
+
+    // Unit 3 — will test bare unit → unit_label cascade
+    const val3Id = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
+    const ver3Id = await postAndGetId('/v2/verification', generateVerification(projectId, val3Id), 'cadTrustVerificationId');
+    const iss3Id = await postAndGetId('/v2/issuance', generateIssuance(ver3Id, pm1Id), 'cadTrustIssuanceId');
+    const unit3Id = await postAndGetId('/v2/unit', generateUnit(iss3Id), 'cadTrustUnitId');
+    const label3Id = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
+    const ul3Id = await postAndGetId('/v2/unit-label', generateUnitLabel(label3Id, unit3Id), 'cadTrustUnitLabelId');
+
+    // Commit the full graph in one cycle
     await commitStagedRecords(request, [], true);
     await waitForPendingCommits(request);
     await waitForStagingEmpty(request);
-    await waitForDataToAppear(request, 'unit-label', unitLabelId);
+    await waitForDataToAppear(request, 'unit-label', ul3Id);
 
-    const deleteResponse = await request.delete(`/v2/unit/${unitId}`).expect(200);
-    expect(deleteResponse.body.success).to.equal(true);
-    expect(deleteResponse.body.stagedChildDeletes).to.equal(1);
+    // --- Scenario A: Delete unit3 → should cascade unit_label ---
+    const unitDelResp = await request.delete(`/v2/unit/${unit3Id}`).expect(200);
+    expect(unitDelResp.body.success).to.equal(true);
+    expect(unitDelResp.body.stagedChildDeletes).to.equal(1);
 
-    const stagingResponse = await request.get('/v2/staging').query({ page: 1, limit: 200 }).expect(200);
+    // --- Scenario B: Delete issuance2 → should cascade unit2 + unit_label2 ---
+    const issDelResp = await request.delete(`/v2/issuance/${iss2Id}`).expect(200);
+    expect(issDelResp.body.success).to.equal(true);
+    expect(issDelResp.body.stagedChildDeletes).to.equal(2);
+
+    // --- Scenario C: Delete verification1 → should cascade issuance1, unit1, unit_label1 ---
+    const verDelResp = await request.delete(`/v2/verification/${ver1Id}`).expect(200);
+    expect(verDelResp.body.success).to.equal(true);
+    expect(verDelResp.body.stagedChildDeletes).to.equal(3);
+
+    // Verify all expected staging rows
+    const stagingResponse = await request.get('/v2/staging').query({ page: 1, limit: 500 }).expect(200);
     const stagedRows = stagingResponse.body?.data || [];
-    expect(hasStagedDelete(stagedRows, 'unit_label', 'cad_trust_unit_label_id', unitLabelId)).to.equal(true);
-    expect(hasStagedDelete(stagedRows, 'unit', 'cad_trust_unit_id', unitId)).to.equal(true);
 
+    const expectedStagedDeletes = [
+      // Scenario A
+      ['unit', 'cad_trust_unit_id', unit3Id],
+      ['unit_label', 'cad_trust_unit_label_id', ul3Id],
+      // Scenario B
+      ['issuance', 'cad_trust_issuance_id', iss2Id],
+      ['unit', 'cad_trust_unit_id', unit2Id],
+      ['unit_label', 'cad_trust_unit_label_id', ul2Id],
+      // Scenario C
+      ['verification', 'cad_trust_verification_id', ver1Id],
+      ['issuance', 'cad_trust_issuance_id', iss1Id],
+      ['unit', 'cad_trust_unit_id', unit1Id],
+      ['unit_label', 'cad_trust_unit_label_id', ul1Id],
+    ];
+
+    for (const [table, key, value] of expectedStagedDeletes) {
+      expect(hasStagedDelete(stagedRows, table, key, value), `missing staged delete ${table}:${value}`).to.equal(true);
+    }
+
+    // Commit all deletes in one cycle
     await commitStagedRecords(request, [], true);
     await waitForPendingCommits(request);
     await waitForStagingEmpty(request);
 
-    const unitLabelGet = await request.get(`/v2/unit-label/${unitLabelId}`);
-    const unitGet = await request.get(`/v2/unit/${unitId}`);
-    expect([400, 404]).to.include(unitLabelGet.status);
-    expect([400, 404]).to.include(unitGet.status);
+    // Verify everything is gone
+    const toVerifyMissing = [
+      ['/v2/unit', unit3Id],
+      ['/v2/unit-label', ul3Id],
+      ['/v2/issuance', iss2Id],
+      ['/v2/unit', unit2Id],
+      ['/v2/unit-label', ul2Id],
+      ['/v2/verification', ver1Id],
+      ['/v2/issuance', iss1Id],
+      ['/v2/unit', unit1Id],
+      ['/v2/unit-label', ul1Id],
+    ];
+
+    for (const [endpoint, id] of toVerifyMissing) {
+      const resp = await request.get(`${endpoint}/${id}`);
+      expect([400, 404]).to.include(resp.status);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **Fixes orphaned children on verification/issuance delete**: `DELETE /v2/verification/:id` now cascades to issuances → units → unit_labels, and `DELETE /v2/issuance/:id` now cascades to units → unit_labels. Previously only the parent row was staged, leaving downstream records orphaned in the datalayer.
- **Adds `stageVerificationChildDeletes` and `stageIssuanceChildDeletes`** to `v2-cascade-delete.js`, mirroring the existing project and unit cascade patterns (transaction + mutex).
- **Documents the two-category deletion design** in a JSDoc block: project-scoped records cascade on delete; shared/standalone records (methodology, stakeholder, program, label) intentionally do NOT cascade because they can be cross-referenced by other registries on the network.

## Test plan

### Integration tests (all new, run via `npm run test:v2`)
- [x] Verification cascade: delete verification → stages issuance + unit + unit_label deletes (3 child deletes)
- [x] Issuance cascade: delete issuance with 2 units + 2 unit_labels → stages all 4 child deletes (also covers multi-unit-per-issuance edge case)
- [x] Issuance no-children: delete issuance with no units → `stagedChildDeletes === 0`
- [x] Verification no-children: existing test updated to assert `stagedChildDeletes === 0`
- [x] Double delete: deleting a project twice before commit creates duplicate staging rows (documents current behavior)
- [x] Multi-unit cascade: project delete with 2 units under one issuance cascades all units + unit_labels

### Live API tests (run via `npm run test:v2:live:cascade-delete`)
- [x] Batched test covering all three cascade levels in one commit cycle: unit → unit_label, issuance → unit + unit_label, verification → issuance + unit + unit_label. Replaces the previous single unit-cascade test to add coverage without adding extra commit cycles (~2 min each).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies V2 deletion staging for `verification` and `issuance` to add transactional cascade behavior; mistakes could over/under-delete staged records or impact DataLayer sync ordering, but scope is limited to delete paths and is covered by new integration/live tests.
> 
> **Overview**
> **Fixes mid-chain delete staging for V2 `verification` and `issuance`.** `DELETE /v2/verification/:id` now also stages deletes for downstream `issuance → unit → unit_label`, and `DELETE /v2/issuance/:id` now stages `unit → unit_label` deletes to prevent orphaned children.
> 
> Deletes are now staged under the existing V2 mutex + `sequelizeV2.transaction`, and responses include `stagedChildDeletes` for visibility. Adds new cascade helpers (`stageVerificationChildDeletes`, `stageIssuanceChildDeletes`) plus expanded integration and live API coverage for multi-child cascades, no-children cases, and documenting current double-delete-before-commit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcdb60fc0757b638e700753bab5fb3787ee4a2b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->