### PR TITLE
fix: upgrade to node:24-trixie and rebuild sqlite3 from source

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,68 @@
+name: Docker Smoke Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+      - 'v2-*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  docker-smoke-test:
+    name: Docker smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build Docker image
+        run: docker build -t cadt-smoke-test .
+
+      - name: Verify native modules load
+        run: |
+          docker run --rm --entrypoint node --workdir /app cadt-smoke-test \
+            --input-type=commonjs -e \
+            "require('sqlite3'); console.log('sqlite3 native module loaded OK')"
+
+      - name: Verify container starts and health endpoints respond
+        run: |
+          trap 'docker rm -f cadt-test > /dev/null 2>&1 || true' EXIT
+
+          docker run -d --name cadt-test \
+            -e USE_SIMULATOR=true \
+            -e BIND_ADDRESS=0.0.0.0 \
+            -p 31310:31310 \
+            cadt-smoke-test
+
+          for i in $(seq 1 60); do
+            if docker logs cadt-test 2>&1 | grep -q "Server listening"; then
+              echo "Server started successfully"
+              break
+            fi
+            if ! docker ps -q --filter "name=cadt-test" | grep -q .; then
+              echo "Container exited unexpectedly:"
+              docker logs cadt-test 2>&1
+              exit 1
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Timeout waiting for server to start"
+              docker logs cadt-test 2>&1
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "Testing health endpoints..."
+
+          curl -sf http://localhost:31310/health | jq .
+          curl -sf http://localhost:31310/v1/health | jq .
+          curl -sf http://localhost:31310/v2/health | jq .
+
+          echo "All health checks passed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mikefarah/yq:4 AS yq
 
-FROM node:24
+FROM node:24-trixie
 
 # Copy yq from the yq image
 COPY --from=yq /usr/bin/yq /usr/local/bin/yq
@@ -15,7 +15,7 @@ COPY src /app/src/
 COPY tests /app/tests/
 WORKDIR /app
 
-RUN npm install
+RUN npm install && npm rebuild sqlite3 --build-from-source
 
 RUN mkdir -p /root/.chia/mainnet/config/ssl && mkdir -p /root/.chia/mainnet/cadt/v1
 


### PR DESCRIPTION
## Summary

- The `node:24` Docker image defaults to **Debian Bookworm** (glibc **2.36**)
- The `sqlite3` npm package (v6.0.1) downloads a prebuilt native binary via `prebuild-install` that requires glibc **2.38**
- This mismatch causes a fatal `GLIBC_2.38 not found` error at container startup, putting CADT pods into CrashLoopBackOff across all chiamanaged namespaces

### Changes

1. **Upgrade base image** from `node:24` (Bookworm / glibc 2.36) to `node:24-trixie` (Debian 13 stable since Aug 2025 / glibc 2.41) — prebuilt native binaries are now compatible with the container's C library
2. **Add `npm rebuild sqlite3 --build-from-source`** as a safety net — compiles the native addon against the container's actual glibc, guarding against future prebuilt binary mismatches
3. **Add Docker smoke test CI workflow** — builds the image and verifies native module loading + container startup on every PR and push to develop/main/v2-*. This would have caught the GLIBC mismatch before it reached k8s.

## Test plan

- [ ] New `Docker Smoke Test` CI workflow passes on this PR
- [ ] CADT container starts without `GLIBC_2.38 not found` error
- [ ] Pods recover from CrashLoopBackOff after redeployment with new image

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the production container base image and native module build behavior, which can affect runtime compatibility and image size/build time.
> 
> **Overview**
> Fixes a container startup failure caused by `sqlite3` native binary/glibc incompatibility by switching the Docker base image from `node:24` to `node:24-trixie` and forcing `sqlite3` to rebuild from source during `npm install`.
> 
> Adds a GitHub Actions `Docker Smoke Test` workflow that builds the image, verifies `require('sqlite3')` works, starts the container, and checks `/health`, `/v1/health`, and `/v2/health` endpoints on PRs and pushes to `develop`/`main`/`v2-*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1b24fd3a6122d5c8e5d31fffd8d3a97d5f59167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->