### PR TITLE
Health check fix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -407,6 +407,10 @@ jobs:
           TEST_API_HOST: 127.0.0.1
         run: |
           echo "########################################################"
+          echo "Running wallet health sanity check"
+          echo "########################################################"
+          npm run test:v2:live:wallet-health
+          echo "########################################################"
           echo "Running organization creation tests"
           echo "########################################################"
           npm run test:v2:live:organization:create
@@ -774,6 +778,10 @@ jobs:
         env:
           TEST_API_HOST: 127.0.0.1
         run: |
+          echo "########################################################"
+          echo "Running wallet health sanity check"
+          echo "########################################################"
+          npm run test:v2:live:wallet-health
           echo "########################################################"
           echo "Running V1 organization creation tests"
           echo "########################################################"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -407,13 +407,13 @@ jobs:
           TEST_API_HOST: 127.0.0.1
         run: |
           echo "########################################################"
-          echo "Running wallet health sanity check"
-          echo "########################################################"
-          npm run test:v2:live:wallet-health
-          echo "########################################################"
           echo "Running organization creation tests"
           echo "########################################################"
           npm run test:v2:live:organization:create
+          echo "########################################################"
+          echo "Running wallet health sanity check"
+          echo "########################################################"
+          npm run test:v2:live:wallet-health
           echo "########################################################"
           echo "Running data tests"
           echo "########################################################"
@@ -779,13 +779,13 @@ jobs:
           TEST_API_HOST: 127.0.0.1
         run: |
           echo "########################################################"
-          echo "Running wallet health sanity check"
-          echo "########################################################"
-          npm run test:v2:live:wallet-health
-          echo "########################################################"
           echo "Running V1 organization creation tests"
           echo "########################################################"
           npm run test:v1:live:organization:create
+          echo "########################################################"
+          echo "Running wallet health sanity check"
+          echo "########################################################"
+          npm run test:v2:live:wallet-health
           echo "########################################################"
           echo "Running V1 data tests"
           echo "########################################################"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:v2:live:data:short": "node --import=extensionless/register tests/v2/live-api/data-short.js",
     "test:v2:live:cascade-delete": "npx cross-env NODE_ENV=production mocha --loader node_modules/extensionless/src/register.js 'tests/v2/live-api/cascade-delete.live.spec.js' --reporter spec --exit --timeout 1800000",
     "test:live:readonly:smoke": "npx cross-env NODE_ENV=production mocha --loader node_modules/extensionless/src/register.js 'tests/v2/live-api/read-only-smoke.live.spec.js' --reporter spec --exit --timeout 600000",
