### PR TITLE
fix(CI): use Ubuntu 22.04 runners for Linux builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,11 +23,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-22.04
             artifact-name: cadt-linux-x64
             build-command: npm run create-linux-x64-dist
             sqlite-path: ./node_modules/sqlite3/build/Release/
-          - runs-on: ubuntu-24.04-arm
+          - runs-on: ubuntu-22.04-arm
             artifact-name: cadt-linux-arm64
             build-command: npm run create-linux-arm64-dist
             sqlite-path: ./node_modules/sqlite3/build/Release/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,23 @@ jobs:
     name: Build Binaries
     runs-on: ${{ matrix.runs-on }}
     strategy:
+      # GLIBC compatibility note for Linux runners:
+      #
+      # The sqlite3 npm package includes a native addon (node_sqlite3.node) that
+      # links against the system GLIBC at compile time. The compiled binary requires
+      # at least the GLIBC version present on the build system at runtime.
+      #
+      # Our .deb packages target Ubuntu 22.04+ (GLIBC 2.35). Using ubuntu-latest
+      # (currently 24.04, GLIBC 2.39) produces binaries that crash on 22.04 with:
+      #   Error: GLIBC_2.38 not found (required by node_sqlite3.node)
+      #
+      # We pin Linux runners to ubuntu-22.04 so the native addon is compiled against
+      # GLIBC 2.35, ensuring compatibility with all non-EOL Ubuntu LTS releases.
+      # The "Rebuild sqlite3 from source" step below is also required because
+      # npm install downloads prebuilt binaries compiled against a newer GLIBC.
+      #
+      # When updating Linux runners, verify the target GLIBC against the oldest
+      # Ubuntu LTS you intend to support. Ubuntu 22.04 support ends May 2027.
       matrix:
         include:
           - runs-on: ubuntu-22.04
@@ -48,7 +65,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - name: Setup Node 20.x
+      - name: Setup Node 24.x
         uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -87,6 +104,9 @@ jobs:
           node --version
           npm install
 
+      # npm install downloads prebuilt node_sqlite3.node binaries via node-pre-gyp.
+      # These prebuilts are compiled against a newer GLIBC than our target (2.35).
+      # Force a source rebuild so the addon links against the runner's GLIBC instead.
       - name: Rebuild sqlite3 from source for GLIBC compatibility
         if: contains(matrix.runs-on, 'ubuntu')
         run: npm rebuild sqlite3 --build-from-source

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,6 +87,10 @@ jobs:
           node --version
           npm install
 
+      - name: Rebuild sqlite3 from source for GLIBC compatibility
+        if: contains(matrix.runs-on, 'ubuntu')
+        run: npm rebuild sqlite3 --build-from-source
+
       - name: npm cache clear --force
         run: npm cache clear --force
 


### PR DESCRIPTION
## Summary

- Pin Linux build runners to Ubuntu 22.04 (`ubuntu-22.04` for x64, `ubuntu-22.04-arm` for arm64) instead of Ubuntu 24.04
- Fixes `GLIBC_2.38 not found` crash when the `.deb` package is installed on Ubuntu 22.04 systems

## Problem

The `ubuntu-latest` (24.04) and `ubuntu-24.04-arm` runners have GLIBC 2.39. When `npm install` compiles the `sqlite3` native addon on these runners, the resulting `node_sqlite3.node` links against a `libm` symbol introduced in GLIBC 2.38. Deployed to Ubuntu 22.04 (GLIBC 2.35), `dlopen` fails immediately:

```
Error: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
  (required by .../sqlite3/build/node_sqlite3.node)
```

## Fix

Ubuntu 22.04 runners have GLIBC 2.35, so the compiled native addon will be compatible with all non-EOL Ubuntu LTS releases (20.04+, 22.04+, 24.04+).

## Test plan

- [ ] CI build succeeds on both `ubuntu-22.04` and `ubuntu-22.04-arm` runners
- [ ] Smoke test passes (binary starts and responds on `/health`)
- [ ] Install resulting `.deb` on an Ubuntu 22.04 arm64 system and verify `cadt` starts without GLIBC errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it affects Linux release artifacts and could impact build times or introduce native-build failures if the sqlite3 source build breaks on the pinned runners.
> 
> **Overview**
> Updates the `build` workflow to **pin Linux runners to `ubuntu-22.04`/`ubuntu-22.04-arm`** (instead of `ubuntu-latest`/24.04) to keep generated binaries compatible with Ubuntu 22.04’s GLIBC.
> 
> Adds a Linux-only step to `npm rebuild sqlite3 --build-from-source` so the bundled `node_sqlite3.node` is compiled against the runner’s GLIBC rather than using downloaded prebuilts, and documents the rationale directly in the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3044c69239b315b19091c46310024a372c4c5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->