### PR TITLE
RC release for docker build fix

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -1,0 +1,68 @@
+name: Docker Smoke Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+      - 'v2-*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  docker-smoke-test:
+    name: Docker smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build Docker image
+        run: docker build -t cadt-smoke-test .
+
+      - name: Verify native modules load
+        run: |
+          docker run --rm --entrypoint node --workdir /app cadt-smoke-test \
+            --input-type=commonjs -e \
+            "require('sqlite3'); console.log('sqlite3 native module loaded OK')"
+
+      - name: Verify container starts and health endpoints respond
+        run: |
+          trap 'docker rm -f cadt-test > /dev/null 2>&1 || true' EXIT
+
+          docker run -d --name cadt-test \
+            -e USE_SIMULATOR=true \
+            -e BIND_ADDRESS=0.0.0.0 \
+            -p 31310:31310 \
+            cadt-smoke-test
+
+          for i in $(seq 1 60); do
+            if docker logs cadt-test 2>&1 | grep -q "Server listening"; then
+              echo "Server started successfully"
+              break
+            fi
+            if ! docker ps -q --filter "name=cadt-test" | grep -q .; then
+              echo "Container exited unexpectedly:"
+              docker logs cadt-test 2>&1
+              exit 1
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Timeout waiting for server to start"
+              docker logs cadt-test 2>&1
+              exit 1
+            fi
+            sleep 1
+          done
+
+          echo "Testing health endpoints..."
+
+          curl -sf http://localhost:31310/health | jq .
+          curl -sf http://localhost:31310/v1/health | jq .
+          curl -sf http://localhost:31310/v2/health | jq .
+
+          echo "All health checks passed"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mikefarah/yq:4 AS yq
 
-FROM node:24
+FROM node:24-trixie
 
 # Copy yq from the yq image
 COPY --from=yq /usr/bin/yq /usr/local/bin/yq
@@ -15,7 +15,7 @@ COPY src /app/src/
 COPY tests /app/tests/
 WORKDIR /app
 
-RUN npm install
+RUN npm install && npm rebuild sqlite3 --build-from-source
 
 RUN mkdir -p /root/.chia/mainnet/config/ssl && mkdir -p /root/.chia/mainnet/cadt/v1
 

--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -3594,6 +3594,25 @@ Response
 
 #### Split unit into multiple units
 