+    "test:v2:live:wallet-health": "npx cross-env NODE_ENV=production mocha --loader node_modules/extensionless/src/register.js 'tests/v2/live-api/wallet-health.live.spec.js' --reporter spec --exit --timeout 60000",
     "test:v2:live:organization:delete": "npx cross-env NODE_ENV=production mocha --loader node_modules/extensionless/src/register.js 'tests/v2/live-api/organization/organization-delete.live.spec.js' --reporter spec --exit --timeout 600000",
     "test:locks": "node --import=extensionless/register tests/helpers/show-test-locks.js",
     "test:v1:live:data:short": "node --import=extensionless/register tests/v1/live-api/data-short.js",

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -582,6 +582,25 @@ const MempoolInclusionStatus = {
 // Cached DL wallet ID (discovered once, reused thereafter)
 let cachedDLWalletId = null;
 
+// chia-blockchain WalletType enum value for DATA_LAYER (see wallet_types.py)
+const CHIA_WALLET_TYPE_DATA_LAYER = 11;
+
+/**
+ * Extract the DataLayer wallet_id from a get_wallets RPC response.
+ * Pure function — no I/O, no caching, no simulator awareness.
+ * @param {Object} data - Parsed response body from get_wallets
+ * @returns {string|null} wallet_id as a string, or null if not found
+ */
+const findDLWalletInResponse = (data) => {
+  if (data.success && Array.isArray(data.wallets)) {
+    const dlWallet = data.wallets.find((w) => w.type === CHIA_WALLET_TYPE_DATA_LAYER);
+    if (dlWallet) {
+      return String(dlWallet.id);
+    }
+  }
+  return null;
+};
+
 /**
  * Discover the DataLayer wallet's wallet_id dynamically via get_wallets RPC.
  * Caches the result so subsequent calls avoid the RPC round-trip.
@@ -608,15 +627,12 @@ const getDLWalletId = async () => {
       .timeout(timeout);
 
     const data = response.body || JSON.parse(response.text);
+    const walletId = findDLWalletInResponse(data);
 
-    if (data.success && Array.isArray(data.wallets)) {
-      // WalletType.DATA_LAYER = 14 in chia-blockchain
-      const dlWallet = data.wallets.find((w) => w.type === 14);
-      if (dlWallet) {
-        cachedDLWalletId = String(dlWallet.id);
-        logger.info(`Discovered DataLayer wallet_id: ${cachedDLWalletId}`);
-        return cachedDLWalletId;
-      }
+    if (walletId) {
+      cachedDLWalletId = walletId;
+      logger.info(`Discovered DataLayer wallet_id: ${cachedDLWalletId}`);
+      return cachedDLWalletId;
     }
 
     logger.warn('DataLayer wallet not found via get_wallets RPC');
@@ -853,6 +869,10 @@ const TRANSIENT_WALLET_ERRORS = [
 const isTransientWalletError = (error) =>
   TRANSIENT_WALLET_ERRORS.some((msg) => error.message?.includes(msg));
 
+const __test_resetDLWalletCache = () => {
+  cachedDLWalletId = null;
+};
+
 export default {
   hasUnconfirmedTransactions,
   hasAnyUnconfirmedTransactions,
@@ -873,4 +893,7 @@ export default {
   getDLWalletId,
   clearRejectedTransactions,
   formatDuration,
+  findDLWalletInResponse,
+  CHIA_WALLET_TYPE_DATA_LAYER,
+  __test_resetDLWalletCache,
 };

--- a/tests/v2/integration/transaction-health.spec.js
+++ b/tests/v2/integration/transaction-health.spec.js
@@ -26,6 +26,7 @@ describe('Transaction Health Monitoring', function () {
   let fsReadFileSyncStub;
 
   beforeEach(function () {
+    wallet.__test_resetDLWalletCache();
     fsReadFileSyncStub = sinon.stub(fs, 'readFileSync').returns(Buffer.from('fake-cert'));
     superagentPostStub = sinon.stub(superagent, 'post');
   });
@@ -340,20 +341,64 @@ describe('Transaction Health Monitoring', function () {
   });
 
   describe('getDLWalletId', function () {
-    it('should discover DL wallet by type 14', async function () {
-      superagentPostStub.returns(createSuperagentMock({
+    it('should return "2" in simulator mode', async function () {
+      const walletId = await wallet.getDLWalletId();
+      expect(walletId).to.equal('2');
+    });
+  });
+
+  describe('findDLWalletInResponse', function () {
+    it('should match type 11 (WalletType.DATA_LAYER from chia-blockchain)', function () {
+      const result = wallet.findDLWalletInResponse({
         success: true,
         wallets: [
           { id: 1, type: 0, name: 'Chia Wallet' },
-          { id: 2, type: 14, name: 'DataLayer Wallet' },
+          { id: 2, type: 11, name: 'DataLayer Wallet' },
         ],
-      }));
+      });
+      expect(result).to.equal('2');
+    });
 
-      // Reset cached value
-      wallet.__test_resetDLWalletCache?.();
+    it('should use the CHIA_WALLET_TYPE_DATA_LAYER constant equal to 11', function () {
+      expect(wallet.CHIA_WALLET_TYPE_DATA_LAYER).to.equal(11);
+    });
 
-      const walletId = await wallet.getDLWalletId();
-      expect(walletId).to.equal('2');
+    it('should return null when no wallet has DATA_LAYER type', function () {
+      const result = wallet.findDLWalletInResponse({
+        success: true,
+        wallets: [
+          { id: 1, type: 0, name: 'Chia Wallet' },
+          { id: 3, type: 6, name: 'CAT Wallet' },
+          { id: 4, type: 10, name: 'NFT Wallet' },
+        ],
+      });
+      expect(result).to.be.null;
+    });
+
+    it('should not match adjacent WalletType values (type 10, 12, 13)', function () {
+      const result = wallet.findDLWalletInResponse({
+        success: true,
+        wallets: [
+          { id: 1, type: 0, name: 'Chia Wallet' },
+          { id: 2, type: 10, name: 'NFT Wallet' },
+          { id: 3, type: 12, name: 'DataLayer Offer Wallet' },
+          { id: 4, type: 13, name: 'VC Wallet' },
+        ],
+      });
+      expect(result).to.be.null;
+    });
+
+    it('should return null on unsuccessful response', function () {
+      const result = wallet.findDLWalletInResponse({
+        success: false,
+        wallets: [{ id: 2, type: 11, name: 'DataLayer Wallet' }],
+      });
+      expect(result).to.be.null;
+    });
+
+    it('should return null when wallets array is missing', function () {
+      const result = wallet.findDLWalletInResponse({ success: true });
+      expect(result).to.be.null;
     });
   });
 

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -1,0 +1,101 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import superagent from 'superagent';
+import { getLiveApiRequest, getLiveApiConfig } from './helpers/live-api-helpers.js';
+import { getChiaRoot } from '../../../src/utils/chia-root.js';
+import wallet from '../../../src/datalayer/wallet.js';
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
+
+const getWalletRpcUrl = () => {
+  const { config } = getLiveApiConfig();
+  return config?.APP?.WALLET_URL || 'https://localhost:9256';
+};
+
+const getWalletBaseOptions = () => {
+  const chiaRoot = getChiaRoot();
+  const certPath = path.resolve(`${chiaRoot}/config/ssl/wallet/private_wallet.crt`);
+  const keyPath = path.resolve(`${chiaRoot}/config/ssl/wallet/private_wallet.key`);
+  return {
+    cert: fs.readFileSync(certPath),
+    key: fs.readFileSync(keyPath),
+    timeout: 30000,
+  };
+};
+
+describe('Wallet Health - Live', function () {
+  this.timeout(60000);
+
+  let request;
+
+  before(async function () {
+    request = await getLiveApiRequest({ apiVersion: 'any' });
+  });
+
+  describe('CADT /health/wallet endpoint', function () {
+    it('should report DataLayer wallet as available', async function () {
+      // Try v2 first, fall back to v1
+      let res = await request.get('/v2/health/wallet');
+      if (res.status === 404) {
+        res = await request.get('/v1/health/wallet');
+      }
+      expect(res.status).to.equal(200);
+
+      if (res.body.readOnly) {
+        this.skip();
+        return;
+      }
+
+      expect(res.body.dataLayerWallet, 'dataLayerWallet missing from response').to.exist;
+      expect(
+        res.body.dataLayerWallet.available,
+        'CADT failed to discover the DataLayer wallet. ' +
+        'This likely means the WalletType constant in getDLWalletId() ' +
+        'does not match chia-blockchain\'s WalletType.DATA_LAYER enum.',
+      ).to.equal(true);
+      expect(res.body.dataLayerWallet.walletId).to.be.a('number').and.to.be.greaterThan(0);
+    });
+  });
+
+  describe('Chia wallet RPC get_wallets', function () {
+    it('should contain a DATA_LAYER wallet matching CADT constant', async function () {
+      const rpcUrl = getWalletRpcUrl();
+      const { cert, key, timeout } = getWalletBaseOptions();
+
+      let data;
+      try {
+        const response = await superagent
+          .post(`${rpcUrl}/get_wallets`)
+          .send({})
+          .key(key)
+          .cert(cert)
+          .timeout(timeout);
+        data = response.body || JSON.parse(response.text);
+      } catch (error) {
+        console.log(`  Wallet RPC at ${rpcUrl} unreachable: ${error.message}`);
+        this.skip();
+        return;
+      }
+
+      expect(data.success, 'get_wallets RPC failed').to.be.true;
+
+      const dlWallet = data.wallets.find(
+        (w) => w.type === wallet.CHIA_WALLET_TYPE_DATA_LAYER,
+      );
+      expect(
+        dlWallet,
+        `No wallet with type=${wallet.CHIA_WALLET_TYPE_DATA_LAYER} (DATA_LAYER) ` +
+        `found in get_wallets response. Types present: ` +
+        `[${data.wallets.map((w) => `${w.type} (${w.name})`).join(', ')}]. ` +
+        `If chia-blockchain changed the WalletType enum, update ` +
+        `CHIA_WALLET_TYPE_DATA_LAYER in src/datalayer/wallet.js.`,
+      ).to.exist;
+
+      const parsedId = wallet.findDLWalletInResponse(data);
+      expect(parsedId, 'findDLWalletInResponse should return the DL wallet id').to.equal(
+        String(dlWallet.id),
+      );
+    });
+  });
+});

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -35,9 +35,9 @@ describe('Wallet Health - Live', function () {
 
   describe('CADT /health/wallet endpoint', function () {
     it('should report DataLayer wallet as available', async function () {
-      // Try v2 first, fall back to v1
+      // Try v2 first, fall back to v1 (v2 returns 403 or 404 when disabled)
       let res = await request.get('/v2/health/wallet');
-      if (res.status === 404) {
+      if (res.status === 403 || res.status === 404) {
         res = await request.get('/v1/health/wallet');
       }
       expect(res.status).to.equal(200);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches wallet RPC discovery logic used by health checks and potentially other runtime paths; incorrect enum handling or caching behavior could affect wallet availability reporting in production.
> 
> **Overview**
> Fixes DataLayer wallet discovery by switching the `get_wallets` lookup to the correct chia-blockchain `WalletType.DATA_LAYER` value (`11`), and extracting the parsing logic into a new pure helper `findDLWalletInResponse`.
> 
> Adds test hooks (`__test_resetDLWalletCache`) and updates/extends integration coverage around wallet-id discovery, plus introduces a new live test (`wallet-health.live.spec.js`) that validates both CADT’s `/health/wallet` response and the underlying wallet RPC `get_wallets` types. CI live workflows now run this new wallet health sanity check in both v1 and v2 live test jobs via the new `test:v2:live:wallet-health` script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374c9f3bb413491f199fb9b5ea16f2560fc96a66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->