### PR TITLE
fix: handle MySQL mirror connection failure gracefully in v1 prepareDb

### DIFF
--- a/src/database/index.js
+++ b/src/database/index.js
@@ -165,20 +165,29 @@ export const prepareDb = async () => {
     getConfig().MIRROR_DB.DB_HOST &&
     getConfig().MIRROR_DB.DB_HOST !== ''
   ) {
-    const connection = await mysql.createConnection({
-      host: getConfig().MIRROR_DB.DB_HOST,
-      port: 3306,
-      user: getConfig().MIRROR_DB.DB_USERNAME,
-      password: getConfig().MIRROR_DB.DB_PASSWORD,
-    });
+    try {
+      const connection = await mysql.createConnection({
+        host: getConfig().MIRROR_DB.DB_HOST,
+        port: 3306,
+        user: getConfig().MIRROR_DB.DB_USERNAME,
+        password: getConfig().MIRROR_DB.DB_PASSWORD,
+      });
 
-    await connection.query(
-      `CREATE DATABASE IF NOT EXISTS \`${getConfig().MIRROR_DB.DB_NAME}\`;`,
-    );
+      try {
+        await connection.query(
+          `CREATE DATABASE IF NOT EXISTS \`${getConfig().MIRROR_DB.DB_NAME}\`;`,
+        );
+      } finally {
+        await connection.end();
+      }
 
-    const db = new Sequelize(config[mirrorConfig]);
+      const db = new Sequelize(config[mirrorConfig]);
 
-    await checkForMigrations(db);
+      await checkForMigrations(db);
+    } catch (error) {
+      // Non-fatal: mirror DB failure should not block main database startup
+      logger.error('[v1]: Error setting up MySQL mirror database:', error);
+    }
   } else if (mirrorConfig == 'mirrorTest') {
     await checkForMigrations(sequelizeMirror);
   }


### PR DESCRIPTION
## Summary

- V1's `prepareDb()` crashed with `ECONNREFUSED` when the MySQL mirror sidecar wasn't ready at startup, causing the entire CADT process to `process.exit(1)`. This is a race condition in K8s pods where the MySQL sidecar takes ~30 seconds to initialize, but CADT starts immediately.
- V2's `prepareV2Db()` already handled this gracefully with a try-catch that logs and continues. This PR aligns V1 with V2's behavior: log the error and continue with the main SQLite database. The mirror reconnects on the next sync cycle via `safeMirrorDbHandler()`.
- Also adds a missing `connection.end()` call in a `finally` block to prevent connection leaks on any failure path.

## Test plan

- [ ] Deploy to testneta observer namespace and verify CADT starts without crash loops when MySQL sidecar is still initializing
- [ ] Verify mirror DB connects and syncs once MySQL becomes available
- [ ] Verify normal startup behavior is unchanged when MySQL is already running

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup-time database initialization to swallow MySQL mirror connection/creation failures and always close the transient MySQL connection; misconfiguration could now be masked and leave the mirror uninitialized until later.
> 
> **Overview**
> V1 `prepareDb()` now wraps MySQL mirror database setup in a `try/catch` so mirror connection/DB-create failures (e.g., sidecar not ready) are logged and **do not block** main database startup.
> 
> It also ensures the temporary MySQL connection used to `CREATE DATABASE` is always closed via a `finally` block, reducing the chance of connection leaks during startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0eb64fbee58ef182f4c3b50763bd57a8065ec8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->