+Splits an existing unit into multiple units. Each new unit inherits all fields from the original unit, then overrides only the fields you provide in each record. The first record keeps the original unit's `cadTrustUnitId`; subsequent records receive new UUIDs.
+
+**Required fields per record:**
+
+| Field | Type | Description |
+|---|---|---|
+| `unitCount` | number | Number of units in this split. The sum of all `unitCount` values must equal the original unit's `unitCount`. |
+
+**Optional fields per record** (override the original unit's values):
+
+| Field | Type | Description |
+|---|---|---|
+| `unitBlockStart` | string | Start block for this split. If both `unitBlockStart` and `unitBlockEnd` are provided, `unitSerialId` is automatically derived. |
+| `unitBlockEnd` | string | End block for this split. |
+| `unitCurrentOwner` | string | New owner for this split. |
+| `unitStatus` | string | Status for this split (e.g., "Issued", "Held", "Retired"). |
+| `unitStatusReason` | string | Reason for the status. |
+| `unitStatusDate` | string | Date of the status change (YYYY-MM-DD). |
+
 Request
 ```shell
 curl --location -g --request POST 'localhost:31310/v2/unit/split' \
@@ -3605,16 +3624,17 @@ curl --location -g --request POST 'localhost:31310/v2/unit/split' \
       "unitCount": 10,
       "unitBlockStart": "A001",
       "unitBlockEnd": "A010",
-      "unitOwner": "New Owner 1",
+      "unitCurrentOwner": "New Owner 1",
       "unitStatus": "Issued",
-      "countryJurisdictionOfOwner": "Bhutan"
+      "unitStatusReason": "Split for partial transfer",
+      "unitStatusDate": "2026-04-07"
     },
     {
       "unitCount": 5,
       "unitBlockStart": "B001",
       "unitBlockEnd": "B005",
-      "unitStatus": "Held",
-      "countryJurisdictionOfOwner": "Canada"
+      "unitCurrentOwner": "New Owner 2",
+      "unitStatus": "Held"
     }
   ]
 }'
@@ -3624,6 +3644,7 @@ Response
 ```json
 {
   "message": "Unit split successful",
+  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "success": true
 }
 ```

--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -1890,18 +1890,36 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustMethodologyId`.
 
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `project_methodology` records reference this methodology, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/methodology/9b9bb857-c71b-4649-b805-a289db27dc1c' \
 --header 'Content-Type: application/json'
 ```
 
-Response
+Response (success — no references)
 ```json
 {
-  "message": "Methodology deletion staged successfully",
+  "message": "Methodology delete staged successfully",
   "success": true
 }
+```
+
+Response (409 — references exist)
+```json
+{
+  "success": false,
+  "message": "Cannot delete methodology: referenced by 2 project-methodology links",
+  "references": [{ "table": "project_methodology", "count": 2 }],
+  "hint": "Remove all references first, or use ?force=true to delete anyway"
+}
+```
+
+Force delete (bypass guard)
+```shell
+curl --location --request DELETE 'localhost:31310/v2/methodology/9b9bb857-c71b-4649-b805-a289db27dc1c?force=true' \
+--header 'Content-Type: application/json'
 ```
 
 ---
@@ -2058,18 +2076,36 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustProgramId`.
 
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `project` records reference this program via `cadTrustProgramId`, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/program/51ca9638-22b0-4e14-ae7a-c09d23b37b58' \
 --header 'Content-Type: application/json'
 ```
 
-Response
+Response (success — no references)
 ```json
 {
-  "message": "Program deletion staged successfully",
+  "message": "Program delete staged successfully",
   "success": true
 }
+```
+
+Response (409 — references exist)
+```json
+{
+  "success": false,
+  "message": "Cannot delete program: referenced by 3 projects",
+  "references": [{ "table": "project", "count": 3 }],
+  "hint": "Remove all references first, or use ?force=true to delete anyway"
+}
+```
+
+Force delete (bypass guard)
+```shell
+curl --location --request DELETE 'localhost:31310/v2/program/51ca9638-22b0-4e14-ae7a-c09d23b37b58?force=true' \
+--header 'Content-Type: application/json'
 ```
 
 ---
@@ -4527,18 +4563,36 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustStakeholderId`.
 
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `stakeholder_projects` records reference this stakeholder, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/stakeholder/e880047e-cdf4-45bb-a9df-e706fa427713' \
 --header 'Content-Type: application/json'
 ```
 
-Response
+Response (success — no references)
 ```json
 {
-  "message": "Stakeholder deletion staged successfully",
+  "message": "Stakeholder delete staged successfully",
   "success": true
 }
+```
+
+Response (409 — references exist)
+```json
+{
+  "success": false,
+  "message": "Cannot delete stakeholder: referenced by 1 stakeholder-project links",
+  "references": [{ "table": "stakeholder_projects", "count": 1 }],
+  "hint": "Remove all references first, or use ?force=true to delete anyway"
+}
+```
+
+Force delete (bypass guard)
+```shell
+curl --location --request DELETE 'localhost:31310/v2/stakeholder/e880047e-cdf4-45bb-a9df-e706fa427713?force=true' \
+--header 'Content-Type: application/json'
 ```
 
 ---
@@ -4837,18 +4891,36 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustLabelId`.
 
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `unit_label` records reference this label, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/label/dcacd68e-1cfb-4f06-9798-efa0aacda42c' \
 --header 'Content-Type: application/json'
 ```
 
-Response
+Response (success — no references)
 ```json
 {
-  "message": "Label deletion staged successfully",
+  "message": "Label delete staged successfully",
   "success": true
 }
+```
+
+Response (409 — references exist)
+```json
+{
+  "success": false,
+  "message": "Cannot delete label: referenced by 4 unit-label links",
+  "references": [{ "table": "unit_label", "count": 4 }],
+  "hint": "Remove all references first, or use ?force=true to delete anyway"
+}
+```
+
+Force delete (bypass guard)
+```shell
+curl --location --request DELETE 'localhost:31310/v2/label/dcacd68e-1cfb-4f06-9798-efa0aacda42c?force=true' \
+--header 'Content-Type: application/json'
 ```
 
 ---

--- a/src/controllers/v2/label-v2.controller.js
+++ b/src/controllers/v2/label-v2.controller.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 import { StagingV2, LabelV2, OrganizationsV2 } from '../../models/v2/index.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 import { labelV2Schema } from '../../validations/v2/label-v2.validations.js';
 import {
   assertV2IfReadOnlyMode,
@@ -263,7 +264,6 @@ export const deleteLabelV2 = async (req, res) => {
 
     const { id } = req.params;
 
-    // Verify record exists
     const existingRecord = await LabelV2.findByPk(id);
     if (!existingRecord) {
       return res.status(404).json({
@@ -272,12 +272,19 @@ export const deleteLabelV2 = async (req, res) => {
       });
     }
 
-    // Stage the delete
+    const force = req.query.force === 'true';
+    if (!force) {
+      const refResult = await checkReferences('label', id);
+      if (refResult.hasReferences) {
+        return res.status(409).json(buildReferenceConflictBody('label', refResult));
+      }
+    }
+
     await StagingV2.create({
       uuid: uuidv4(),
       table: 'label',
       action: 'DELETE',
-      data: JSON.stringify([{ cad_trust_label_id: id }]), // Use UUID string directly
+      data: JSON.stringify([{ cad_trust_label_id: id }]),
       committed: false,
       failed_commit: false,
       is_transfer: false,

--- a/src/controllers/v2/methodology-v2.controller.js
+++ b/src/controllers/v2/methodology-v2.controller.js
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Sequelize } from 'sequelize';
 
 import { StagingV2, MethodologyV2, OrganizationsV2 } from '../../models/v2/index.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 
 import {
   optionallyPaginatedResponse,
@@ -267,7 +268,6 @@ export const destroy = async (req, res) => {
 
     const { id } = req.params;
 
-    // Verify record exists
     const existingRecord = await MethodologyV2.findByPk(id);
     if (!existingRecord) {
       return res.status(404).json({
@@ -276,7 +276,14 @@ export const destroy = async (req, res) => {
       });
     }
 
-    // Stage the delete
+    const force = req.query.force === 'true';
+    if (!force) {
+      const refResult = await checkReferences('methodology', id);
+      if (refResult.hasReferences) {
+        return res.status(409).json(buildReferenceConflictBody('methodology', refResult));
+      }
+    }
+
     await StagingV2.create({
       uuid: uuidv4(),
       table: 'methodology',

--- a/src/controllers/v2/program-v2.controller.js
+++ b/src/controllers/v2/program-v2.controller.js
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Sequelize } from 'sequelize';
 
 import { StagingV2, ProgramV2, OrganizationsV2 } from '../../models/v2/index.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 
 import {
   optionallyPaginatedResponse,
@@ -256,7 +257,6 @@ export const destroy = async (req, res) => {
 
     const { id } = req.params;
 
-    // Verify record exists
     const existingRecord = await ProgramV2.findByPk(id);
     if (!existingRecord) {
       return res.status(404).json({
@@ -265,12 +265,19 @@ export const destroy = async (req, res) => {
       });
     }
 
-    // Stage the delete
+    const force = req.query.force === 'true';
+    if (!force) {
+      const refResult = await checkReferences('program', id);
+      if (refResult.hasReferences) {
+        return res.status(409).json(buildReferenceConflictBody('program', refResult));
+      }
+    }
+
     await StagingV2.create({
       uuid: uuidv4(),
       table: 'program',
       action: 'DELETE',
-      data: JSON.stringify([{ cad_trust_program_id: id }]), // Use UUID string directly
+      data: JSON.stringify([{ cad_trust_program_id: id }]),
       committed: false,
       failed_commit: false,
       is_transfer: false,

--- a/src/controllers/v2/stakeholder-v2.controller.js
+++ b/src/controllers/v2/stakeholder-v2.controller.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 
 import { StagingV2, StakeholderV2, OrganizationsV2 } from '../../models/v2/index.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 import { stakeholderV2Schema } from '../../validations/v2/stakeholder-v2.validations.js';
 import {
   assertV2IfReadOnlyMode,
@@ -254,7 +255,6 @@ export const deleteStakeholderV2 = async (req, res) => {
 
     const { id } = req.params;
 
-    // Verify record exists
     const existingRecord = await StakeholderV2.findByPk(id);
     if (!existingRecord) {
       return res.status(404).json({
@@ -263,12 +263,19 @@ export const deleteStakeholderV2 = async (req, res) => {
       });
     }
 
-    // Stage the delete
+    const force = req.query.force === 'true';
+    if (!force) {
+      const refResult = await checkReferences('stakeholder', id);
+      if (refResult.hasReferences) {
+        return res.status(409).json(buildReferenceConflictBody('stakeholder', refResult));
+      }
+    }
+
     await StagingV2.create({
       uuid: uuidv4(),
       table: 'stakeholder',
       action: 'DELETE',
-      data: JSON.stringify([{ cad_trust_stakeholder_id: id }]), // Use UUID string directly
+      data: JSON.stringify([{ cad_trust_stakeholder_id: id }]),
       committed: false,
       failed_commit: false,
       is_transfer: false,

--- a/src/utils/v2-cascade-delete.js
+++ b/src/utils/v2-cascade-delete.js
@@ -1,5 +1,54 @@
 'use strict';
 
+/**
+ * V2 Cascade Delete — Design Rationale
+ *
+ * CADT records fall into two categories with fundamentally different deletion
+ * strategies. Understanding this distinction is critical before modifying any
+ * delete logic.
+ *
+ * ## 1. Project-scoped records — CASCADE on delete
+ *
+ * These are exclusively owned by a single project (or by a single unit in the
+ * case of unit_label). No other project or registry can reference them, so they
+ * are safe to cascade-delete when their parent is removed.
+ *
+ *   project → location, estimation, rating, co_benefit, validation,
+ *             verification, project_methodology (link), stakeholder_projects (link)
+ *   verification → issuance
+ *   issuance → unit
+ *   unit → unit_label
+ *
+ * When a project is deleted, the full chain above is traversed and every child
+ * gets a staged DELETE entry. When a unit is deleted, its unit_label rows are
+ * cascade-staged. The same applies to mid-chain deletes of verification or
+ * issuance — their downstream children must also be staged.
+ *
+ * ## 2. Shared / standalone records — DO NOT cascade
+ *
+ * These exist independently with their own org_uid and can be cross-referenced
+ * by any registry on the network:
+ *
+ *   methodology  — referenced via project_methodology from any project
+ *   stakeholder  — referenced via stakeholder_projects from any project
+ *   program      — referenced via cad_trust_program_id from any project
+ *   label        — referenced via unit_label from any unit
+ *
+ * Hard-deleting a shared record propagates through DataLayer sync to every
+ * subscriber, silently breaking referential integrity for any registry that
+ * still references it. There is no mechanism to notify affected registries.
+ *
+ * These records intentionally do NOT cascade. The correct approaches (in order
+ * of priority) are:
+ *   - Tier 2: Block delete with 409 if local references exist (or allow with
+ *             ?force=true after showing impact)
+ *   - Tier 3: Soft delete / deprecation (the only truly safe distributed
+ *             systems answer — tombstones over hard deletes)
+ *   - Tier 4: Orphan cleanup endpoint for records with zero local references
+ *
+ * See: docs/orphaned-records-analysis.md for the full analysis.
+ */
+
 import { v4 as uuidv4 } from 'uuid';
 import {
   StagingV2,

--- a/src/utils/v2-reference-guards.js
+++ b/src/utils/v2-reference-guards.js
@@ -19,6 +19,7 @@ import {
   StagingV2,
 } from '../models/v2/index.js';
 import { Op } from 'sequelize';
+import { toSnakeCase } from './v2-camel-to-snake.js';
 
 const REFERENCE_MAP = {
   methodology: [
@@ -55,13 +56,12 @@ const REFERENCE_MAP = {
   ],
 };
 
-const toSnakeCase = (value) => value.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`);
-
 const countStagedReferences = async (table, snakeFkField, recordId) => {
   const stagedRows = await StagingV2.findAll({
     where: {
       table,
       action: { [Op.in]: ['INSERT', 'UPDATE'] },
+      committed: false,
       failed_commit: false,
     },
     raw: true,

--- a/src/utils/v2-reference-guards.js
+++ b/src/utils/v2-reference-guards.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/**
+ * V2 Delete Reference Guards
+ *
+ * Prevents deletion of shared/standalone records (methodology, stakeholder,
+ * program, label) when local references still exist. Returns reference counts
+ * so the caller can decide whether to proceed with ?force=true.
+ *
+ * See v2-cascade-delete.js for the full design rationale on why these records
+ * must not be silently deleted.
+ */
+
+import {
+  ProjectMethodologyV2,
+  StakeholderProjectV2,
+  UnitLabelV2,
+  ProjectV2,
+  StagingV2,
+} from '../models/v2/index.js';
+import { Op } from 'sequelize';
+
+const REFERENCE_MAP = {
+  methodology: [
+    {
+      model: ProjectMethodologyV2,
+      fkField: 'cadTrustMethodologyId',
+      table: 'project_methodology',
+      label: 'project-methodology links',
+    },
+  ],
+  stakeholder: [
+    {
+      model: StakeholderProjectV2,
+      fkField: 'cadTrustStakeholderId',
+      table: 'stakeholder_projects',
+      label: 'stakeholder-project links',
+    },
+  ],
+  program: [
+    {
+      model: ProjectV2,
+      fkField: 'cadTrustProgramId',
+      table: 'project',
+      label: 'projects',
+    },
+  ],
+  label: [
+    {
+      model: UnitLabelV2,
+      fkField: 'cadTrustLabelId',
+      table: 'unit_label',
+      label: 'unit-label links',
+    },
+  ],
+};
+
+const toSnakeCase = (value) => value.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`);
+
+const countStagedReferences = async (table, snakeFkField, recordId) => {
+  const stagedRows = await StagingV2.findAll({
+    where: {
+      table,
+      action: { [Op.in]: ['INSERT', 'UPDATE'] },
+      failed_commit: false,
+    },
+    raw: true,
+  });
+
+  let count = 0;
+  for (const stagedRow of stagedRows) {
+    try {
+      const parsedData = JSON.parse(stagedRow.data);
+      const records = Array.isArray(parsedData) ? parsedData : [parsedData];
+      for (const record of records) {
+        if (record?.[snakeFkField] === recordId) {
+          count += 1;
+        }
+      }
+    } catch {
+      // Ignore malformed staging rows here; staging validation catches these separately.
+      continue;
+    }
+  }
+  return count;
+};
+
+/**
+ * Check whether any local records reference the given shared record.
+ *
+ * @param {string} table   – one of 'methodology', 'stakeholder', 'program', 'label'
+ * @param {string} recordId – PK of the record being deleted
+ * @returns {{ hasReferences: boolean, references: Array<{table: string, count: number, label: string}> }}
+ */
+export const checkReferences = async (table, recordId) => {
+  const definitions = REFERENCE_MAP[table];
+  if (!definitions) {
+    return { hasReferences: false, references: [] };
+  }
+
+  const references = [];
+
+  for (const { model, fkField, table: refTable, label } of definitions) {
+    const mainCount = await model.count({ where: { [fkField]: recordId } });
+    const stagedCount = await countStagedReferences(refTable, toSnakeCase(fkField), recordId);
+    const totalCount = mainCount + stagedCount;
+
+    if (totalCount > 0) {
+      references.push({ table: refTable, count: totalCount, label });
+    }
+  }
+
+  return {
+    hasReferences: references.length > 0,
+    references,
+  };
+};
+
+/**
+ * Build a 409 response body from a reference check result.
+ *
+ * @param {string} entityName – human-readable name ("methodology", "program", …)
+ * @param {{ references: Array<{count: number, label: string}> }} refResult
+ * @returns {object} JSON-serialisable response body
+ */
+export const buildReferenceConflictBody = (entityName, refResult) => {
+  const parts = refResult.references.map((r) => `${r.count} ${r.label}`);
+  return {
+    success: false,
+    message: `Cannot delete ${entityName}: referenced by ${parts.join(', ')}`,
+    references: refResult.references.map(({ table, count }) => ({ table, count })),
+    hint: 'Remove all references first, or use ?force=true to delete anyway',
+  };
+};

--- a/tests/v2/integration/label-v2.spec.js
+++ b/tests/v2/integration/label-v2.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { LabelV2, StagingV2, OrganizationsV2 } from '../../../src/models/v2/index.js';
+import { LabelV2, StagingV2, OrganizationsV2, UnitLabelV2 } from '../../../src/models/v2/index.js';
 import { v4 as uuidv4 } from 'uuid';
 import { createV2TestHomeOrg } from '../utils/v2-test-helpers.js';
 
@@ -615,6 +615,101 @@ describe('Label V2 Endpoint Integration Tests', function () {
       expect(response.body).to.have.property('message');
       expect(response.body.message).to.equal('Label delete staged successfully');
       expect(response.body).to.have.property('success', true);
+    });
+  });
+
+  describe('DELETE /v2/label/:id — reference guards', function () {
+    beforeEach(async function () {
+      await StagingV2.destroy({ where: {} });
+      await UnitLabelV2.destroy({ where: {} });
+    });
+
+    it('should return 409 when unit_label references exist', async function () {
+      const label = await LabelV2.create({
+        cadTrustLabelId: uuidv4(),
+        labelName: 'Referenced Label',
+        labelType: 'Certification',
+      });
+
+      await UnitLabelV2.create({
+        cadTrustUnitLabelId: uuidv4(),
+        cadTrustLabelId: label.cadTrustLabelId,
+        cadTrustUnitId: uuidv4(),
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/label/${label.cadTrustLabelId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.message).to.include('Cannot delete label');
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('unit_label');
+      expect(response.body.references[0].count).to.equal(1);
+      expect(response.body.hint).to.include('force=true');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'label', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.be.null;
+    });
+
+    it('should return 409 when staged unit_label references exist', async function () {
+      const label = await LabelV2.create({
+        cadTrustLabelId: uuidv4(),
+        labelName: 'Staged Referenced Label',
+        labelType: 'Certification',
+      });
+
+      await StagingV2.create({
+        uuid: uuidv4(),
+        table: 'unit_label',
+        action: 'INSERT',
+        data: JSON.stringify([{
+          cad_trust_unit_label_id: uuidv4(),
+          cad_trust_label_id: label.cadTrustLabelId,
+          cad_trust_unit_id: uuidv4(),
+        }]),
+        committed: false,
+        failed_commit: false,
+        is_transfer: false,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/label/${label.cadTrustLabelId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('unit_label');
+      expect(response.body.references[0].count).to.equal(1);
+    });
+
+    it('should allow delete with ?force=true despite references', async function () {
+      const label = await LabelV2.create({
+        cadTrustLabelId: uuidv4(),
+        labelName: 'Force Delete Label',
+        labelType: 'Certification',
+      });
+
+      await UnitLabelV2.create({
+        cadTrustUnitLabelId: uuidv4(),
+        cadTrustLabelId: label.cadTrustLabelId,
+        cadTrustUnitId: uuidv4(),
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/label/${label.cadTrustLabelId}`)
+        .query({ force: 'true' })
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.message).to.equal('Label delete staged successfully');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'label', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.exist;
     });
   });
 });

