### PR TITLE
Fix builds for Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,11 +23,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: ubuntu-latest
+          - runs-on: ubuntu-22.04
             artifact-name: cadt-linux-x64
             build-command: npm run create-linux-x64-dist
             sqlite-path: ./node_modules/sqlite3/build/Release/
-          - runs-on: ubuntu-24.04-arm
+          - runs-on: ubuntu-22.04-arm
             artifact-name: cadt-linux-arm64
             build-command: npm run create-linux-arm64-dist
             sqlite-path: ./node_modules/sqlite3/build/Release/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,23 @@ jobs:
     name: Build Binaries
     runs-on: ${{ matrix.runs-on }}
     strategy:
+      # GLIBC compatibility note for Linux runners:
+      #
+      # The sqlite3 npm package includes a native addon (node_sqlite3.node) that
+      # links against the system GLIBC at compile time. The compiled binary requires
+      # at least the GLIBC version present on the build system at runtime.
+      #
+      # Our .deb packages target Ubuntu 22.04+ (GLIBC 2.35). Using ubuntu-latest
+      # (currently 24.04, GLIBC 2.39) produces binaries that crash on 22.04 with:
+      #   Error: GLIBC_2.38 not found (required by node_sqlite3.node)
+      #
+      # We pin Linux runners to ubuntu-22.04 so the native addon is compiled against
+      # GLIBC 2.35, ensuring compatibility with all non-EOL Ubuntu LTS releases.
+      # The "Rebuild sqlite3 from source" step below is also required because
+      # npm install downloads prebuilt binaries compiled against a newer GLIBC.
+      #
+      # When updating Linux runners, verify the target GLIBC against the oldest
+      # Ubuntu LTS you intend to support. Ubuntu 22.04 support ends May 2027.
       matrix:
         include:
           - runs-on: ubuntu-22.04
@@ -48,7 +65,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - name: Setup Node 20.x
+      - name: Setup Node 24.x
         uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -87,6 +104,9 @@ jobs:
           node --version
           npm install
 
+      # npm install downloads prebuilt node_sqlite3.node binaries via node-pre-gyp.
+      # These prebuilts are compiled against a newer GLIBC than our target (2.35).
+      # Force a source rebuild so the addon links against the runner's GLIBC instead.
       - name: Rebuild sqlite3 from source for GLIBC compatibility
         if: contains(matrix.runs-on, 'ubuntu')
         run: npm rebuild sqlite3 --build-from-source

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,6 +87,10 @@ jobs:
           node --version
           npm install
 
+      - name: Rebuild sqlite3 from source for GLIBC compatibility
+        if: contains(matrix.runs-on, 'ubuntu')
+        run: npm rebuild sqlite3 --build-from-source
+
       - name: npm cache clear --force
         run: npm cache clear --force
 

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -165,20 +165,29 @@ export const prepareDb = async () => {
     getConfig().MIRROR_DB.DB_HOST &&
     getConfig().MIRROR_DB.DB_HOST !== ''
   ) {
-    const connection = await mysql.createConnection({
-      host: getConfig().MIRROR_DB.DB_HOST,
-      port: 3306,
-      user: getConfig().MIRROR_DB.DB_USERNAME,
-      password: getConfig().MIRROR_DB.DB_PASSWORD,
-    });
+    try {
+      const connection = await mysql.createConnection({
+        host: getConfig().MIRROR_DB.DB_HOST,
+        port: 3306,
+        user: getConfig().MIRROR_DB.DB_USERNAME,
+        password: getConfig().MIRROR_DB.DB_PASSWORD,
+      });
 
-    await connection.query(
-      `CREATE DATABASE IF NOT EXISTS \`${getConfig().MIRROR_DB.DB_NAME}\`;`,
-    );
+      try {
+        await connection.query(
+          `CREATE DATABASE IF NOT EXISTS \`${getConfig().MIRROR_DB.DB_NAME}\`;`,
+        );
+      } finally {
+        await connection.end();
+      }
 
-    const db = new Sequelize(config[mirrorConfig]);
+      const db = new Sequelize(config[mirrorConfig]);
 
-    await checkForMigrations(db);
+      await checkForMigrations(db);
+    } catch (error) {
+      // Non-fatal: mirror DB failure should not block main database startup
+      logger.error('[v1]: Error setting up MySQL mirror database:', error);
+    }
   } else if (mirrorConfig == 'mirrorTest') {
     await checkForMigrations(sequelizeMirror);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the release build pipeline to pin Linux runners and rebuild native `sqlite3` from source, which directly affects produced artifacts. Also makes mirror-DB setup errors non-fatal, which could hide mirror connectivity issues while improving startup resilience.
> 
> **Overview**
> Build workflow now pins Linux GitHub Actions runners to `ubuntu-22.04`/`ubuntu-22.04-arm` and upgrades to Node `24`, with an added `npm rebuild sqlite3 --build-from-source` step to ensure the `sqlite3` native addon is GLIBC-compatible with Ubuntu 22.04+.
> 
> Database initialization now wraps MySQL mirror DB creation/migrations in `try/finally` to always close the connection, and treats mirror setup failures as non-blocking (logging an error but continuing main DB startup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce837d8b787f71aaebfb223af94b0a97c692b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->