--- a/tests/v2/integration/methodology-v2.spec.js
+++ b/tests/v2/integration/methodology-v2.spec.js
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StagingV2, MethodologyV2 } from '../../../src/models/v2/index.js';
+import { StagingV2, MethodologyV2, ProjectMethodologyV2, ProjectV2, ProgramV2 } from '../../../src/models/v2/index.js';
+import { v4 as uuidv4 } from 'uuid';
 import {
   resetV2StagingTable,
   resetV2DataTables,
@@ -395,6 +396,126 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
       // Verify staged deletion data
       const stagedData = JSON.parse(stagingRecord.data);
       expect(stagedData[0].cad_trust_methodology_id).to.equal('test-uuid-delete');
+    });
+  });
+
+  describe('DELETE /v2/methodology/:id — reference guards', function () {
+    it('should return 409 when project_methodology references exist', async function () {
+      const methodology = await MethodologyV2.create({
+        cadTrustMethodologyId: uuidv4(),
+        methodologyCode: 'REFGUARD-METHOD-001',
+        methodologyName: 'Referenced Methodology',
+      });
+
+      const program = await ProgramV2.create({
+        programName: 'Ref Guard Program',
+        programRegistry: 'Test Registry',
+        programRegistryActivityId: 'REFGUARD-001',
+      });
+
+      const project = await ProjectV2.create({
+        cadTrustProjectId: uuidv4(),
+        orgUid: 'test-home-org-v2',
+        projectRegistryName: 'Test Registry',
+        projectId: 'REFGUARD-PROJ-001',
+        projectName: 'Ref Guard Project',
+        cadTrustProgramId: program.cadTrustProgramId,
+      });
+
+      await ProjectMethodologyV2.create({
+        cadTrustProjectMethodologyId: uuidv4(),
+        cadTrustProjectId: project.cadTrustProjectId,
+        cadTrustMethodologyId: methodology.cadTrustMethodologyId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/methodology/${methodology.cadTrustMethodologyId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.message).to.include('Cannot delete methodology');
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('project_methodology');
+      expect(response.body.references[0].count).to.equal(1);
+      expect(response.body.hint).to.include('force=true');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'methodology', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.be.null;
+    });
+
+    it('should return 409 when staged project_methodology references exist', async function () {
+      const methodology = await MethodologyV2.create({
+        cadTrustMethodologyId: uuidv4(),
+        methodologyCode: 'STAGED-REF-METHOD-001',
+        methodologyName: 'Staged Referenced Methodology',
+      });
+
+      await StagingV2.create({
+        uuid: uuidv4(),
+        table: 'project_methodology',
+        action: 'INSERT',
+        data: JSON.stringify([{
+          cad_trust_project_methodology_id: uuidv4(),
+          cad_trust_project_id: uuidv4(),
+          cad_trust_methodology_id: methodology.cadTrustMethodologyId,
+        }]),
+        committed: false,
+        failed_commit: false,
+        is_transfer: false,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/methodology/${methodology.cadTrustMethodologyId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('project_methodology');
+      expect(response.body.references[0].count).to.equal(1);
+    });
+
+    it('should allow delete with ?force=true despite references', async function () {
+      const methodology = await MethodologyV2.create({
+        cadTrustMethodologyId: uuidv4(),
+        methodologyCode: 'FORCE-METHOD-001',
+        methodologyName: 'Force Delete Methodology',
+      });
+
+      const program = await ProgramV2.create({
+        programName: 'Force Delete Program',
+        programRegistry: 'Test Registry',
+        programRegistryActivityId: 'FORCE-001',
+      });
+
+      const project = await ProjectV2.create({
+        cadTrustProjectId: uuidv4(),
+        orgUid: 'test-home-org-v2',
+        projectRegistryName: 'Test Registry',
+        projectId: 'FORCE-PROJ-001',
+        projectName: 'Force Delete Project',
+        cadTrustProgramId: program.cadTrustProgramId,
+      });
+
+      await ProjectMethodologyV2.create({
+        cadTrustProjectMethodologyId: uuidv4(),
+        cadTrustProjectId: project.cadTrustProjectId,
+        cadTrustMethodologyId: methodology.cadTrustMethodologyId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/methodology/${methodology.cadTrustMethodologyId}`)
+        .query({ force: 'true' })
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.message).to.equal('Methodology delete staged successfully');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'methodology', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.exist;
     });
   });
 });

--- a/tests/v2/integration/program-v2.spec.js
+++ b/tests/v2/integration/program-v2.spec.js
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StagingV2, ProgramV2 } from '../../../src/models/v2/index.js';
+import { StagingV2, ProgramV2, ProjectV2 } from '../../../src/models/v2/index.js';
+import { v4 as uuidv4 } from 'uuid';
 import {
   resetV2StagingTable,
   resetV2DataTables,
@@ -425,6 +426,108 @@ describe('V2 Program API - Basic CRUD Tests', function () {
       // Verify staged deletion data
       const stagedData = JSON.parse(stagingRecord.data);
       expect(stagedData[0].cad_trust_program_id).to.equal(program.cadTrustProgramId);
+    });
+  });
+
+  describe('DELETE /v2/program/:id — reference guards', function () {
+    it('should return 409 when projects reference the program', async function () {
+      const program = await ProgramV2.create({
+        cadTrustProgramId: uuidv4(),
+        programName: 'Referenced Program',
+        programRegistry: 'Test Registry',
+        programRegistryActivityId: 'REFGUARD-PROG-001',
+      });
+
+      await ProjectV2.create({
+        cadTrustProjectId: uuidv4(),
+        orgUid: 'test-home-org-v2',
+        projectRegistryName: 'Test Registry',
+        projectId: 'REFGUARD-PROJ-001',
+        projectName: 'Project Using Program',
+        cadTrustProgramId: program.cadTrustProgramId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/program/${program.cadTrustProgramId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.message).to.include('Cannot delete program');
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('project');
+      expect(response.body.references[0].count).to.equal(1);
+      expect(response.body.hint).to.include('force=true');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'program', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.be.null;
+    });
+
+    it('should return 409 when staged project references exist', async function () {
+      const program = await ProgramV2.create({
+        cadTrustProgramId: uuidv4(),
+        programName: 'Staged Referenced Program',
+        programRegistry: 'Test Registry',
+        programRegistryActivityId: 'STAGED-REF-PROG-001',
+      });
+
+      await StagingV2.create({
+        uuid: uuidv4(),
+        table: 'project',
+        action: 'INSERT',
+        data: JSON.stringify([{
+          cad_trust_project_id: uuidv4(),
+          org_uid: 'test-home-org-v2',
+          project_registry_name: 'Test Registry',
+          project_id: 'STAGED-REF-PROJECT-001',
+          project_name: 'Staged Project',
+          cad_trust_program_id: program.cadTrustProgramId,
+        }]),
+        committed: false,
+        failed_commit: false,
+        is_transfer: false,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/program/${program.cadTrustProgramId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('project');
+      expect(response.body.references[0].count).to.equal(1);
+    });
+
+    it('should allow delete with ?force=true despite references', async function () {
+      const program = await ProgramV2.create({
+        cadTrustProgramId: uuidv4(),
+        programName: 'Force Delete Program',
+        programRegistry: 'Test Registry',
+        programRegistryActivityId: 'FORCE-PROG-001',
+      });
+
+      await ProjectV2.create({
+        cadTrustProjectId: uuidv4(),
+        orgUid: 'test-home-org-v2',
+        projectRegistryName: 'Test Registry',
+        projectId: 'FORCE-PROJ-001',
+        projectName: 'Project Using Program for Force',
+        cadTrustProgramId: program.cadTrustProgramId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/program/${program.cadTrustProgramId}`)
+        .query({ force: 'true' })
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.message).to.equal('Program delete staged successfully');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'program', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.exist;
     });
   });
 });

--- a/tests/v2/integration/stakeholder-v2.spec.js
+++ b/tests/v2/integration/stakeholder-v2.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StakeholderV2, StagingV2 } from '../../../src/models/v2/index.js';
+import { StakeholderV2, StagingV2, StakeholderProjectV2 } from '../../../src/models/v2/index.js';
 import { v4 as uuidv4 } from 'uuid';
 import { createV2TestHomeOrg } from '../utils/v2-test-helpers.js';
 
@@ -527,6 +527,101 @@ describe('Stakeholder V2 Endpoint Integration Tests', function () {
       expect(response.body).to.have.property('message');
       expect(response.body.message).to.equal('Stakeholder delete staged successfully');
       expect(response.body).to.have.property('success', true);
+    });
+  });
+
+  describe('DELETE /v2/stakeholder/:id — reference guards', function () {
+    beforeEach(async function () {
+      await StagingV2.destroy({ where: {} });
+      await StakeholderProjectV2.destroy({ where: {} });
+    });
+
+    it('should return 409 when stakeholder_projects references exist', async function () {
+      const stakeholder = await StakeholderV2.create({
+        cadTrustStakeholderId: uuidv4(),
+        stakeholderName: 'Referenced Stakeholder',
+        stakeholderType: 'Owner',
+      });
+
+      await StakeholderProjectV2.create({
+        cadTrustStakeholderProjectId: uuidv4(),
+        cadTrustStakeholderId: stakeholder.cadTrustStakeholderId,
+        cadTrustProjectId: uuidv4(),
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/stakeholder/${stakeholder.cadTrustStakeholderId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.message).to.include('Cannot delete stakeholder');
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('stakeholder_projects');
+      expect(response.body.references[0].count).to.equal(1);
+      expect(response.body.hint).to.include('force=true');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'stakeholder', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.be.null;
+    });
+
+    it('should return 409 when staged stakeholder_projects references exist', async function () {
+      const stakeholder = await StakeholderV2.create({
+        cadTrustStakeholderId: uuidv4(),
+        stakeholderName: 'Staged Referenced Stakeholder',
+        stakeholderType: 'Owner',
+      });
+
+      await StagingV2.create({
+        uuid: uuidv4(),
+        table: 'stakeholder_projects',
+        action: 'INSERT',
+        data: JSON.stringify([{
+          cad_trust_stakeholder_project_id: uuidv4(),
+          cad_trust_stakeholder_id: stakeholder.cadTrustStakeholderId,
+          cad_trust_project_id: uuidv4(),
+        }]),
+        committed: false,
+        failed_commit: false,
+        is_transfer: false,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/stakeholder/${stakeholder.cadTrustStakeholderId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.references).to.be.an('array').with.lengthOf(1);
+      expect(response.body.references[0].table).to.equal('stakeholder_projects');
+      expect(response.body.references[0].count).to.equal(1);
+    });
+
+    it('should allow delete with ?force=true despite references', async function () {
+      const stakeholder = await StakeholderV2.create({
+        cadTrustStakeholderId: uuidv4(),
+        stakeholderName: 'Force Delete Stakeholder',
+        stakeholderType: 'Consultant',
+      });
+
+      await StakeholderProjectV2.create({
+        cadTrustStakeholderProjectId: uuidv4(),
+        cadTrustStakeholderId: stakeholder.cadTrustStakeholderId,
+        cadTrustProjectId: uuidv4(),
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/stakeholder/${stakeholder.cadTrustStakeholderId}`)
+        .query({ force: 'true' })
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.message).to.equal('Stakeholder delete staged successfully');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'stakeholder', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.exist;
     });
   });
 });

--- a/tests/v2/live-api/helpers/api-request-helpers.js
+++ b/tests/v2/live-api/helpers/api-request-helpers.js
@@ -292,7 +292,7 @@ export const makePutRequest = async (request, endpoint, id, data) => {
  * @param {string|object} id - Record ID (string for single key, object for composite key)
  * @returns {Promise<object>} - Response body
  */
-export const makeDeleteRequest = async (request, endpoint, id) => {
+export const makeDeleteRequest = async (request, endpoint, id, options = {}) => {
   // Construct full endpoint path with ID
   // All endpoints now use UUID primary keys
   const fullEndpoint = `${endpoint}/${id}`;
@@ -300,8 +300,11 @@ export const makeDeleteRequest = async (request, endpoint, id) => {
   // Note: Request logging is handled by the request wrapper in live-api-helpers.js
   // No need to log here to avoid duplicate logs
 
-  const response = await request
-    .delete(fullEndpoint);
+  let req = request.delete(fullEndpoint);
+  if (options.query) {
+    req = req.query(options.query);
+  }
+  const response = await req;
 
   // Return response object even for non-200 status codes so tests can handle them
   // The response.body will contain the error information

--- a/tests/v2/live-api/label-validation.live.spec.js
+++ b/tests/v2/live-api/label-validation.live.spec.js
@@ -264,7 +264,7 @@ describe('Label Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/label', id);
+        const response = await makeDeleteRequest(request, '/v2/label', id, { query: { force: 'true' } });
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {

--- a/tests/v2/live-api/methodology-validation.live.spec.js
+++ b/tests/v2/live-api/methodology-validation.live.spec.js
@@ -289,7 +289,7 @@ describe('Methodology Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/methodology', id);
+        const response = await makeDeleteRequest(request, '/v2/methodology', id, { query: { force: 'true' } });
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {

--- a/tests/v2/live-api/program-validation.live.spec.js
+++ b/tests/v2/live-api/program-validation.live.spec.js
@@ -277,7 +277,7 @@ describe('Program Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/program', id);
+        const response = await makeDeleteRequest(request, '/v2/program', id, { query: { force: 'true' } });
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {

--- a/tests/v2/live-api/stakeholder-validation.live.spec.js
+++ b/tests/v2/live-api/stakeholder-validation.live.spec.js
@@ -265,7 +265,7 @@ describe('Stakeholder Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/stakeholder', id);
+        const response = await makeDeleteRequest(request, '/v2/stakeholder', id, { query: { force: 'true' } });
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new 409 conflict behavior to multiple V2 DELETE endpoints unless `?force=true`, which can affect clients and deletion workflows. Docker base image and native module build steps also change CI/build behavior, with moderate risk of environment-specific breakage.
> 
> **Overview**
> **V2 DELETE endpoints now enforce referential integrity guards** for `methodology`, `program`, `stakeholder`, and `label`: deletions return `409 Conflict` with reference counts when dependent records exist (including staged `INSERT`/`UPDATE` rows), unless `?force=true` is provided.
> 
> **Build/CI hardening:** adds a GitHub Actions `docker-smoke-test` workflow that builds the image, verifies `sqlite3` loads, starts the container, and hits health endpoints; updates the `Dockerfile` to use `node:24-trixie` and rebuild `sqlite3` from source after `npm install`. Docs and both integration/live tests are updated to cover the new guard/force-delete behavior and messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64299a633d1a3f6a1c54e8788b48125844bf3c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->