### PR TITLE
fix: init mirror models eagerly and recover lost writes on reconnect

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -161,6 +161,34 @@ jobs:
           }
           echo "✓ MariaDB (MySQL-compatible) mirror database is ready for testing"
 
+          # Stop MariaDB so CADT starts against a DOWN mirror. This exercises
+          # the startup race that k8s observers hit: CADT up before MySQL is
+          # reachable. The subsequent "Delay-start MariaDB (exercise mirror
+          # reconnect recovery)" step will restart MariaDB ~30s after CADT,
+          # and the V2 mirror reconnect path must transparently run
+          # migrations + backfill and catch up without losing any writes.
+          # If the test fails, either the init race fix or the
+          # reconnect-backfill logic has regressed.
+          #
+          # The race test is load-bearing on MariaDB actually being down
+          # when CADT starts - fail the job if mysqladmin can still ping it
+          # after 10 seconds of retries rather than letting the test
+          # silently degrade into a no-op.
+          echo "Stopping MariaDB so CADT starts against a down mirror..."
+          service mariadb stop
+          for STOP_ATTEMPT in $(seq 1 10); do
+            if ! mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "✓ MariaDB stopped after ${STOP_ATTEMPT}s - CADT startup will race against delayed restart"
+              break
+            fi
+            if [ "$STOP_ATTEMPT" -eq 10 ]; then
+              echo "ERROR: MariaDB still responding 10s after 'service mariadb stop'."
+              echo "The race test's precondition (MariaDB down when CADT starts) cannot be met."
+              exit 1
+            fi
+            sleep 1
+          done
+
       - name: Configure Chia
         shell: bash
         run: |
@@ -174,7 +202,11 @@ jobs:
       - name: Configure CADT
         shell: bash
         run: |
-          # Run cadt momentarily to create config file
+          # Run cadt momentarily to create config file. Note: MariaDB is
+          # intentionally stopped at this point to exercise the mirror
+          # init race on first boot - CADT must log the setup failure
+          # non-fatally and continue, then recover automatically once
+          # MariaDB restarts.
           pm2 start npm --no-autorestart --name "cadt" -- start
           sleep 10
           pm2 logs cadt --nostream
@@ -283,6 +315,10 @@ jobs:
       - name: Start CADT
         shell: bash
         run: |
+          # MariaDB is still stopped at this point (see "Configure MySQL").
+          # CADT must start successfully, log the mirror setup failure as
+          # non-fatal, and expose its health endpoint. This exercises the
+          # mirror init race that broke production observers on k8s.
           pm2 start npm --no-autorestart --name "cadt" -- start
           echo "Waiting for CADT health endpoint..."
           MAX_CADT_HEALTH_ATTEMPTS=30
@@ -298,6 +334,37 @@ jobs:
             fi
             sleep 2
           done
+
+      - name: Delay-start MariaDB (exercise mirror reconnect recovery)
+        shell: bash
+        run: |
+          # Restart MariaDB now that CADT has been running without it for a
+          # while. The next V2 mirror operation should:
+          #   1. Detect authenticate success following previous failures.
+          #   2. Retry CREATE DATABASE + migrations via prepareMysqlMirrorV2
+          #      (they never ran at startup because MariaDB was down).
+          #   3. Run backfillMirrorV2 to catch up any writes + deletes that
+          #      happened while MariaDB was unavailable.
+          # The live-api tests' verifyMirrorRecordsBatch assertions will
+          # fail if any step regresses.
+          echo "Waiting a few seconds so CADT logs multiple mirror-down messages..."
+          sleep 10
+          echo "Starting MariaDB (CADT should reconnect and recover)..."
+          service mariadb start
+          for i in {1..30}; do
+            if mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "MariaDB is back up"
+              break
+            fi
+            sleep 1
+          done
+          # Re-verify the DB and test user persist - they were created
+          # before the stop, and the data directory is unchanged.
+          mysql -u cadt_test -pcadt_test_password -e "SELECT 1 as test;" || {
+            echo "Failed to reconnect to MariaDB after restart"
+            exit 1
+          }
+          echo "✓ MariaDB back online - CADT mirror recovery path will engage"
 
       - name: Wait for wallet sync and datalayer readiness
         shell: bash
@@ -593,7 +660,63 @@ jobs:
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/chia.gpg] https://repo.chia.net/chia-tools/debian/ stable main" | tee /etc/apt/sources.list.d/chia-tools.list > /dev/null
 
           apt-get update
-          apt-get install -y yq jq bc iproute2 chia-blockchain-cli chia-tools
+          apt-get install -y yq jq bc iproute2 default-mysql-server default-mysql-client chia-blockchain-cli chia-tools
+
+      - name: Configure MySQL for V1 mirror database testing
+        shell: bash
+        run: |
+          echo "Starting MariaDB service..."
+          service mariadb start
+
+          echo "Waiting for MariaDB to be ready..."
+          for i in {1..30}; do
+            if mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "MariaDB is ready!"
+              break
+            fi
+            echo "Waiting for MariaDB... ($i/30)"
+            sleep 1
+          done
+
+          echo "Creating V1 test database and user..."
+          mysql -u root <<EOF
+          CREATE DATABASE IF NOT EXISTS cadt_mirror_test;
+          CREATE USER IF NOT EXISTS 'cadt_test'@'localhost' IDENTIFIED BY 'cadt_test_password';
+          GRANT ALL PRIVILEGES ON cadt_mirror_test.* TO 'cadt_test'@'localhost';
+          FLUSH PRIVILEGES;
+          EOF
+
+          echo "Verifying MariaDB setup..."
+          mysql -u cadt_test -pcadt_test_password -e "SELECT 1 as test;" || {
+            echo "Failed to connect as test user"
+            exit 1
+          }
+          echo "✓ MariaDB (V1 mirror database) is ready for testing"
+
+          # Stop MariaDB so CADT starts against a DOWN mirror. This
+          # exercises the V1 mirror init race (same bug class as V2: the
+          # fire-and-forget handler would skip model.init() when MySQL was
+          # unreachable at module load). The "Delay-start MariaDB" step
+          # below restarts MariaDB ~30s after CADT, and the V1 mirror
+          # reconnect path must transparently run migrations + backfill.
+          #
+          # Fail the job if mysqladmin can still ping MariaDB after 10
+          # seconds of retries rather than letting the race test silently
+          # degrade into a no-op against an always-up DB.
+          echo "Stopping MariaDB so CADT starts against a down mirror..."
+          service mariadb stop
+          for STOP_ATTEMPT in $(seq 1 10); do
+            if ! mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "✓ MariaDB stopped after ${STOP_ATTEMPT}s - CADT V1 startup will race against delayed restart"
+              break
+            fi
+            if [ "$STOP_ATTEMPT" -eq 10 ]; then
+              echo "ERROR: MariaDB still responding 10s after 'service mariadb stop'."
+              echo "The race test's precondition (MariaDB down when CADT starts) cannot be met."
+              exit 1
+            fi
+            sleep 1
+          done
 
       - name: Configure Chia
         shell: bash
@@ -608,7 +731,9 @@ jobs:
       - name: Configure CADT
         shell: bash
         run: |
-          # Run cadt momentarily to create config file
+          # Run cadt momentarily to create config file. MariaDB is
+          # intentionally stopped at this point to exercise the V1 mirror
+          # init race on first boot.
           pm2 start npm --no-autorestart --name "cadt" -- start
           sleep 10
           pm2 logs cadt --nostream
@@ -635,6 +760,16 @@ jobs:
           # Enable V1 only for V1 live API tests
           yq -yi '.V1.ENABLE = true' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.V2.ENABLE = false' ~/.chia/mainnet/cadt/config.yaml
+
+          # Configure MySQL mirror database for V1 testing.
+          # V1.MIRROR_DB is the V1 analog of V2.MIRROR_DB; the V1 live-api
+          # test runner (tests/v1/live-api/data-short.js) reads this path
+          # and asserts each record is mirrored correctly.
+          echo "Configuring MySQL mirror database for V1..."
+          yq -yi '.V1.MIRROR_DB.DB_HOST = "localhost"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V1.MIRROR_DB.DB_USERNAME = "cadt_test"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V1.MIRROR_DB.DB_PASSWORD = "cadt_test_password"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V1.MIRROR_DB.DB_NAME = "cadt_mirror_test"' ~/.chia/mainnet/cadt/config.yaml
 
           # Show the config file
           echo "Showing the config file after configuration..."
@@ -708,8 +843,60 @@ jobs:
       - name: Start CADT
         shell: bash
         run: |
+          # MariaDB is still stopped at this point (see "Configure MySQL
+          # for V1 mirror database testing"). CADT must start successfully,
+          # log the mirror setup failure as non-fatal, and expose its API.
+          # The subsequent "Delay-start MariaDB" step restarts MariaDB
+          # shortly after so the V1 mirror reconnect path is exercised
+          # while CADT is still booting.
           pm2 start npm --no-autorestart --name "cadt" -- start
-          sleep 30
+          echo "Waiting for CADT API endpoint (V1 port ${CW_PORT:-31310})..."
+          MAX_CADT_HEALTH_ATTEMPTS=30
+          for CADT_ATTEMPT in $(seq 1 "$MAX_CADT_HEALTH_ATTEMPTS"); do
+            # V1 API doesn't expose /health - probe /v1/organizations instead
+            if curl -fsS --max-time 5 http://127.0.0.1:31310/v1/organizations >/dev/null 2>&1; then
+              echo "CADT V1 API is ready"
+              break
+            fi
+            if [ "$CADT_ATTEMPT" -eq "$MAX_CADT_HEALTH_ATTEMPTS" ]; then
+              echo "ERROR: CADT V1 API did not become ready in time"
+              pm2 logs cadt --lines 200 --nostream || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Delay-start MariaDB (exercise V1 mirror reconnect recovery)
+        shell: bash
+        run: |
+          # Restart MariaDB now that CADT has been running without it.
+          # The next V1 mirror operation should run prepareMysqlMirror +
+          # backfillMirror via the reconnect path, catching up any writes
+          # or deletes that would otherwise be lost during the outage
+          # window. The V1 live-api test runner
+          # (tests/v1/live-api/data-short.js) asserts each record lands
+          # in the MySQL mirror, so a regression in the init race or
+          # reconnect/backfill logic will fail this job.
+          #
+          # Small delay first so CADT accumulates multiple "mirror down"
+          # log entries - matches the V2 job's sequencing and gives the
+          # reconnect path a non-trivial backlog to catch up on.
+          echo "Waiting a few seconds so CADT logs multiple mirror-down messages..."
+          sleep 10
+          echo "Starting MariaDB (CADT should reconnect and recover)..."
+          service mariadb start
+          for i in {1..30}; do
+            if mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "MariaDB is back up"
+              break
+            fi
+            sleep 1
+          done
+          mysql -u cadt_test -pcadt_test_password -e "SELECT 1 as test;" || {
+            echo "Failed to reconnect to MariaDB after restart"
+            exit 1
+          }
+          echo "✓ MariaDB back online - CADT V1 mirror recovery path will engage"
 
       - name: Wait for wallet sync and datalayer readiness
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -314,20 +314,12 @@ jobs:
 
       - name: Start CADT
         shell: bash
-        env:
-          # TEMPORARY: capture stack traces for the first few base
-          # DATE._stringify invocations. One CI run pinpoints the
-          # Sequelize internal path that reaches the base serialiser
-          # despite mysql.DATE being wired up. Remove this env var once
-          # the stacks are captured and the comment in src/config/config.js
-          # is updated with the concrete root cause.
-          CADT_DATE_STRINGIFY_DIAG: "1"
         run: |
           # MariaDB is still stopped at this point (see "Configure MySQL").
           # CADT must start successfully, log the mirror setup failure as
           # non-fatal, and expose its health endpoint. This exercises the
           # mirror init race that broke production observers on k8s.
-          pm2 start npm --no-autorestart --name "cadt" --update-env -- start
+          pm2 start npm --no-autorestart --name "cadt" -- start
           echo "Waiting for CADT health endpoint..."
           MAX_CADT_HEALTH_ATTEMPTS=30
           for CADT_ATTEMPT in $(seq 1 "$MAX_CADT_HEALTH_ATTEMPTS"); do
@@ -850,14 +842,6 @@ jobs:
 
       - name: Start CADT
         shell: bash
-        env:
-          # TEMPORARY: capture stack traces for the first few base
-          # DATE._stringify invocations. One CI run pinpoints the
-          # Sequelize internal path that reaches the base serialiser
-          # despite mysql.DATE being wired up. Remove this env var once
-          # the stacks are captured and the comment in src/config/config.js
-          # is updated with the concrete root cause.
-          CADT_DATE_STRINGIFY_DIAG: "1"
         run: |
           # MariaDB is still stopped at this point (see "Configure MySQL
           # for V1 mirror database testing"). CADT must start successfully,
@@ -865,7 +849,7 @@ jobs:
           # The subsequent "Delay-start MariaDB" step restarts MariaDB
           # shortly after so the V1 mirror reconnect path is exercised
           # while CADT is still booting.
-          pm2 start npm --no-autorestart --name "cadt" --update-env -- start
+          pm2 start npm --no-autorestart --name "cadt" -- start
           echo "Waiting for CADT API endpoint (V1 port ${CW_PORT:-31310})..."
           MAX_CADT_HEALTH_ATTEMPTS=30
           for CADT_ATTEMPT in $(seq 1 "$MAX_CADT_HEALTH_ATTEMPTS"); do

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -314,12 +314,20 @@ jobs:
 
       - name: Start CADT
         shell: bash
+        env:
+          # TEMPORARY: capture stack traces for the first few base
+          # DATE._stringify invocations. One CI run pinpoints the
+          # Sequelize internal path that reaches the base serialiser
+          # despite mysql.DATE being wired up. Remove this env var once
+          # the stacks are captured and the comment in src/config/config.js
+          # is updated with the concrete root cause.
+          CADT_DATE_STRINGIFY_DIAG: "1"
         run: |
           # MariaDB is still stopped at this point (see "Configure MySQL").
           # CADT must start successfully, log the mirror setup failure as
           # non-fatal, and expose its health endpoint. This exercises the
           # mirror init race that broke production observers on k8s.
-          pm2 start npm --no-autorestart --name "cadt" -- start
+          pm2 start npm --no-autorestart --name "cadt" --update-env -- start
           echo "Waiting for CADT health endpoint..."
           MAX_CADT_HEALTH_ATTEMPTS=30
           for CADT_ATTEMPT in $(seq 1 "$MAX_CADT_HEALTH_ATTEMPTS"); do
@@ -842,6 +850,14 @@ jobs:
 
       - name: Start CADT
         shell: bash
+        env:
+          # TEMPORARY: capture stack traces for the first few base
+          # DATE._stringify invocations. One CI run pinpoints the
+          # Sequelize internal path that reaches the base serialiser
+          # despite mysql.DATE being wired up. Remove this env var once
+          # the stacks are captured and the comment in src/config/config.js
+          # is updated with the concrete root cause.
+          CADT_DATE_STRINGIFY_DIAG: "1"
         run: |
           # MariaDB is still stopped at this point (see "Configure MySQL
           # for V1 mirror database testing"). CADT must start successfully,
@@ -849,7 +865,7 @@ jobs:
           # The subsequent "Delay-start MariaDB" step restarts MariaDB
           # shortly after so the V1 mirror reconnect path is exercised
           # while CADT is still booting.
-          pm2 start npm --no-autorestart --name "cadt" -- start
+          pm2 start npm --no-autorestart --name "cadt" --update-env -- start
           echo "Waiting for CADT API endpoint (V1 port ${CW_PORT:-31310})..."
           MAX_CADT_HEALTH_ATTEMPTS=30
           for CADT_ATTEMPT in $(seq 1 "$MAX_CADT_HEALTH_ATTEMPTS"); do

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,54 +1,7 @@
-import Sequelize from 'sequelize';
-import moment from 'moment';
 import { getConfig, getConfigV2 } from '../utils/config-loader';
 import { getChiaRoot } from '../utils/chia-root.js';
 import { logger } from './logger.js';
 import { createHash } from 'crypto';
-
-// Force MariaDB-compatible datetime serialisation across all code paths.
-//
-// Sequelize 6's default BaseTypes.DATE._stringify formats dates as
-//   "YYYY-MM-DD HH:mm:ss.SSS Z"        (e.g. "2026-04-17 17:07:13.399 +00:00")
-// which recent MariaDB strict mode rejects:
-//   Incorrect datetime value: '2026-04-17 17:07:13.399 +00:00'
-//     for column `cadt_mirror_test`.`audit`.`createdAt` at row 1
-//
-// The mysql-specific subclass emits a safe format ("YYYY-MM-DD HH:mm:ss"),
-// but some runtime paths in Sequelize end up calling the BASE class's
-// _stringify even when the column belongs to a MySQL dialect. Observed
-// in CI: V2 mirror produced ~60 "Incorrect datetime value" errors per
-// live-api run even with `timezone: "+00:00"` set at the Sequelize
-// constructor level.
-//
-// Fix: patch BASE DATE._stringify to emit the MariaDB-safe format, and
-// explicitly restore the original "YYYY-MM-DD HH:mm:ss.SSS Z" format on
-// the SQLite subclass (whose `parse()` relies on the trailing offset
-// for round-trip). This leaves MySQL/MariaDB writes safe regardless of
-// which dispatch path Sequelize chooses, without breaking SQLite.
-const _origBaseStringify = Sequelize.DataTypes.DATE.prototype._stringify;
-Sequelize.DataTypes.DATE.prototype._stringify = function _stringify(
-  date,
-  options,
-) {
-  if (!moment.isMoment(date)) {
-    date = this._applyTimezone(date, options);
-  }
-  // Drop fractional seconds and the " Z" offset. MariaDB strict mode
-  // rejects " +00:00". CADT doesn't use sub-second resolution on any
-  // DATE column.
-  return date.format('YYYY-MM-DD HH:mm:ss');
-};
-// SQLite's DATE class only overrides `parse`, not `_stringify`, so the
-// base-class patch above would otherwise silently change the format of
-// SQLite writes. SQLite's `parse()` appends options.timezone when the
-// string lacks a "+"/"-" offset - if we stripped the offset on write,
-// parse() would concatenate the offset on read, producing a value
-// different from what was written. Shadow an own-property `_stringify`
-// on `sqlite.DATE.prototype` that points to the original base
-// serialiser, so SQLite retains the "YYYY-MM-DD HH:mm:ss.SSS Z" format.
-if (Sequelize.DataTypes.sqlite && Sequelize.DataTypes.sqlite.DATE) {
-  Sequelize.DataTypes.sqlite.DATE.prototype._stringify = _origBaseStringify;
-}
 
 const chiaRoot = getChiaRoot();
 const persistanceFolder = `${chiaRoot}/cadt/v1`;
@@ -108,18 +61,6 @@ export default {
     host: getConfig().MIRROR_DB.DB_HOST || '',
     dialect: 'mysql',
     logging: mirrorLogging,
-    // Tell Sequelize to serialise Date values as UTC without a trailing
-    // "+00:00" offset. Recent MariaDB strict mode rejects the
-    // "YYYY-MM-DD HH:MM:SS.SSS +00:00" format Sequelize emits by default,
-    // with errors like:
-    //   Incorrect datetime value: '2026-04-16 22:41:27.490 +00:00'
-    //     for column `cadt_mirror_test`.`audit`.`createdAt` at row 1
-    // Setting timezone at the Sequelize constructor level (as opposed to
-    // Model.init, where it is silently ignored) produces the MariaDB-safe
-    // "YYYY-MM-DD HH:MM:SS" format. Without this, every mirror write that
-    // touches a DATE/DATETIME column is silently dropped by the
-    // fire-and-forget safeMirrorDbHandler.
-    timezone: '+00:00',
   },
   // V2 Database Configurations
   v2Local: {
@@ -155,8 +96,5 @@ export default {
     host: getConfigV2().MIRROR_DB?.DB_HOST || '',
     dialect: 'mysql',
     logging: mirrorLogging,
-    // See comment on `mirror` above. Same MariaDB strict-mode datetime
-    // issue applies to V2.
-    timezone: '+00:00',
   },
 };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,7 +1,54 @@
+import Sequelize from 'sequelize';
+import moment from 'moment';
 import { getConfig, getConfigV2 } from '../utils/config-loader';
 import { getChiaRoot } from '../utils/chia-root.js';
 import { logger } from './logger.js';
 import { createHash } from 'crypto';
+
+// Force MariaDB-compatible datetime serialisation across all code paths.
+//
+// Sequelize 6's default BaseTypes.DATE._stringify formats dates as
+//   "YYYY-MM-DD HH:mm:ss.SSS Z"        (e.g. "2026-04-17 17:07:13.399 +00:00")
+// which recent MariaDB strict mode rejects:
+//   Incorrect datetime value: '2026-04-17 17:07:13.399 +00:00'
+//     for column `cadt_mirror_test`.`audit`.`createdAt` at row 1
+//
+// The mysql-specific subclass emits a safe format ("YYYY-MM-DD HH:mm:ss"),
+// but some runtime paths in Sequelize end up calling the BASE class's
+// _stringify even when the column belongs to a MySQL dialect. Observed
+// in CI: V2 mirror produced ~60 "Incorrect datetime value" errors per
+// live-api run even with `timezone: "+00:00"` set at the Sequelize
+// constructor level.
+//
+// Fix: patch BASE DATE._stringify to emit the MariaDB-safe format, and
+// explicitly restore the original "YYYY-MM-DD HH:mm:ss.SSS Z" format on
+// the SQLite subclass (whose `parse()` relies on the trailing offset
+// for round-trip). This leaves MySQL/MariaDB writes safe regardless of
+// which dispatch path Sequelize chooses, without breaking SQLite.
+const _origBaseStringify = Sequelize.DataTypes.DATE.prototype._stringify;
+Sequelize.DataTypes.DATE.prototype._stringify = function _stringify(
+  date,
+  options,
+) {
+  if (!moment.isMoment(date)) {
+    date = this._applyTimezone(date, options);
+  }
+  // Drop fractional seconds and the " Z" offset. MariaDB strict mode
+  // rejects " +00:00". CADT doesn't use sub-second resolution on any
+  // DATE column.
+  return date.format('YYYY-MM-DD HH:mm:ss');
+};
+// SQLite's DATE class only overrides `parse`, not `_stringify`, so the
+// base-class patch above would otherwise silently change the format of
+// SQLite writes. SQLite's `parse()` appends options.timezone when the
+// string lacks a "+"/"-" offset - if we stripped the offset on write,
+// parse() would concatenate the offset on read, producing a value
+// different from what was written. Shadow an own-property `_stringify`
+// on `sqlite.DATE.prototype` that points to the original base
+// serialiser, so SQLite retains the "YYYY-MM-DD HH:mm:ss.SSS Z" format.
+if (Sequelize.DataTypes.sqlite && Sequelize.DataTypes.sqlite.DATE) {
+  Sequelize.DataTypes.sqlite.DATE.prototype._stringify = _origBaseStringify;
+}
 
 const chiaRoot = getChiaRoot();
 const persistanceFolder = `${chiaRoot}/cadt/v1`;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,7 +1,46 @@
+import Sequelize from 'sequelize';
+import moment from 'moment';
 import { getConfig, getConfigV2 } from '../utils/config-loader';
 import { getChiaRoot } from '../utils/chia-root.js';
 import { logger } from './logger.js';
 import { createHash } from 'crypto';
+
+// Strip the " +00:00" offset suffix from Sequelize's base DATE serialiser.
+//
+// Sequelize 6's default BaseTypes.DATE._stringify formats Date values as
+//   "YYYY-MM-DD HH:mm:ss.SSS Z"    (e.g. "2026-04-17 19:12:48.720 +00:00")
+// which recent MariaDB strict mode rejects with:
+//   Incorrect datetime value: '2026-04-17 19:12:48.720 +00:00'
+//     for column `cadt_mirror_test`.`audit`.`createdAt` at row 1
+//
+// The mysql-specific subclass overrides _stringify to a safer format
+// ("YYYY-MM-DD HH:mm:ss") and is always invoked for attribute-typed
+// writes on a MySQL dialect. However, V1 live-api CI reproducibly shows
+// the base format reaching MariaDB on Audit.create mirror writes even
+// with the mysql subclass wired up - presumably via some Sequelize
+// internal path that prototype-invokes the base method rather than
+// dispatching through the resolved attribute type. Rather than continue
+// bisecting Sequelize internals, patch the base emitter to drop the
+// offset suffix. The ".SSS" fractional-seconds form is kept so local
+// SQLite round-trips preserve millisecond precision (sqlite.DATE inherits
+// this _stringify - it doesn't define its own). Legacy rows written in
+// the pre-patch "... +00:00" form still round-trip via sqlite.DATE.parse
+// because its `date.includes("+")` branch returns `new Date(str)`
+// directly.
+//
+// MariaDB strict mode accepts ".SSS" (rounds half-up to whole seconds on
+// DATETIME(0) columns). CADT's mirror verification helpers
+// (tests/v{1,2}/live-api/helpers/mysql-mirror-helpers.js) compare on
+// the YYYY-MM-DD prefix only, so the rounding is not observable.
+Sequelize.DataTypes.DATE.prototype._stringify = function _stringify(
+  date,
+  options,
+) {
+  if (!moment.isMoment(date)) {
+    date = this._applyTimezone(date, options);
+  }
+  return date.format('YYYY-MM-DD HH:mm:ss.SSS');
+};
 
 const chiaRoot = getChiaRoot();
 const persistanceFolder = `${chiaRoot}/cadt/v1`;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -13,71 +13,45 @@ import { createHash } from 'crypto';
 //   Incorrect datetime value: '2026-04-17 19:12:48.720 +00:00'
 //     for column `cadt_mirror_test`.`audit`.`createdAt` at row 1
 //
-// The mysql-specific subclass overrides _stringify to a safer format
-// ("YYYY-MM-DD HH:mm:ss") and is always invoked for attribute-typed
-// writes on a MySQL dialect. However, V1 live-api CI reproducibly shows
-// the base format reaching MariaDB on Audit.create mirror writes even
-// with the mysql subclass wired up - presumably via some Sequelize
-// internal path that prototype-invokes the base method rather than
-// dispatching through the resolved attribute type. Rather than continue
-// bisecting Sequelize internals, patch the base emitter to drop the
-// offset suffix. The ".SSS" fractional-seconds form is kept so local
-// SQLite round-trips preserve millisecond precision (sqlite.DATE inherits
-// this _stringify - it doesn't define its own). Legacy rows written in
-// the pre-patch "... +00:00" form still round-trip via sqlite.DATE.parse
-// because its `date.includes("+")` branch returns `new Date(str)`
-// directly.
+// WHY PATCH THE BASE CLASS WHEN MYSQL HAS ITS OWN _stringify?
+// A CI stack-trace diagnostic (removed in a follow-up commit) confirmed
+// that the base _stringify is invoked only for SQLite writes - every
+// MySQL mirror write correctly dispatches through mysql.DATE._stringify,
+// which already emits the safe "YYYY-MM-DD HH:mm:ss" format. So the
+// rejected strings MariaDB was seeing were not produced during a MySQL
+// write at all: they were produced during a SQLite source write, then
+// forwarded verbatim to MariaDB by a code path that did not re-parse
+// them.
 //
-// MariaDB strict mode accepts ".SSS" (rounds half-up to whole seconds on
-// DATETIME(0) columns). CADT's mirror verification helpers
+// The known such path is the reconnect-backfill, fixed separately by
+// dropping `raw: true` from `source.findAll` in backfillMirror[V2] and
+// using `.get({ plain: true, raw: true })` on the resulting instances
+// (raw:true-only returns unparsed SQLite strings; instance construction
+// runs sqlite.DATE.parse so DATE columns become Date objects). However,
+// empirical CI comparison shows the backfill fix alone is insufficient
+// - there is at least one additional path that forwards SQLite-stored
+// strings to MariaDB without going through _stringify, which I was
+// unable to isolate. Patching the base emitter covers that unknown
+// path by ensuring SQLite never persists the " +00:00" form in the
+// first place.
+//
+// Format choice: "YYYY-MM-DD HH:mm:ss.SSS" - drop the offset, keep
+// millisecond precision. Keeping .SSS preserves round-trip equality
+// for SQLite reads (sqlite.DATE inherits this _stringify - it does not
+// define its own) and is required by V1 integration tests that compare
+// fixture dates byte-for-byte after a create-read round trip. MariaDB
+// strict mode accepts .SSS (rounds half-up to whole seconds on
+// DATETIME(0) columns); CADT's mirror verification helpers
 // (tests/v{1,2}/live-api/helpers/mysql-mirror-helpers.js) compare on
 // the YYYY-MM-DD prefix only, so the rounding is not observable.
-
-// Diagnostic counters for the patched base _stringify below. Gated by
-// CADT_DATE_STRINGIFY_DIAG so tests and production runs don't pay the
-// stack-capture cost or spam the logger. This block is TEMPORARY - it
-// exists to identify the specific Sequelize entry point that reaches
-// the base _stringify despite the mysql.DATE subclass being wired up.
-// Remove once that path is understood and documented in the comment
-// above.
-const MAX_BASE_STRINGIFY_STACKS = 8;
-let baseStringifyDiagCount = 0;
-const baseStringifyDiagEnabled =
-  process.env.CADT_DATE_STRINGIFY_DIAG !== undefined
-    ? process.env.CADT_DATE_STRINGIFY_DIAG !== '0' &&
-      process.env.CADT_DATE_STRINGIFY_DIAG !== 'false'
-    : false;
-
+//
+// Legacy rows written in the pre-patch " +00:00" form still round-trip
+// via sqlite.DATE.parse because its `date.includes("+")` branch returns
+// `new Date(str)` directly.
 Sequelize.DataTypes.DATE.prototype._stringify = function _stringify(
   date,
   options,
 ) {
-  // TEMPORARY DIAGNOSTIC - see MAX_BASE_STRINGIFY_STACKS block above.
-  if (
-    baseStringifyDiagEnabled &&
-    baseStringifyDiagCount < MAX_BASE_STRINGIFY_STACKS
-  ) {
-    baseStringifyDiagCount += 1;
-    const stack = new Error('[DATE-diag]').stack
-      .split('\n')
-      .slice(1, 12)
-      .join('\n');
-    const valueStr =
-      date instanceof Date
-        ? date.toISOString()
-        : moment.isMoment(date)
-          ? date.toISOString()
-          : String(date);
-    const dialectHint = this?.constructor?.name || 'unknown';
-    logger.warn(
-      `[DATE-diag] base _stringify called ` +
-        `(${baseStringifyDiagCount}/${MAX_BASE_STRINGIFY_STACKS}) ` +
-        `value=${valueStr} ` +
-        `timezone=${options?.timezone ?? 'unset'} ` +
-        `this.constructor.name=${dialectHint}\n` +
-        stack,
-    );
-  }
   if (!moment.isMoment(date)) {
     date = this._applyTimezone(date, options);
   }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -61,6 +61,18 @@ export default {
     host: getConfig().MIRROR_DB.DB_HOST || '',
     dialect: 'mysql',
     logging: mirrorLogging,
+    // Tell Sequelize to serialise Date values as UTC without a trailing
+    // "+00:00" offset. Recent MariaDB strict mode rejects the
+    // "YYYY-MM-DD HH:MM:SS.SSS +00:00" format Sequelize emits by default,
+    // with errors like:
+    //   Incorrect datetime value: '2026-04-16 22:41:27.490 +00:00'
+    //     for column `cadt_mirror_test`.`audit`.`createdAt` at row 1
+    // Setting timezone at the Sequelize constructor level (as opposed to
+    // Model.init, where it is silently ignored) produces the MariaDB-safe
+    // "YYYY-MM-DD HH:MM:SS" format. Without this, every mirror write that
+    // touches a DATE/DATETIME column is silently dropped by the
+    // fire-and-forget safeMirrorDbHandler.
+    timezone: '+00:00',
   },
   // V2 Database Configurations
   v2Local: {
@@ -96,5 +108,8 @@ export default {
     host: getConfigV2().MIRROR_DB?.DB_HOST || '',
     dialect: 'mysql',
     logging: mirrorLogging,
+    // See comment on `mirror` above. Same MariaDB strict-mode datetime
+    // issue applies to V2.
+    timezone: '+00:00',
   },
 };

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -32,10 +32,52 @@ import { createHash } from 'crypto';
 // DATETIME(0) columns). CADT's mirror verification helpers
 // (tests/v{1,2}/live-api/helpers/mysql-mirror-helpers.js) compare on
 // the YYYY-MM-DD prefix only, so the rounding is not observable.
+
+// Diagnostic counters for the patched base _stringify below. Gated by
+// CADT_DATE_STRINGIFY_DIAG so tests and production runs don't pay the
+// stack-capture cost or spam the logger. This block is TEMPORARY - it
+// exists to identify the specific Sequelize entry point that reaches
+// the base _stringify despite the mysql.DATE subclass being wired up.
+// Remove once that path is understood and documented in the comment
+// above.
+const MAX_BASE_STRINGIFY_STACKS = 8;
+let baseStringifyDiagCount = 0;
+const baseStringifyDiagEnabled =
+  process.env.CADT_DATE_STRINGIFY_DIAG !== undefined
+    ? process.env.CADT_DATE_STRINGIFY_DIAG !== '0' &&
+      process.env.CADT_DATE_STRINGIFY_DIAG !== 'false'
+    : false;
+
 Sequelize.DataTypes.DATE.prototype._stringify = function _stringify(
   date,
   options,
 ) {
+  // TEMPORARY DIAGNOSTIC - see MAX_BASE_STRINGIFY_STACKS block above.
+  if (
+    baseStringifyDiagEnabled &&
+    baseStringifyDiagCount < MAX_BASE_STRINGIFY_STACKS
+  ) {
+    baseStringifyDiagCount += 1;
+    const stack = new Error('[DATE-diag]').stack
+      .split('\n')
+      .slice(1, 12)
+      .join('\n');
+    const valueStr =
+      date instanceof Date
+        ? date.toISOString()
+        : moment.isMoment(date)
+          ? date.toISOString()
+          : String(date);
+    const dialectHint = this?.constructor?.name || 'unknown';
+    logger.warn(
+      `[DATE-diag] base _stringify called ` +
+        `(${baseStringifyDiagCount}/${MAX_BASE_STRINGIFY_STACKS}) ` +
+        `value=${valueStr} ` +
+        `timezone=${options?.timezone ?? 'unset'} ` +
+        `this.constructor.name=${dialectHint}\n` +
+        stack,
+    );
+  }
   if (!moment.isMoment(date)) {
     date = this._applyTimezone(date, options);
   }

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -332,6 +332,11 @@ const sweepMirrorOrphans = async (source, mirror, name) => {
   }
   const pkAttr = pkAttrs[0];
 
+  // `raw: true` is safe here - the projection is PK-only, so there are
+  // no DATE or custom-getter columns whose raw SQLite representation
+  // could leak into a bulk write (which is the hazard backfillMirror
+  // avoids). If a future change adds more projected attributes, revisit
+  // the raw:true pattern (see backfillMirror for the safe variant).
   const mirrorPkRows = await mirror.findAll({
     attributes: [pkAttr],
     raw: true,
@@ -475,13 +480,29 @@ export const backfillMirror = async () => {
           while (true) {
             const where =
               lastPk === null ? undefined : { [pk]: { [Sequelize.Op.gt]: lastPk } };
-            const rows = await source.findAll({
-              raw: true,
+            // NOTE: Do NOT pass `raw: true` to findAll. With raw:true
+            // Sequelize returns SQLite values as-stored (strings),
+            // including DATE columns as "YYYY-MM-DD HH:mm:ss.SSS +00:00".
+            // Forwarding those strings verbatim to MariaDB's bulkCreate
+            // triggers strict-mode "Incorrect datetime value" rejections.
+            // Building model instances runs sqlite.DATE.parse so DATE
+            // columns become real Date objects; mysql.DATE then serialises
+            // them in the MariaDB-safe "YYYY-MM-DD HH:mm:ss" format.
+            //
+            // `.get({ plain: true, raw: true })` extracts dataValues
+            // directly (bypassing any attribute-level `get()` accessors
+            // a source model may define). Dates remain Date objects on
+            // dataValues because the sqlite parser runs during instance
+            // construction, not at get() time.
+            const instances = await source.findAll({
               where,
               limit: BACKFILL_BATCH_SIZE,
               order: [[pk, 'ASC']],
             });
-            if (rows.length === 0) break;
+            if (instances.length === 0) break;
+            const rows = instances.map((r) =>
+              r.get({ plain: true, raw: true }),
+            );
             await mirror.bulkCreate(rows, { updateOnDuplicate: updateFields });
             synced += rows.length;
             lastPk = rows[rows.length - 1][pk];

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -50,7 +50,38 @@ const logDebounce = _.debounce(() => {
   logger.info('Mirror DB not connected');
 }, 120000);
 
+// Test-only override. Tests set this to force mirror-enabled behaviour
+// against the SQLite fallback sequelizeMirror so backfill / reconnect code
+// paths can be exercised without a live MySQL instance. null means "use the
+// real config value".
+let mirrorEnabledTestOverride = null;
+
+// Track the last observed auth outcome so we can detect a transition from
+// "disconnected" back to "connected" and trigger a catch-up backfill. This
+// recovers writes (INSERT/UPDATE) and deletes that were dropped during an
+// outage because safeMirrorDbHandler is fire-and-forget and silently drops
+// its callback when authenticate() fails.
+let mirrorAuthState = 'unknown'; // 'unknown' | 'connected' | 'disconnected'
+
+// Tracks whether the MySQL-side setup (CREATE DATABASE + migrations)
+// succeeded. Set by prepareMysqlMirror. If it failed at startup (e.g. MySQL
+// not yet reachable), we treat the first successful runtime authenticate
+// as a reconnect so the setup is retried and the initial backfill runs.
+let mirrorSetupSucceeded = false;
+
+// Concurrency guard for prepareMysqlMirror - only one attempt at a time.
+let mirrorSetupPromise = null;
+
+// Single in-flight reconnect backfill. Concurrent callers share the same
+// promise so we don't run multiple backfills in parallel, and writes issued
+// after the reconnect are serialized behind it so the mirror is caught up
+// before new operations are applied.
+let reconnectBackfillPromise = null;
+
 export const mirrorDBEnabled = () => {
+  if (mirrorEnabledTestOverride !== null) {
+    return mirrorEnabledTestOverride;
+  }
   const CONFIG = getConfig();
   if (
     mirrorConfig === 'mirror' &&
@@ -65,6 +96,138 @@ export const mirrorDBEnabled = () => {
   return true;
 };
 
+// Test-only. DO NOT call from production code. Passing `null` restores the
+// real config-driven behaviour. See mirrorEnabledTestOverride above.
+export const __setMirrorEnabledForTests = (value) => {
+  mirrorEnabledTestOverride = value;
+};
+
+// Test-only. DO NOT call from production code. Signals to the reconnect
+// path whether the one-time MySQL setup (CREATE DATABASE + migrations) has
+// succeeded. In production this is set to true by prepareMysqlMirror.
+export const __setMirrorSetupSucceededForTests = (value) => {
+  mirrorSetupSucceeded = value;
+};
+
+/**
+ * Ensure the V1 MySQL mirror database exists and has up-to-date migrations.
+ * Idempotent: safe to call from startup and again on every reconnect.
+ *
+ * Returns true on success, false on failure. Never throws so it won't take
+ * down the main database path.
+ */
+export const prepareMysqlMirror = async () => {
+  if (mirrorSetupPromise) {
+    return mirrorSetupPromise;
+  }
+
+  mirrorSetupPromise = (async () => {
+    const CONFIG = getConfig();
+    const mirrorDbConfig = CONFIG?.MIRROR_DB;
+    if (
+      !mirrorDbConfig?.DB_HOST ||
+      mirrorDbConfig.DB_HOST === '' ||
+      !mirrorDbConfig.DB_NAME ||
+      !mirrorDbConfig.DB_USERNAME ||
+      !mirrorDbConfig.DB_PASSWORD
+    ) {
+      return false;
+    }
+
+    try {
+      const connection = await mysql.createConnection({
+        host: mirrorDbConfig.DB_HOST,
+        port: 3306,
+        user: mirrorDbConfig.DB_USERNAME,
+        password: mirrorDbConfig.DB_PASSWORD,
+      });
+
+      try {
+        await connection.query(
+          `CREATE DATABASE IF NOT EXISTS \`${mirrorDbConfig.DB_NAME}\`;`,
+        );
+      } finally {
+        await connection.end();
+      }
+
+      // checkForMigrations is idempotent (it checks SequelizeMeta), so it's
+      // safe to re-run on every reconnect.
+      await checkForMigrations(sequelizeMirror);
+      mirrorSetupSucceeded = true;
+      return true;
+    } catch (error) {
+      logger.error(
+        `Error setting up MySQL mirror database: ${error.message}`,
+      );
+      return false;
+    }
+  })().finally(() => {
+    mirrorSetupPromise = null;
+  });
+
+  return mirrorSetupPromise;
+};
+
+// Returns true if V1.MIRROR_DB is fully configured with MySQL credentials.
+// Used to gate reconnect-setup retries - only MySQL configs need the setup
+// retry path; SQLite test fallbacks never need it.
+const isMysqlMirrorConfiguredForReconnect = () => {
+  const CONFIG = getConfig();
+  return !!(
+    CONFIG?.MIRROR_DB?.DB_HOST &&
+    CONFIG.MIRROR_DB.DB_HOST !== '' &&
+    CONFIG.MIRROR_DB.DB_NAME &&
+    CONFIG.MIRROR_DB.DB_USERNAME &&
+    CONFIG.MIRROR_DB.DB_PASSWORD
+  );
+};
+
+const startReconnectBackfill = () => {
+  if (reconnectBackfillPromise) {
+    return reconnectBackfillPromise;
+  }
+  reconnectBackfillPromise = (async () => {
+    try {
+      logger.info('Mirror DB reconnected, running catch-up recovery...');
+
+      // If setup (CREATE DATABASE + migrations) never succeeded (e.g. MySQL
+      // was down at CADT startup), retry it before backfill. Only applies
+      // to MySQL configurations - SQLite test fallbacks don't need setup
+      // retries and don't have config to retry against.
+      if (!mirrorSetupSucceeded && isMysqlMirrorConfiguredForReconnect()) {
+        const ok = await prepareMysqlMirror();
+        if (!ok) {
+          logger.error(
+            'Reconnect recovery: mirror setup still failing, backfill skipped',
+          );
+          // Keep auth state as 'disconnected' so the next successful
+          // authenticate re-enters this path and retries setup+backfill.
+          mirrorAuthState = 'disconnected';
+          return;
+        }
+      }
+
+      if (!mirrorSetupSucceeded) {
+        // SQLite test fallback path never marked setup complete and has no
+        // MySQL to retry against. Skip the backfill quietly - there's
+        // nothing to reconnect to.
+        return;
+      }
+
+      await backfillMirror();
+    } catch (error) {
+      logger.error(`Reconnect backfill failed: ${error.message}`);
+      // Mark disconnected so the next authenticate success retries the
+      // catch-up. Without this reset, a transient backfill failure would
+      // leave the mirror permanently behind until the NEXT real outage.
+      mirrorAuthState = 'disconnected';
+    } finally {
+      reconnectBackfillPromise = null;
+    }
+  })();
+  return reconnectBackfillPromise;
+};
+
 export const safeMirrorDbHandler = (callback) => {
   if (!mirrorDBEnabled()) {
     return Promise.resolve();
@@ -75,6 +238,26 @@ export const safeMirrorDbHandler = (callback) => {
       sequelizeMirror
         .authenticate()
         .then(async () => {
+          const wasDisconnected = mirrorAuthState === 'disconnected';
+          // If MySQL setup never succeeded at startup (e.g. MySQL was down
+          // when prepareDb ran), the first successful authenticate needs
+          // to re-run setup + backfill even though we were never in an
+          // explicit 'disconnected' state. Only applies when MySQL is
+          // actually configured - the SQLite test fallback doesn't need a
+          // reconnect path and would otherwise spam recovery logs on every
+          // model write during tests.
+          const setupNeverRan =
+            !mirrorSetupSucceeded && isMysqlMirrorConfiguredForReconnect();
+          mirrorAuthState = 'connected';
+
+          if (wasDisconnected || setupNeverRan) {
+            await startReconnectBackfill();
+          } else if (reconnectBackfillPromise) {
+            // Another concurrent caller already triggered the backfill;
+            // wait for it so our write lands on a caught-up mirror.
+            await reconnectBackfillPromise;
+          }
+
           try {
             await callback();
           } catch (e) {
@@ -82,6 +265,7 @@ export const safeMirrorDbHandler = (callback) => {
           }
         })
         .catch(() => {
+          mirrorAuthState = 'disconnected';
           logDebounce();
         });
     } catch (error) {
@@ -93,6 +277,223 @@ export const safeMirrorDbHandler = (callback) => {
       resolve();
     }
   });
+};
+
+// Initialize a V1 mirror Sequelize Model synchronously at module-load time.
+//
+// Model.init() only registers schema metadata on the Sequelize instance; it
+// does not require a live database connection. Gating init on a successful
+// authenticate() (as safeMirrorDbHandler does for runtime operations) causes
+// a silent, permanent failure when the MySQL sidecar is not yet reachable at
+// CADT startup: the .then() callback never runs, the model is never
+// initialized, and every subsequent mirror write throws
+// "Cannot read properties of undefined (reading 'constructor')" from within
+// Sequelize (this.sequelize is undefined on an uninitialized Model).
+//
+// Runtime writes continue to be gated through safeMirrorDbHandler, which
+// authenticates on each call and short-circuits cleanly when MySQL is down
+// and transparently resumes when the connection pool recovers.
+export const initMirrorModel = (initFn) => {
+  try {
+    initFn();
+  } catch (error) {
+    logger.error(`Failed to initialize mirror model: ${error.message}`);
+  }
+};
+
+/**
+ * Backfill MySQL mirror database from SQLite source data.
+ *
+ * Runs on startup and on every reconnect after a connection outage. For each
+ * source/mirror pair this performs two passes:
+ *   1. Upsert pass: bulkCreate(updateOnDuplicate) inserts missing rows and
+ *      updates stale rows. This recovers inserts and updates that happened
+ *      while the mirror was unreachable.
+ *   2. Orphan sweep: rows present in mirror but no longer in source are
+ *      deleted. This recovers deletes that happened while the mirror was
+ *      unreachable (deletes are otherwise lost because the fire-and-forget
+ *      safeMirrorDbHandler silently drops operations during an outage).
+ *
+ * Ordering matters for the orphan sweep: mirror PKs are snapshotted BEFORE
+ * source PKs so rows inserted concurrently are not misclassified as orphans.
+ *
+ * Uses dynamic imports to avoid circular dependency (model files import from
+ * this file).
+ */
+const BACKFILL_BATCH_SIZE = 1000;
+
+const sweepMirrorOrphans = async (source, mirror, name) => {
+  const pkAttrs = mirror.primaryKeyAttributes;
+  if (!pkAttrs || pkAttrs.length !== 1) {
+    logger.debug(
+      `Mirror backfill: ${name} - skipping orphan sweep (composite or missing primary key)`,
+    );
+    return 0;
+  }
+  const pkAttr = pkAttrs[0];
+
+  const mirrorPkRows = await mirror.findAll({
+    attributes: [pkAttr],
+    raw: true,
+  });
+  if (mirrorPkRows.length === 0) {
+    return 0;
+  }
+
+  const sourcePkRows = await source.findAll({
+    attributes: [pkAttr],
+    raw: true,
+  });
+  const sourcePks = new Set(sourcePkRows.map((r) => r[pkAttr]));
+
+  const orphanPks = mirrorPkRows
+    .map((r) => r[pkAttr])
+    .filter((pk) => !sourcePks.has(pk));
+
+  if (orphanPks.length === 0) {
+    return 0;
+  }
+
+  let removed = 0;
+  for (let i = 0; i < orphanPks.length; i += BACKFILL_BATCH_SIZE) {
+    const batch = orphanPks.slice(i, i + BACKFILL_BATCH_SIZE);
+    removed += await mirror.destroy({
+      where: { [pkAttr]: batch },
+    });
+  }
+
+  logger.info(`Mirror backfill: ${name} - removed ${removed} orphan rows`);
+  return removed;
+};
+
+export const backfillMirror = async () => {
+  if (!mirrorDBEnabled()) {
+    return;
+  }
+
+  logger.info('Starting MySQL mirror backfill from SQLite...');
+
+  try {
+    // Dynamic import of the models barrel to avoid circular dependency:
+    // V1 model files statically import { sequelizeMirror, safeMirrorDbHandler }
+    // from this file, so a static import of the models here would introduce
+    // a module cycle. Dynamic import lets Node fully resolve the V1 model
+    // graph (including cross-model associations in src/models/index.js)
+    // before we reference any model class.
+    // eslint-disable-next-line no-restricted-syntax -- see comment above
+    const models = await import('../models/index.js');
+
+    // Mirrors are not all re-exported through the barrel today, so import
+    // each mirror file directly. Same circular-dep rationale applies.
+    /* eslint-disable no-restricted-syntax -- dynamic imports intentional; see comment above */
+    const [
+      { ProjectMirror },
+      { CoBenefitMirror },
+      { ProjectLocationMirror },
+      { LabelMirror },
+      { RatingMirror },
+      { RelatedProjectMirror },
+      { UnitMirror },
+      { IssuanceMirror },
+      { EstimationMirror },
+      { LabelUnitMirror },
+      { AuditMirror },
+    ] = await Promise.all([
+      import('../models/projects/projects.model.mirror.js'),
+      import('../models/co-benefits/co-benefits.model.mirror.js'),
+      import('../models/locations/locations.model.mirror.js'),
+      import('../models/labels/labels.model.mirror.js'),
+      import('../models/ratings/ratings.model.mirror.js'),
+      import('../models/related-projects/related-projects.model.mirror.js'),
+      import('../models/units/units.model.mirror.js'),
+      import('../models/issuances/issuances.model.mirror.js'),
+      import('../models/estimations/estimations.model.mirror.js'),
+      import('../models/labelUnits/labelUnits.model.mirror.js'),
+      import('../models/audit/audit.model.mirror.js'),
+    ]);
+    /* eslint-enable no-restricted-syntax */
+
+    const mirrorPairs = [
+      { source: models.Project, mirror: ProjectMirror, name: 'project' },
+      { source: models.CoBenefit, mirror: CoBenefitMirror, name: 'co_benefit' },
+      { source: models.ProjectLocation, mirror: ProjectLocationMirror, name: 'location' },
+      { source: models.Label, mirror: LabelMirror, name: 'label' },
+      { source: models.Rating, mirror: RatingMirror, name: 'rating' },
+      { source: models.RelatedProject, mirror: RelatedProjectMirror, name: 'related_project' },
+      { source: models.Unit, mirror: UnitMirror, name: 'unit' },
+      { source: models.Issuance, mirror: IssuanceMirror, name: 'issuance' },
+      { source: models.Estimation, mirror: EstimationMirror, name: 'estimation' },
+      { source: models.LabelUnit, mirror: LabelUnitMirror, name: 'label_unit' },
+      { source: models.Audit, mirror: AuditMirror, name: 'audit' },
+    ];
+
+    let totalSynced = 0;
+    let totalOrphansRemoved = 0;
+
+    for (const { source, mirror, name } of mirrorPairs) {
+      try {
+        if (!mirror.rawAttributes || Object.keys(mirror.rawAttributes).length === 0) {
+          logger.warn(`Mirror backfill: ${name} - mirror model not initialized, skipping`);
+          continue;
+        }
+
+        // Orphan sweep first (mirror snapshot before source snapshot) so
+        // concurrent inserts aren't wrongly classified as orphans.
+        const orphansRemoved = await sweepMirrorOrphans(source, mirror, name);
+        totalOrphansRemoved += orphansRemoved;
+
+        const count = await source.count();
+        if (count === 0) {
+          logger.debug(`Mirror backfill: ${name} - no records to sync`);
+          continue;
+        }
+
+        const updateFields = Object.keys(mirror.rawAttributes).filter(
+          (attr) => !mirror.primaryKeyAttributes.includes(attr),
+        );
+
+        // Paginate with an explicit ORDER BY on the primary key - neither
+        // SQLite nor MySQL guarantees consistent ordering across pages
+        // without it, and concurrent writes mid-backfill could otherwise
+        // shift rows between pages and cause some to be silently skipped.
+        const pkAttrs = mirror.primaryKeyAttributes || [];
+        const order =
+          pkAttrs.length === 1 ? [[pkAttrs[0], 'ASC']] : undefined;
+
+        let synced = 0;
+        for (let offset = 0; offset < count; offset += BACKFILL_BATCH_SIZE) {
+          const rows = await source.findAll({
+            raw: true,
+            offset,
+            limit: BACKFILL_BATCH_SIZE,
+            order,
+          });
+
+          await mirror.bulkCreate(rows, {
+            updateOnDuplicate: updateFields,
+          });
+
+          synced += rows.length;
+        }
+
+        logger.info(`Mirror backfill: ${name} - synced ${synced} records`);
+        totalSynced += synced;
+      } catch (error) {
+        logger.error(`Mirror backfill error for ${name}: ${error.message}`);
+        // Continue with next table - don't let one failure stop the entire backfill
+      }
+    }
+
+    logger.info(
+      `MySQL mirror backfill completed - ${totalSynced} records upserted, ${totalOrphansRemoved} orphan rows removed`,
+    );
+  } catch (error) {
+    logger.error(
+      `MySQL mirror backfill failed: ${error?.message || error?.name || 'unknown error'}`,
+    );
+    logger.debug(error?.stack || error);
+    // Don't throw - allow main database to continue operating
+  }
 };
 
 export const sanitizeSqliteFtsQuery = (query) => {
@@ -157,42 +558,36 @@ export const checkForMigrations = async (db) => {
 };
 
 export const prepareDb = async () => {
-  const mirrorConfig =
+  const envMirrorConfig =
     (process.env.NODE_ENV || 'local') === 'local' ? 'mirror' : 'mirrorTest';
 
   if (
-    mirrorConfig == 'mirror' &&
-    getConfig().MIRROR_DB.DB_HOST &&
+    envMirrorConfig == 'mirror' &&
+    getConfig().MIRROR_DB?.DB_HOST &&
     getConfig().MIRROR_DB.DB_HOST !== ''
   ) {
-    try {
-      const connection = await mysql.createConnection({
-        host: getConfig().MIRROR_DB.DB_HOST,
-        port: 3306,
-        user: getConfig().MIRROR_DB.DB_USERNAME,
-        password: getConfig().MIRROR_DB.DB_PASSWORD,
-      });
-
-      try {
-        await connection.query(
-          `CREATE DATABASE IF NOT EXISTS \`${getConfig().MIRROR_DB.DB_NAME}\`;`,
-        );
-      } finally {
-        await connection.end();
-      }
-
-      const db = new Sequelize(config[mirrorConfig]);
-
-      await checkForMigrations(db);
-    } catch (error) {
-      // Non-fatal: mirror DB failure should not block main database startup
-      logger.error('[v1]: Error setting up MySQL mirror database:', error);
-    }
-  } else if (mirrorConfig == 'mirrorTest') {
+    // Non-fatal: mirror DB failure should not block main database startup.
+    // When the mirror becomes reachable later, safeMirrorDbHandler will
+    // detect the reconnect and trigger a catch-up backfill automatically.
+    await prepareMysqlMirror();
+  } else if (envMirrorConfig == 'mirrorTest') {
+    // SQLite fallback used in unit/integration tests (NODE_ENV=test). The
+    // DB is always reachable so migrations run directly. Marking setup as
+    // succeeded prevents safeMirrorDbHandler from treating the first
+    // authenticate as a reconnect and spamming the "reconnect recovery"
+    // log for every model write during tests.
     await checkForMigrations(sequelizeMirror);
+    mirrorSetupSucceeded = true;
   }
 
   await checkForMigrations(sequelize);
+
+  // Run the mirror backfill after main migrations so all source and mirror
+  // tables exist. This catches up rows that were inserted/updated/deleted
+  // while the mirror was unavailable on a previous run.
+  if (mirrorSetupSucceeded) {
+    await backfillMirror();
+  }
 };
 
 // Function to set WAL mode

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -45,6 +45,24 @@ const mirrorConfig =
   (process.env.NODE_ENV || 'local') === 'local' ? 'mirror' : 'mirrorTest';
 export const sequelizeMirror = new Sequelize(config[mirrorConfig]);
 
+// Snapshot of whether V1 MIRROR_DB was fully configured at module-load time.
+// Captured alongside sequelizeMirror construction so mirrorDBEnabled() stays
+// consistent with the backend sequelizeMirror was actually built against.
+// Reading the live config on every call would let tests that clear the
+// getConfig() memoize cache (or any future runtime-reload path) drift the
+// enablement check away from the already-constructed Sequelize instance.
+// Symmetric with v2MirrorTargetsMysql in src/database/v2/index.js.
+const v1MirrorConfiguredAtLoad = (() => {
+  const CONFIG = getConfig();
+  return !!(
+    CONFIG?.MIRROR_DB?.DB_HOST &&
+    CONFIG.MIRROR_DB.DB_HOST !== '' &&
+    CONFIG.MIRROR_DB.DB_NAME &&
+    CONFIG.MIRROR_DB.DB_USERNAME &&
+    CONFIG.MIRROR_DB.DB_PASSWORD
+  );
+})();
+
 const logDebounce = _.debounce(() => {
   console.log('Mirror DB not connected');
   logger.info('Mirror DB not connected');
@@ -55,6 +73,11 @@ const logDebounce = _.debounce(() => {
 // paths can be exercised without a live MySQL instance. null means "use the
 // real config value".
 let mirrorEnabledTestOverride = null;
+
+// Test-only override for isMysqlMirrorConfiguredForReconnect(). Tests set
+// this to simulate "MySQL is configured" (or not) independently of the
+// actual config.yaml. null means "use the real config value".
+let mysqlConfiguredForReconnectOverride = null;
 
 // Track the last observed auth outcome so we can detect a transition from
 // "disconnected" back to "connected" and trigger a catch-up backfill. This
@@ -82,7 +105,6 @@ export const mirrorDBEnabled = () => {
   if (mirrorEnabledTestOverride !== null) {
     return mirrorEnabledTestOverride;
   }
-  const CONFIG = getConfig();
   // In production-like mode ('local' env), require full MySQL config.
   // In SQLite-fallback test mode ('mirrorTest' env), leave the mirror
   // enabled unconditionally so integration tests that rely on the
@@ -97,13 +119,11 @@ export const mirrorDBEnabled = () => {
   // is gated separately in prepareDb() via
   // isMysqlMirrorConfiguredForReconnect(), not via mirrorDBEnabled(),
   // so the backfill only fires when MySQL is actually configured.
-  if (
-    mirrorConfig === 'mirror' &&
-    (!CONFIG?.MIRROR_DB?.DB_HOST ||
-      !CONFIG?.MIRROR_DB?.DB_NAME ||
-      !CONFIG?.MIRROR_DB?.DB_USERNAME ||
-      !CONFIG?.MIRROR_DB?.DB_PASSWORD)
-  ) {
+  //
+  // Uses v1MirrorConfiguredAtLoad (module-load snapshot) so this check
+  // stays consistent with the backend sequelizeMirror was built against.
+  // Symmetric with mirrorDBEnabledV2.
+  if (mirrorConfig === 'mirror' && !v1MirrorConfiguredAtLoad) {
     return false;
   }
   return true;
@@ -120,6 +140,23 @@ export const __setMirrorEnabledForTests = (value) => {
 // succeeded. In production this is set to true by prepareMysqlMirror.
 export const __setMirrorSetupSucceededForTests = (value) => {
   mirrorSetupSucceeded = value;
+};
+
+// Test-only. DO NOT call from production code. Forces
+// isMysqlMirrorConfiguredForReconnect() to return a specific boolean so
+// tests can exercise the reconnect setup / skip-callback guards without a
+// live MySQL instance or a real MIRROR_DB config. null restores live behaviour.
+export const __setMysqlConfiguredForReconnectForTests = (value) => {
+  mysqlConfiguredForReconnectOverride = value;
+};
+
+// Test-only. DO NOT call from production code. Resets the internal
+// auth-state machine back to 'unknown' so tests that intentionally leave
+// the state in 'disconnected' can reset it in an afterEach hook and avoid
+// leaking reconnect behaviour into downstream specs running in the same
+// mocha session.
+export const __resetMirrorAuthStateForTests = () => {
+  mirrorAuthState = 'unknown';
 };
 
 /**
@@ -185,6 +222,9 @@ export const prepareMysqlMirror = async () => {
 // Used to gate reconnect-setup retries - only MySQL configs need the setup
 // retry path; SQLite test fallbacks never need it.
 const isMysqlMirrorConfiguredForReconnect = () => {
+  if (mysqlConfiguredForReconnectOverride !== null) {
+    return mysqlConfiguredForReconnectOverride;
+  }
   const CONFIG = getConfig();
   return !!(
     CONFIG?.MIRROR_DB?.DB_HOST &&
@@ -269,6 +309,20 @@ export const safeMirrorDbHandler = (callback) => {
             // Another concurrent caller already triggered the backfill;
             // wait for it so our write lands on a caught-up mirror.
             await reconnectBackfillPromise;
+          }
+
+          // If MySQL is configured but the one-time setup (CREATE DATABASE
+          // + migrations) has not yet completed, the mirror tables don't
+          // exist. Running the callback would produce a confusing
+          // "table doesn't exist" error that gets swallowed by the catch
+          // below. Skip quietly - the next authenticate success will
+          // re-enter startReconnectBackfill and retry setup. Symmetric
+          // with safeMirrorDbHandlerV2.
+          if (
+            isMysqlMirrorConfiguredForReconnect() &&
+            !mirrorSetupSucceeded
+          ) {
+            return;
           }
 
           try {

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -442,41 +442,82 @@ export const backfillMirror = async () => {
         const orphansRemoved = await sweepMirrorOrphans(source, mirror, name);
         totalOrphansRemoved += orphansRemoved;
 
-        const count = await source.count();
-        if (count === 0) {
-          logger.debug(`Mirror backfill: ${name} - no records to sync`);
-          continue;
-        }
-
         const updateFields = Object.keys(mirror.rawAttributes).filter(
           (attr) => !mirror.primaryKeyAttributes.includes(attr),
         );
 
-        // Paginate with an explicit ORDER BY on the primary key - neither
-        // SQLite nor MySQL guarantees consistent ordering across pages
-        // without it, and concurrent writes mid-backfill could otherwise
-        // shift rows between pages and cause some to be silently skipped.
+        // Keyset pagination (WHERE pk > :lastSeenPk ORDER BY pk ASC LIMIT N)
+        // instead of offset-based. Offset pagination under concurrent
+        // writes can silently skip rows: a delete at position N shifts
+        // later rows down, so the next page's OFFSET lands one row later
+        // than intended. Keyset pagination avoids that page-shift-on-delete
+        // hazard by using a lower-bound predicate instead of a position
+        // count.
+        //
+        // Note: keyset pagination is NOT immune to concurrent INSERTs with
+        // a PK less than `lastPk`. Such rows will be missed in the current
+        // pass but picked up by the next reconnect backfill. A subsequent
+        // steady-state safeMirrorDbHandler write also directly upserts
+        // them, so the miss window is bounded.
+        //
+        // Requires a single-column comparable PK. Composite-PK models fall
+        // back to a single unordered bulk read - safer than a wrong-order
+        // keyset walk. No V1 models currently use composite PKs, and the
+        // single-PK invariant is asserted at load time by
+        // mirror-model-init.spec.js.
         const pkAttrs = mirror.primaryKeyAttributes || [];
-        const order =
-          pkAttrs.length === 1 ? [[pkAttrs[0], 'ASC']] : undefined;
 
         let synced = 0;
-        for (let offset = 0; offset < count; offset += BACKFILL_BATCH_SIZE) {
-          const rows = await source.findAll({
-            raw: true,
-            offset,
-            limit: BACKFILL_BATCH_SIZE,
-            order,
-          });
-
-          await mirror.bulkCreate(rows, {
-            updateOnDuplicate: updateFields,
-          });
-
-          synced += rows.length;
+        if (pkAttrs.length === 1) {
+          const pk = pkAttrs[0];
+          let lastPk = null;
+          // eslint-disable-next-line no-constant-condition
+          while (true) {
+            const where =
+              lastPk === null ? undefined : { [pk]: { [Sequelize.Op.gt]: lastPk } };
+            const rows = await source.findAll({
+              raw: true,
+              where,
+              limit: BACKFILL_BATCH_SIZE,
+              order: [[pk, 'ASC']],
+            });
+            if (rows.length === 0) break;
+            await mirror.bulkCreate(rows, { updateOnDuplicate: updateFields });
+            synced += rows.length;
+            lastPk = rows[rows.length - 1][pk];
+            // Defensive: a null/undefined terminal PK means we can't
+            // continue the keyset walk safely (Op.gt: undefined is
+            // ill-defined and would loop on the same page). Stop the
+            // walk; subsequent reconnects will retry from scratch.
+            if (lastPk == null) {
+              logger.warn(
+                `Mirror backfill: ${name} - terminal row had null PK; ` +
+                  `stopping keyset walk early (${synced} rows synced).`,
+              );
+              break;
+            }
+            if (rows.length < BACKFILL_BATCH_SIZE) break;
+          }
+        } else {
+          // Composite-PK mirrors are not supported by keyset-paginated
+          // backfill. mirror-model-init.spec.js asserts every current
+          // mirror has a single-column PK; if someone introduces a
+          // composite-PK mirror without extending this function, fail
+          // loudly (caught by the per-table try/catch) rather than
+          // silently loading the whole table into memory.
+          throw new Error(
+            `Mirror backfill: ${name} has a composite primary key ` +
+              `(${pkAttrs.join(', ')}). Keyset pagination needs a ` +
+              `single-column comparable PK. Either reduce to a single-column ` +
+              `PK, or extend backfillMirror to handle composite keys.`,
+          );
         }
 
-        logger.info(`Mirror backfill: ${name} - synced ${synced} records`);
+        if (synced === 0) {
+          logger.debug(`Mirror backfill: ${name} - no records to sync`);
+        } else {
+          logger.info(`Mirror backfill: ${name} - synced ${synced} records`);
+        }
         totalSynced += synced;
       } catch (error) {
         logger.error(`Mirror backfill error for ${name}: ${error.message}`);

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -83,6 +83,20 @@ export const mirrorDBEnabled = () => {
     return mirrorEnabledTestOverride;
   }
   const CONFIG = getConfig();
+  // In production-like mode ('local' env), require full MySQL config.
+  // In SQLite-fallback test mode ('mirrorTest' env), leave the mirror
+  // enabled unconditionally so integration tests that rely on the
+  // SQLite fallback mirror continue to see their writes land.
+  //
+  // Asymmetry note: V2's mirrorDBEnabledV2() is stricter - it returns
+  // false in SQLite-fallback test mode, and V2 tests opt in via
+  // __setMirrorEnabledForTestsV2. V1 integration tests predate that
+  // pattern and rely on the implicit test-mode enablement here.
+  //
+  // The cost of the on-startup backfill iterating all 11 table pairs
+  // is gated separately in prepareDb() via
+  // isMysqlMirrorConfiguredForReconnect(), not via mirrorDBEnabled(),
+  // so the backfill only fires when MySQL is actually configured.
   if (
     mirrorConfig === 'mirror' &&
     (!CONFIG?.MIRROR_DB?.DB_HOST ||
@@ -92,7 +106,6 @@ export const mirrorDBEnabled = () => {
   ) {
     return false;
   }
-
   return true;
 };
 
@@ -332,39 +345,74 @@ const sweepMirrorOrphans = async (source, mirror, name) => {
   }
   const pkAttr = pkAttrs[0];
 
+  // Concurrency invariant: mirror is scanned BEFORE source. A row
+  // inserted concurrently (after the mirror page fetch, before or
+  // during the source page fetch) will be absent from orphanCandidates
+  // and thus cannot be misclassified as an orphan. A row inserted
+  // before the mirror scan and deleted from source during the scan is
+  // a true orphan and will be correctly removed. Reversing the order
+  // would allow false-positive orphan deletes for rows inserted into
+  // both tables during the sweep.
+  //
+  // Both scans are keyset-paginated. An earlier revision loaded every
+  // PK from both tables in a single unbounded findAll; this is fine
+  // for today's row counts but spikes memory on long-running
+  // deployments with large tables. Peak memory here is O(|mirror|) for
+  // the candidate set; the source side is streamed.
+  //
   // `raw: true` is safe here - the projection is PK-only, so there are
   // no DATE or custom-getter columns whose raw SQLite representation
-  // could leak into a bulk write (which is the hazard backfillMirror
-  // avoids). If a future change adds more projected attributes, revisit
-  // the raw:true pattern (see backfillMirror for the safe variant).
-  const mirrorPkRows = await mirror.findAll({
-    attributes: [pkAttr],
-    raw: true,
-  });
-  if (mirrorPkRows.length === 0) {
-    return 0;
-  }
-
-  const sourcePkRows = await source.findAll({
-    attributes: [pkAttr],
-    raw: true,
-  });
-  const sourcePks = new Set(sourcePkRows.map((r) => r[pkAttr]));
-
-  const orphanPks = mirrorPkRows
-    .map((r) => r[pkAttr])
-    .filter((pk) => !sourcePks.has(pk));
-
-  if (orphanPks.length === 0) {
-    return 0;
-  }
-
-  let removed = 0;
-  for (let i = 0; i < orphanPks.length; i += BACKFILL_BATCH_SIZE) {
-    const batch = orphanPks.slice(i, i + BACKFILL_BATCH_SIZE);
-    removed += await mirror.destroy({
-      where: { [pkAttr]: batch },
+  // could leak into a bulk write (the hazard backfillMirror avoids).
+  const orphanCandidates = new Set();
+  let lastMirrorPk = null;
+  while (true) {
+    const where =
+      lastMirrorPk === null
+        ? undefined
+        : { [pkAttr]: { [Sequelize.Op.gt]: lastMirrorPk } };
+    const page = await mirror.findAll({
+      attributes: [pkAttr],
+      where,
+      limit: BACKFILL_BATCH_SIZE,
+      order: [[pkAttr, 'ASC']],
+      raw: true,
     });
+    if (page.length === 0) break;
+    for (const r of page) orphanCandidates.add(r[pkAttr]);
+    lastMirrorPk = page[page.length - 1][pkAttr];
+    if (lastMirrorPk == null) break;
+    if (page.length < BACKFILL_BATCH_SIZE) break;
+  }
+
+  if (orphanCandidates.size === 0) return 0;
+
+  let lastSrcPk = null;
+  while (true) {
+    const where =
+      lastSrcPk === null
+        ? undefined
+        : { [pkAttr]: { [Sequelize.Op.gt]: lastSrcPk } };
+    const page = await source.findAll({
+      attributes: [pkAttr],
+      where,
+      limit: BACKFILL_BATCH_SIZE,
+      order: [[pkAttr, 'ASC']],
+      raw: true,
+    });
+    if (page.length === 0) break;
+    for (const r of page) orphanCandidates.delete(r[pkAttr]);
+    lastSrcPk = page[page.length - 1][pkAttr];
+    if (lastSrcPk == null) break;
+    if (page.length < BACKFILL_BATCH_SIZE) break;
+  }
+
+  if (orphanCandidates.size === 0) return 0;
+
+  const orphans = [...orphanCandidates];
+  let removed = 0;
+  for (let i = 0; i < orphans.length; i += BACKFILL_BATCH_SIZE) {
+    const batch = orphans.slice(i, i + BACKFILL_BATCH_SIZE);
+    removed += await mirror.destroy({ where: { [pkAttr]: batch } });
   }
 
   logger.info(`Mirror backfill: ${name} - removed ${removed} orphan rows`);
@@ -644,10 +692,17 @@ export const prepareDb = async () => {
 
   await checkForMigrations(sequelize);
 
-  // Run the mirror backfill after main migrations so all source and mirror
-  // tables exist. This catches up rows that were inserted/updated/deleted
-  // while the mirror was unavailable on a previous run.
-  if (mirrorSetupSucceeded) {
+  // Run the mirror backfill after main migrations so all source and
+  // mirror tables exist. This catches up rows that were inserted/
+  // updated/deleted while the mirror was unavailable on a previous run.
+  //
+  // Gate on isMysqlMirrorConfiguredForReconnect() (MySQL mode only) so
+  // SQLite-fallback test startups don't iterate all 11 source/mirror
+  // table pairs on every run. Tests that need the backfill code path
+  // exercised call backfillMirror() directly with
+  // __setMirrorSetupSucceededForTests and __setMirrorEnabledForTests
+  // to opt in.
+  if (mirrorSetupSucceeded && isMysqlMirrorConfiguredForReconnect()) {
     await backfillMirror();
   }
 };

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -581,8 +581,17 @@ const sweepMirrorOrphansV2 = async (source, mirror, name) => {
  * Ensure the MySQL mirror database exists and has up-to-date migrations.
  * Idempotent: safe to call from startup and again on every reconnect.
  *
- * Returns true on success, false on failure. Never throws so it won't take
- * down the main database path.
+ * Returns true on success, false on transient I/O failure (e.g. MySQL not
+ * reachable, CREATE DATABASE fails, migrations fail). I/O failures are
+ * caught and logged so they don't take down the main database path.
+ *
+ * THROWS (intentionally) when V1 and V2 are misconfigured to share the
+ * same MIRROR_DB.DB_NAME - see validateMirrorDbNames. That is a
+ * programmer/ops error, not a retryable failure, and surfacing it loudly
+ * at CADT startup prevents silent data corruption where V1 and V2 would
+ * clobber each other's rows in the mirror. Callers on both the startup
+ * path (prepareV2Db) and the reconnect path (startV2ReconnectBackfill)
+ * are already wrapped in try/catch at the appropriate level.
  */
 export const prepareMysqlMirrorV2 = async () => {
   if (v2MirrorSetupPromise) {

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -599,40 +599,74 @@ const sweepMirrorOrphansV2 = async (source, mirror, name) => {
   }
   const pkAttr = pkAttrs[0];
 
+  // Concurrency invariant: mirror is scanned BEFORE source. A row
+  // inserted concurrently (after the mirror page fetch, before or
+  // during the source page fetch) will be absent from orphanCandidates
+  // and thus cannot be misclassified as an orphan. A row inserted
+  // before the mirror scan and deleted from source during the scan is
+  // a true orphan and will be correctly removed. Reversing the order
+  // would allow false-positive orphan deletes for rows inserted into
+  // both tables during the sweep.
+  //
+  // Both scans are keyset-paginated. An earlier revision loaded every
+  // PK from both tables in a single unbounded findAll; this is fine
+  // for today's row counts but spikes memory on long-running
+  // deployments with large tables. Peak memory here is O(|mirror|) for
+  // the candidate set; the source side is streamed.
+  //
   // `raw: true` is safe here - the projection is PK-only, so there are
   // no DATE or custom-getter columns whose raw SQLite representation
-  // could leak into a bulk write (which is the hazard backfillMirrorV2
-  // avoids). If a future change adds more projected attributes, revisit
-  // the raw:true pattern (see backfillMirrorV2 for the safe variant).
-  const mirrorPkRows = await mirror.findAll({
-    attributes: [pkAttr],
-    raw: true,
-  });
-  if (mirrorPkRows.length === 0) {
-    return 0;
-  }
-
-  const sourcePkRows = await source.findAll({
-    attributes: [pkAttr],
-    raw: true,
-  });
-  const sourcePks = new Set(sourcePkRows.map((r) => r[pkAttr]));
-
-  const orphanPks = mirrorPkRows
-    .map((r) => r[pkAttr])
-    .filter((pk) => !sourcePks.has(pk));
-
-  if (orphanPks.length === 0) {
-    return 0;
-  }
-
-  // Batch deletes to avoid unbounded IN (...) lists
-  let removed = 0;
-  for (let i = 0; i < orphanPks.length; i += BACKFILL_BATCH_SIZE) {
-    const batch = orphanPks.slice(i, i + BACKFILL_BATCH_SIZE);
-    removed += await mirror.destroy({
-      where: { [pkAttr]: batch },
+  // could leak into a bulk write (the hazard backfillMirrorV2 avoids).
+  const orphanCandidates = new Set();
+  let lastMirrorPk = null;
+  while (true) {
+    const where =
+      lastMirrorPk === null
+        ? undefined
+        : { [pkAttr]: { [Sequelize.Op.gt]: lastMirrorPk } };
+    const page = await mirror.findAll({
+      attributes: [pkAttr],
+      where,
+      limit: BACKFILL_BATCH_SIZE,
+      order: [[pkAttr, 'ASC']],
+      raw: true,
     });
+    if (page.length === 0) break;
+    for (const r of page) orphanCandidates.add(r[pkAttr]);
+    lastMirrorPk = page[page.length - 1][pkAttr];
+    if (lastMirrorPk == null) break;
+    if (page.length < BACKFILL_BATCH_SIZE) break;
+  }
+
+  if (orphanCandidates.size === 0) return 0;
+
+  let lastSrcPk = null;
+  while (true) {
+    const where =
+      lastSrcPk === null
+        ? undefined
+        : { [pkAttr]: { [Sequelize.Op.gt]: lastSrcPk } };
+    const page = await source.findAll({
+      attributes: [pkAttr],
+      where,
+      limit: BACKFILL_BATCH_SIZE,
+      order: [[pkAttr, 'ASC']],
+      raw: true,
+    });
+    if (page.length === 0) break;
+    for (const r of page) orphanCandidates.delete(r[pkAttr]);
+    lastSrcPk = page[page.length - 1][pkAttr];
+    if (lastSrcPk == null) break;
+    if (page.length < BACKFILL_BATCH_SIZE) break;
+  }
+
+  if (orphanCandidates.size === 0) return 0;
+
+  const orphans = [...orphanCandidates];
+  let removed = 0;
+  for (let i = 0; i < orphans.length; i += BACKFILL_BATCH_SIZE) {
+    const batch = orphans.slice(i, i + BACKFILL_BATCH_SIZE);
+    removed += await mirror.destroy({ where: { [pkAttr]: batch } });
   }
 
   loggerV2.info(

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -496,13 +496,31 @@ export const backfillMirrorV2 = async () => {
           while (true) {
             const where =
               lastPk === null ? undefined : { [pk]: { [Sequelize.Op.gt]: lastPk } };
-            const rows = await source.findAll({
-              raw: true,
+            // NOTE: Do NOT pass `raw: true` to findAll. With raw:true
+            // Sequelize returns SQLite values as-stored (strings),
+            // including DATE columns as "YYYY-MM-DD HH:mm:ss.SSS +00:00".
+            // Forwarding those strings verbatim to MariaDB's bulkCreate
+            // triggers strict-mode "Incorrect datetime value" rejections.
+            // Building model instances runs sqlite.DATE.parse so DATE
+            // columns become real Date objects; mysql.DATE then serialises
+            // them in the MariaDB-safe "YYYY-MM-DD HH:mm:ss" format.
+            //
+            // `.get({ plain: true, raw: true })` extracts dataValues
+            // directly (bypassing any attribute-level `get()` accessors -
+            // e.g. ProjectV2.projectSector returns a parsed Array via its
+            // getter, but the mirror column stores the raw JSON string).
+            // Dates are still Date objects on dataValues because the
+            // sqlite parser runs during instance construction, not at
+            // get() time.
+            const instances = await source.findAll({
               where,
               limit: BACKFILL_BATCH_SIZE,
               order: [[pk, 'ASC']],
             });
-            if (rows.length === 0) break;
+            if (instances.length === 0) break;
+            const rows = instances.map((r) =>
+              r.get({ plain: true, raw: true }),
+            );
             await mirror.bulkCreate(rows, { updateOnDuplicate: updateFields });
             synced += rows.length;
             lastPk = rows[rows.length - 1][pk];
@@ -581,6 +599,11 @@ const sweepMirrorOrphansV2 = async (source, mirror, name) => {
   }
   const pkAttr = pkAttrs[0];
 
+  // `raw: true` is safe here - the projection is PK-only, so there are
+  // no DATE or custom-getter columns whose raw SQLite representation
+  // could leak into a bulk write (which is the hazard backfillMirrorV2
+  // avoids). If a future change adds more projected attributes, revisit
+  // the raw:true pattern (see backfillMirrorV2 for the safe variant).
   const mirrorPkRows = await mirror.findAll({
     attributes: [pkAttr],
     raw: true,

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -55,12 +55,77 @@ const mirrorConfig = mysqlMirrorConfigured ? 'v2Mirror' : 'v2MirrorTest';
 
 loggerV2.info(`[v2]: Mirror DB config selected: ${mirrorConfig} (MySQL configured: ${!!mysqlMirrorConfigured})`);
 
+// Returns true if V2.MIRROR_DB is fully configured with MySQL credentials.
+// Used to gate reconnect-setup retries - only MySQL configs need the setup
+// retry path; SQLite test fallbacks never need it. Reads config on every
+// call so the check stays correct across config reloads (symmetric with
+// V1's isMysqlMirrorConfiguredForReconnect).
+const isMysqlMirrorConfiguredForReconnectV2 = () => {
+  const c = getConfigV2()?.MIRROR_DB;
+  return !!(
+    c?.DB_HOST &&
+    c.DB_HOST !== '' &&
+    c.DB_NAME &&
+    c.DB_USERNAME &&
+    c.DB_PASSWORD
+  );
+};
+
 export const sequelizeV2Mirror = new Sequelize(config[mirrorConfig]);
 
+// Test-only override. Tests set this to force mirror-enabled behaviour
+// against the SQLite fallback sequelizeV2Mirror so backfill / reconnect
+// code paths can be exercised without a live MySQL instance. null means
+// "use the real config value".
+let mirrorEnabledTestOverrideV2 = null;
+
+// Track the last observed auth outcome so we can detect a transition from
+// "disconnected" back to "connected" and trigger a catch-up backfill. This
+// recovers writes (INSERT/UPDATE) and deletes that were dropped during an
+// outage because safeMirrorDbHandlerV2 is fire-and-forget and silently drops
+// its callback when authenticate() fails.
+let v2MirrorAuthState = 'unknown'; // 'unknown' | 'connected' | 'disconnected'
+
+// Tracks whether the MySQL-side setup (CREATE DATABASE + migrations)
+// succeeded. If it failed at startup (e.g. MySQL not yet reachable), we
+// treat the first successful runtime authenticate as a reconnect so the
+// setup is retried and the initial backfill runs.
+let v2MirrorSetupSucceeded = false;
+
+// Concurrency guard for prepareMysqlMirrorV2 - only one attempt at a time.
+let v2MirrorSetupPromise = null;
+
+// Single in-flight reconnect backfill. Concurrent callers share the same
+// promise so we don't run multiple backfills in parallel, and all writes
+// issued after the reconnect are serialized behind it so the mirror is in a
+// caught-up state before new operations are applied.
+let v2ReconnectBackfillPromise = null;
+
 export const mirrorDBEnabledV2 = () => {
-  // Mirror DB is only enabled if MySQL is actually configured
-  // In test mode without MySQL, mirror operations should be no-ops
-  return mysqlMirrorConfigured;
+  // Mirror DB is only enabled if MySQL is actually configured.
+  // In test mode without MySQL, mirror operations should be no-ops.
+  if (mirrorEnabledTestOverrideV2 !== null) {
+    return mirrorEnabledTestOverrideV2;
+  }
+  // Read config dynamically so any runtime reload is reflected here
+  // (symmetric with V1's mirrorDBEnabled and with the setupNeverRan gate
+  // in safeMirrorDbHandlerV2 below).
+  return isMysqlMirrorConfiguredForReconnectV2();
+};
+
+// Test-only. DO NOT call from production code. Passing `null` restores the
+// real config-driven behaviour. See mirrorEnabledTestOverrideV2 above.
+export const __setMirrorEnabledForTestsV2 = (value) => {
+  mirrorEnabledTestOverrideV2 = value;
+};
+
+// Test-only. DO NOT call from production code. Signals to the reconnect
+// path whether the one-time MySQL setup (CREATE DATABASE + migrations) has
+// succeeded. In production this is set to true by prepareMysqlMirrorV2.
+// Tests use this to bypass MySQL setup (they run against SQLite fallback)
+// while still exercising the reconnect-backfill behaviour.
+export const __setMirrorSetupSucceededForTestsV2 = (value) => {
+  v2MirrorSetupSucceeded = value;
 };
 
 /**
@@ -84,6 +149,60 @@ export const validateMirrorDbNames = (v1Config, v2Config) => {
   }
 };
 
+const startV2ReconnectBackfill = () => {
+  if (v2ReconnectBackfillPromise) {
+    return v2ReconnectBackfillPromise;
+  }
+  v2ReconnectBackfillPromise = (async () => {
+    try {
+      loggerV2.info(
+        '[v2]: Mirror DB reconnected, running catch-up recovery...',
+      );
+
+      // If the initial setup (CREATE DATABASE + migrations) never succeeded
+      // (e.g. MySQL was down at CADT startup), retry it before backfill.
+      // prepareMysqlMirrorV2 is idempotent. Only applies to real MySQL
+      // configurations - the SQLite test fallback never needs setup retries
+      // and would otherwise log a spurious "still failing" error on every
+      // call when tests force the mirror enabled via the test override.
+      if (
+        !v2MirrorSetupSucceeded &&
+        isMysqlMirrorConfiguredForReconnectV2()
+      ) {
+        const ok = await prepareMysqlMirrorV2();
+        if (!ok) {
+          loggerV2.error(
+            '[v2]: Reconnect recovery: mirror setup still failing, backfill skipped',
+          );
+          // Keep auth state as 'disconnected' so the next successful
+          // authenticate re-enters this path and retries setup+backfill,
+          // instead of silently treating the mirror as caught up.
+          v2MirrorAuthState = 'disconnected';
+          return;
+        }
+      }
+
+      if (!v2MirrorSetupSucceeded) {
+        // SQLite test fallback path never marked setup complete and has no
+        // MySQL to retry against. Skip the backfill quietly - symmetric
+        // with V1's startReconnectBackfill.
+        return;
+      }
+
+      await backfillMirrorV2();
+    } catch (error) {
+      loggerV2.error(`[v2]: Reconnect backfill failed: ${error.message}`);
+      // Mark disconnected so the next authenticate success retries the
+      // catch-up. Without this reset, a transient backfill failure would
+      // leave the mirror permanently behind until the NEXT real outage.
+      v2MirrorAuthState = 'disconnected';
+    } finally {
+      v2ReconnectBackfillPromise = null;
+    }
+  })();
+  return v2ReconnectBackfillPromise;
+};
+
 export const safeMirrorDbHandlerV2 = (callback) => {
   if (!mirrorDBEnabledV2()) {
     return Promise.resolve();
@@ -94,6 +213,27 @@ export const safeMirrorDbHandlerV2 = (callback) => {
       sequelizeV2Mirror
         .authenticate()
         .then(async () => {
+          const wasDisconnected = v2MirrorAuthState === 'disconnected';
+          // If MySQL setup never succeeded at startup (e.g. MySQL was down
+          // when prepareV2Db ran), the first successful authenticate needs
+          // to re-run setup + backfill even though we were never in an
+          // explicit 'disconnected' state. Only applies when MySQL is
+          // actually configured - the SQLite test fallback doesn't need
+          // the reconnect path and would otherwise spam recovery logs on
+          // every model write during tests. Uses a live config check so
+          // any runtime config reload stays consistent (symmetric with V1).
+          const setupNeverRan =
+            !v2MirrorSetupSucceeded && isMysqlMirrorConfiguredForReconnectV2();
+          v2MirrorAuthState = 'connected';
+
+          if (wasDisconnected || setupNeverRan) {
+            await startV2ReconnectBackfill();
+          } else if (v2ReconnectBackfillPromise) {
+            // Another concurrent caller already triggered the backfill;
+            // wait for it to finish so our write lands on a caught-up mirror.
+            await v2ReconnectBackfillPromise;
+          }
+
           try {
             await callback();
           } catch (e) {
@@ -101,6 +241,7 @@ export const safeMirrorDbHandlerV2 = (callback) => {
           }
         })
         .catch(() => {
+          v2MirrorAuthState = 'disconnected';
           loggerV2.info('V2 Mirror DB not connected');
         });
     } catch (error) {
@@ -112,6 +253,30 @@ export const safeMirrorDbHandlerV2 = (callback) => {
       resolve();
     }
   });
+};
+
+// Initialize a V2 mirror Sequelize Model synchronously at module-load time.
+//
+// Model.init() only registers schema metadata on the Sequelize instance; it
+// does not require a live database connection. Gating init on a successful
+// authenticate() (as safeMirrorDbHandlerV2 does for runtime operations) causes
+// a silent, permanent failure when the MySQL sidecar is not yet reachable at
+// CADT startup: the .then() callback never runs, the model is never
+// initialized, and every subsequent mirror write throws
+// "Cannot read properties of undefined (reading 'constructor')" from within
+// Sequelize (this.sequelize is undefined on an uninitialized Model).
+//
+// Runtime writes continue to be gated through safeMirrorDbHandlerV2, which
+// authenticates on each call and short-circuits cleanly when MySQL is down
+// and transparently resumes when the connection pool recovers.
+export const initMirrorModelV2 = (initFn) => {
+  try {
+    initFn();
+  } catch (error) {
+    loggerV2.error(
+      `[v2]: Failed to initialize mirror model: ${error.message}`,
+    );
+  }
 };
 
 export const seedV2Db = async (db) => {
@@ -218,9 +383,21 @@ export const checkForV2Migrations = async (db) => {
 
 /**
  * Backfill MySQL mirror database from SQLite source data.
- * Runs on every startup when mirror is configured. Uses bulkCreate with
- * updateOnDuplicate for idempotent upsert behavior - rows that already exist
- * in MySQL get updated, missing rows get inserted.
+ *
+ * Runs on startup and on every reconnect after a connection outage. For each
+ * source/mirror pair this performs two passes:
+ *   1. Upsert pass: bulkCreate(updateOnDuplicate) inserts missing rows and
+ *      updates stale rows. This recovers inserts and updates that happened
+ *      while the mirror was unreachable.
+ *   2. Orphan sweep: rows present in mirror but no longer in source are
+ *      deleted. This recovers deletes that happened while the mirror was
+ *      unreachable (deletes are otherwise lost because the fire-and-forget
+ *      safeMirrorDbHandlerV2 silently drops operations during an outage).
+ *
+ * Ordering matters for the orphan sweep: mirror PKs are snapshotted BEFORE
+ * source PKs. This prevents false-positive deletes when a row is inserted
+ * concurrently (it would appear in source snapshot but not in mirror
+ * snapshot - we'd classify it as not-orphan either way, which is correct).
  *
  * Uses dynamic imports to avoid circular dependency (models import from this file).
  */
@@ -266,6 +443,7 @@ export const backfillMirrorV2 = async () => {
     ];
 
     let totalSynced = 0;
+    let totalOrphansRemoved = 0;
 
     for (const { source, mirror, name } of mirrorPairs) {
       try {
@@ -274,6 +452,13 @@ export const backfillMirrorV2 = async () => {
           loggerV2.warn(`[v2]: Mirror backfill: ${name} - mirror model not initialized, skipping`);
           continue;
         }
+
+        // Orphan sweep pass - snapshot mirror PKs BEFORE source PKs so that
+        // rows inserted concurrently (after mirror snapshot) are not wrongly
+        // treated as orphans. See function-level comment for the full
+        // concurrency argument.
+        const orphansRemoved = await sweepMirrorOrphansV2(source, mirror, name);
+        totalOrphansRemoved += orphansRemoved;
 
         const count = await source.count();
         if (count === 0) {
@@ -288,12 +473,24 @@ export const backfillMirrorV2 = async () => {
           (attr) => !mirror.primaryKeyAttributes.includes(attr),
         );
 
+        // SQLite (and MySQL) do not guarantee consistent row order across
+        // paginated queries without an explicit ORDER BY. Without it,
+        // concurrent writes during backfill can shift rows between pages
+        // and cause some to be skipped entirely - defeating the purpose
+        // of the recovery backfill. Order by the primary key when it's a
+        // single column (all V2 mirrors today); fall back to unordered
+        // for the composite-PK case (none exist in V2 today).
+        const pkAttrs = mirror.primaryKeyAttributes || [];
+        const order =
+          pkAttrs.length === 1 ? [[pkAttrs[0], 'ASC']] : undefined;
+
         let synced = 0;
         for (let offset = 0; offset < count; offset += BACKFILL_BATCH_SIZE) {
           const rows = await source.findAll({
             raw: true,
             offset,
             limit: BACKFILL_BATCH_SIZE,
+            order,
           });
 
           await mirror.bulkCreate(rows, {
@@ -311,11 +508,143 @@ export const backfillMirrorV2 = async () => {
       }
     }
 
-    loggerV2.info(`[v2]: MySQL mirror backfill completed - ${totalSynced} total records synced`);
+    loggerV2.info(
+      `[v2]: MySQL mirror backfill completed - ${totalSynced} records upserted, ${totalOrphansRemoved} orphan rows removed`,
+    );
   } catch (error) {
     loggerV2.error('[v2]: MySQL mirror backfill failed:', error.message);
     // Don't throw - allow main database to continue operating
   }
+};
+
+/**
+ * Remove rows from a V2 mirror table whose primary key no longer exists in
+ * the source table. Returns the number of rows removed.
+ *
+ * Safe against concurrent writes because we snapshot mirror PKs before
+ * source PKs: a row inserted concurrently into source appears in the source
+ * snapshot but not the mirror snapshot, so it's never classified as an
+ * orphan. A row deleted concurrently from source shows up only in the
+ * mirror snapshot and IS classified as orphan - correct behavior.
+ *
+ * Skips tables with composite primary keys (none exist in V2 today; fall
+ * back to log-and-continue if one is introduced later).
+ */
+const sweepMirrorOrphansV2 = async (source, mirror, name) => {
+  const pkAttrs = mirror.primaryKeyAttributes;
+  if (!pkAttrs || pkAttrs.length !== 1) {
+    loggerV2.debug(
+      `[v2]: Mirror backfill: ${name} - skipping orphan sweep (composite or missing primary key)`,
+    );
+    return 0;
+  }
+  const pkAttr = pkAttrs[0];
+
+  const mirrorPkRows = await mirror.findAll({
+    attributes: [pkAttr],
+    raw: true,
+  });
+  if (mirrorPkRows.length === 0) {
+    return 0;
+  }
+
+  const sourcePkRows = await source.findAll({
+    attributes: [pkAttr],
+    raw: true,
+  });
+  const sourcePks = new Set(sourcePkRows.map((r) => r[pkAttr]));
+
+  const orphanPks = mirrorPkRows
+    .map((r) => r[pkAttr])
+    .filter((pk) => !sourcePks.has(pk));
+
+  if (orphanPks.length === 0) {
+    return 0;
+  }
+
+  // Batch deletes to avoid unbounded IN (...) lists
+  let removed = 0;
+  for (let i = 0; i < orphanPks.length; i += BACKFILL_BATCH_SIZE) {
+    const batch = orphanPks.slice(i, i + BACKFILL_BATCH_SIZE);
+    removed += await mirror.destroy({
+      where: { [pkAttr]: batch },
+    });
+  }
+
+  loggerV2.info(
+    `[v2]: Mirror backfill: ${name} - removed ${removed} orphan rows`,
+  );
+  return removed;
+};
+
+/**
+ * Ensure the MySQL mirror database exists and has up-to-date migrations.
+ * Idempotent: safe to call from startup and again on every reconnect.
+ *
+ * Returns true on success, false on failure. Never throws so it won't take
+ * down the main database path.
+ */
+export const prepareMysqlMirrorV2 = async () => {
+  if (v2MirrorSetupPromise) {
+    return v2MirrorSetupPromise;
+  }
+
+  v2MirrorSetupPromise = (async () => {
+    const mirrorDbConfig = getConfigV2()?.MIRROR_DB;
+    const isMysqlMirrorConfigured =
+      mirrorDbConfig?.DB_HOST &&
+      mirrorDbConfig?.DB_HOST !== '' &&
+      mirrorDbConfig?.DB_NAME &&
+      mirrorDbConfig?.DB_USERNAME &&
+      mirrorDbConfig?.DB_PASSWORD;
+
+    if (!isMysqlMirrorConfigured) {
+      return false;
+    }
+
+    // validateMirrorDbNames throws when V1 and V2 are misconfigured to use
+    // the same MIRROR_DB.DB_NAME. That is a programmer/ops error, not a
+    // transient I/O failure, and must fail loudly rather than being lumped
+    // in with "MySQL unreachable" retryable failures below.
+    validateMirrorDbNames(getConfig(), getConfigV2());
+
+    try {
+      const connection = await mysql.createConnection({
+        host: mirrorDbConfig.DB_HOST,
+        port: 3306,
+        user: mirrorDbConfig.DB_USERNAME,
+        password: mirrorDbConfig.DB_PASSWORD,
+      });
+
+      try {
+        const dbName = mirrorDbConfig.DB_NAME;
+        await connection.query(
+          `CREATE DATABASE IF NOT EXISTS \`${dbName}\`;`,
+        );
+        loggerV2.info(
+          `[v2]: MySQL mirror database '${dbName}' created/verified`,
+        );
+      } finally {
+        await connection.end();
+      }
+
+      // checkForV2Migrations is idempotent (it checks SequelizeMeta), so
+      // it's safe to re-run on every reconnect.
+      await checkForV2Migrations(sequelizeV2Mirror);
+      loggerV2.info('[v2]: MySQL mirror database migrations completed');
+      v2MirrorSetupSucceeded = true;
+      return true;
+    } catch (error) {
+      loggerV2.error(
+        `[v2]: Error setting up MySQL mirror database: ${error.message}`,
+      );
+      return false;
+    }
+  })().finally(() => {
+    v2MirrorSetupPromise = null;
+  });
+
+  return v2MirrorSetupPromise;
 };
 
 // Mutex to prevent concurrent prepareV2Db calls
@@ -366,30 +695,15 @@ export const prepareV2Db = async () => {
       mirrorDbConfig?.DB_PASSWORD;
 
     if (isMysqlMirrorConfigured) {
-      // Validate that V1 and V2 mirror database names are different
-      validateMirrorDbNames(getConfig(), getConfigV2());
-
-      loggerV2.info('[v2]: MySQL mirror database configured, creating database and running migrations...');
-      try {
-        const connection = await mysql.createConnection({
-          host: mirrorDbConfig.DB_HOST,
-          port: 3306,
-          user: mirrorDbConfig.DB_USERNAME,
-          password: mirrorDbConfig.DB_PASSWORD,
-        });
-
-        const dbName = mirrorDbConfig.DB_NAME;
-        await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbName}\`;`);
-        loggerV2.info(`[v2]: MySQL mirror database '${dbName}' created/verified`);
-        await connection.end();
-
-        // Run migrations on the MySQL mirror database
-        await checkForV2Migrations(sequelizeV2Mirror);
-        loggerV2.info('[v2]: MySQL mirror database migrations completed');
-      } catch (error) {
-        loggerV2.error('[v2]: Error setting up MySQL mirror database:', error.message);
-        // Don't throw - allow main database to continue
-      }
+      loggerV2.info(
+        '[v2]: MySQL mirror database configured, creating database and running migrations...',
+      );
+      // If this fails (e.g. MySQL sidecar not yet reachable), it returns
+      // false and leaves v2MirrorSetupSucceeded=false. safeMirrorDbHandlerV2
+      // will retry setup the first time authenticate succeeds at runtime,
+      // then run the catch-up backfill, so the mirror eventually converges
+      // without requiring a CADT restart.
+      await prepareMysqlMirrorV2();
     } else {
       // No MySQL mirror configured - mirror operations will be no-ops
       loggerV2.info('[v2]: No MySQL mirror configured, mirror operations disabled');
@@ -401,7 +715,7 @@ export const prepareV2Db = async () => {
 
     // Backfill mirror database from SQLite source data (idempotent upsert).
     // Runs after both mirror and main migrations are complete so all tables exist.
-    if (isMysqlMirrorConfigured) {
+    if (isMysqlMirrorConfigured && v2MirrorSetupSucceeded) {
       await backfillMirrorV2();
     }
 

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -55,12 +55,20 @@ const mirrorConfig = mysqlMirrorConfigured ? 'v2Mirror' : 'v2MirrorTest';
 
 loggerV2.info(`[v2]: Mirror DB config selected: ${mirrorConfig} (MySQL configured: ${!!mysqlMirrorConfigured})`);
 
+// Test-only override for isMysqlMirrorConfiguredForReconnectV2(). Tests set
+// this to simulate "MySQL is configured" (or not) independently of the actual
+// config.yaml. null means "use the real config value".
+let mysqlConfiguredForReconnectOverrideV2 = null;
+
 // Returns true if V2.MIRROR_DB is fully configured with MySQL credentials.
 // Used to gate reconnect-setup retries - only MySQL configs need the setup
 // retry path; SQLite test fallbacks never need it. Reads config on every
 // call so the check stays correct across config reloads (symmetric with
 // V1's isMysqlMirrorConfiguredForReconnect).
 const isMysqlMirrorConfiguredForReconnectV2 = () => {
+  if (mysqlConfiguredForReconnectOverrideV2 !== null) {
+    return mysqlConfiguredForReconnectOverrideV2;
+  }
   const c = getConfigV2()?.MIRROR_DB;
   return !!(
     c?.DB_HOST &&
@@ -72,6 +80,21 @@ const isMysqlMirrorConfiguredForReconnectV2 = () => {
 };
 
 export const sequelizeV2Mirror = new Sequelize(config[mirrorConfig]);
+
+// Snapshot of "is the mirror Sequelize instance actually pointing at MySQL"
+// taken at module-load time, alongside sequelizeV2Mirror construction.
+//
+// mirrorDBEnabledV2() must stay consistent with the backend that
+// sequelizeV2Mirror writes to. sequelizeV2Mirror is built ONCE above from
+// either the MySQL config (v2Mirror) or the SQLite fallback (v2MirrorTest)
+// and is never rebuilt - runtime config changes cannot move an already-open
+// Sequelize instance to a different target. If we re-read the live config
+// on every mirrorDBEnabledV2() call (the previous behaviour), a runtime
+// config change could flip enablement true while writes still go to the
+// originally-selected SQLite fallback, silently desyncing the mirror.
+// See PR #1585 bugbot finding "Mirror enable check desynchronizes mirror
+// target".
+const v2MirrorTargetsMysql = !!mysqlMirrorConfigured;
 
 // Test-only override. Tests set this to force mirror-enabled behaviour
 // against the SQLite fallback sequelizeV2Mirror so backfill / reconnect
@@ -107,10 +130,15 @@ export const mirrorDBEnabledV2 = () => {
   if (mirrorEnabledTestOverrideV2 !== null) {
     return mirrorEnabledTestOverrideV2;
   }
-  // Read config dynamically so any runtime reload is reflected here
-  // (symmetric with V1's mirrorDBEnabled and with the setupNeverRan gate
-  // in safeMirrorDbHandlerV2 below).
-  return isMysqlMirrorConfiguredForReconnectV2();
+  // Use the module-load snapshot so this check stays consistent with the
+  // backend that sequelizeV2Mirror was actually constructed against.
+  // Reading the live config here would allow the check to drift away from
+  // the Sequelize instance after a runtime config change, causing writes
+  // intended for MySQL to silently land in the SQLite fallback (or vice
+  // versa). The setupNeverRan gate in safeMirrorDbHandlerV2 below still
+  // reads live config for its own purpose (deciding whether to retry the
+  // reconnect setup path).
+  return v2MirrorTargetsMysql;
 };
 
 // Test-only. DO NOT call from production code. Passing `null` restores the
@@ -126,6 +154,23 @@ export const __setMirrorEnabledForTestsV2 = (value) => {
 // while still exercising the reconnect-backfill behaviour.
 export const __setMirrorSetupSucceededForTestsV2 = (value) => {
   v2MirrorSetupSucceeded = value;
+};
+
+// Test-only. DO NOT call from production code. Forces
+// isMysqlMirrorConfiguredForReconnectV2() to return a specific boolean so
+// tests can exercise the reconnect setup / skip-callback guards without a
+// live MySQL instance or a real MIRROR_DB config. null restores live behaviour.
+export const __setMysqlConfiguredForReconnectForTestsV2 = (value) => {
+  mysqlConfiguredForReconnectOverrideV2 = value;
+};
+
+// Test-only. DO NOT call from production code. Resets the internal
+// auth-state machine back to 'unknown' so tests that intentionally leave
+// the state in 'disconnected' can reset it in an afterEach hook and avoid
+// leaking reconnect behaviour into downstream specs running in the same
+// mocha session.
+export const __resetMirrorAuthStateForTestsV2 = () => {
+  v2MirrorAuthState = 'unknown';
 };
 
 /**
@@ -232,6 +277,19 @@ export const safeMirrorDbHandlerV2 = (callback) => {
             // Another concurrent caller already triggered the backfill;
             // wait for it to finish so our write lands on a caught-up mirror.
             await v2ReconnectBackfillPromise;
+          }
+
+          // If MySQL is configured but the one-time setup (CREATE DATABASE
+          // + migrations) has not yet completed, the mirror tables don't
+          // exist. Running the callback would produce a confusing
+          // "table doesn't exist" error that gets swallowed by the catch
+          // below. Skip quietly - the next authenticate success will
+          // re-enter startV2ReconnectBackfill and retry setup.
+          if (
+            isMysqlMirrorConfiguredForReconnectV2() &&
+            !v2MirrorSetupSucceeded
+          ) {
+            return;
           }
 
           try {

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -460,12 +460,6 @@ export const backfillMirrorV2 = async () => {
         const orphansRemoved = await sweepMirrorOrphansV2(source, mirror, name);
         totalOrphansRemoved += orphansRemoved;
 
-        const count = await source.count();
-        if (count === 0) {
-          loggerV2.debug(`[v2]: Mirror backfill: ${name} - no records to sync`);
-          continue;
-        }
-
         // Determine which fields to update on duplicate key conflict.
         // Include all non-primary-key attributes so the mirror stays in sync
         // with any changes that occurred in the source.
@@ -473,34 +467,78 @@ export const backfillMirrorV2 = async () => {
           (attr) => !mirror.primaryKeyAttributes.includes(attr),
         );
 
-        // SQLite (and MySQL) do not guarantee consistent row order across
-        // paginated queries without an explicit ORDER BY. Without it,
-        // concurrent writes during backfill can shift rows between pages
-        // and cause some to be skipped entirely - defeating the purpose
-        // of the recovery backfill. Order by the primary key when it's a
-        // single column (all V2 mirrors today); fall back to unordered
-        // for the composite-PK case (none exist in V2 today).
+        // Keyset pagination (WHERE pk > :lastSeenPk ORDER BY pk ASC LIMIT N)
+        // instead of offset-based. Offset pagination under concurrent
+        // writes can silently skip rows: a delete at position N shifts
+        // later rows down, so the next page's OFFSET lands one row later
+        // than intended. Keyset pagination avoids that page-shift-on-delete
+        // hazard by using a lower-bound predicate instead of a position
+        // count.
+        //
+        // Note: keyset pagination is NOT immune to concurrent INSERTs with
+        // a PK less than `lastPk` (plausible with UUID PKs, which most V2
+        // mirrors use). Such rows will be missed in the current pass but
+        // picked up by the next reconnect backfill. A subsequent
+        // steady-state safeMirrorDbHandler write also directly upserts
+        // them, so the miss window is bounded.
+        //
+        // Requires a single-column comparable PK. For the (currently none)
+        // composite-PK case, fall back to a single unordered query -
+        // safer than a wrong-order keyset walk. The single-PK invariant
+        // is asserted at load time by mirror-model-init.spec.js.
         const pkAttrs = mirror.primaryKeyAttributes || [];
-        const order =
-          pkAttrs.length === 1 ? [[pkAttrs[0], 'ASC']] : undefined;
 
         let synced = 0;
-        for (let offset = 0; offset < count; offset += BACKFILL_BATCH_SIZE) {
-          const rows = await source.findAll({
-            raw: true,
-            offset,
-            limit: BACKFILL_BATCH_SIZE,
-            order,
-          });
-
-          await mirror.bulkCreate(rows, {
-            updateOnDuplicate: updateFields,
-          });
-
-          synced += rows.length;
+        if (pkAttrs.length === 1) {
+          const pk = pkAttrs[0];
+          let lastPk = null;
+          // eslint-disable-next-line no-constant-condition
+          while (true) {
+            const where =
+              lastPk === null ? undefined : { [pk]: { [Sequelize.Op.gt]: lastPk } };
+            const rows = await source.findAll({
+              raw: true,
+              where,
+              limit: BACKFILL_BATCH_SIZE,
+              order: [[pk, 'ASC']],
+            });
+            if (rows.length === 0) break;
+            await mirror.bulkCreate(rows, { updateOnDuplicate: updateFields });
+            synced += rows.length;
+            lastPk = rows[rows.length - 1][pk];
+            // Defensive: a null/undefined terminal PK means we can't
+            // continue the keyset walk safely (Op.gt: undefined is
+            // ill-defined and would loop on the same page). Stop the
+            // walk; subsequent reconnects will retry from scratch.
+            if (lastPk == null) {
+              loggerV2.warn(
+                `[v2]: Mirror backfill: ${name} - terminal row had null PK; ` +
+                  `stopping keyset walk early (${synced} rows synced).`,
+              );
+              break;
+            }
+            if (rows.length < BACKFILL_BATCH_SIZE) break;
+          }
+        } else {
+          // Composite-PK mirrors are not supported by keyset-paginated
+          // backfill. mirror-model-init.spec.js asserts every current
+          // mirror has a single-column PK; if someone introduces a
+          // composite-PK mirror without extending this function, fail
+          // loudly (caught by the per-table try/catch) rather than
+          // silently loading the whole table into memory.
+          throw new Error(
+            `[v2]: Mirror backfill: ${name} has a composite primary key ` +
+              `(${pkAttrs.join(', ')}). Keyset pagination needs a ` +
+              `single-column comparable PK. Either reduce to a single-column ` +
+              `PK, or extend backfillMirrorV2 to handle composite keys.`,
+          );
         }
 
-        loggerV2.info(`[v2]: Mirror backfill: ${name} - synced ${synced} records`);
+        if (synced === 0) {
+          loggerV2.debug(`[v2]: Mirror backfill: ${name} - no records to sync`);
+        } else {
+          loggerV2.info(`[v2]: Mirror backfill: ${name} - synced ${synced} records`);
+        }
         totalSynced += synced;
       } catch (error) {
         loggerV2.error(`[v2]: Mirror backfill error for ${name}: ${error.message}`);
@@ -512,7 +550,10 @@ export const backfillMirrorV2 = async () => {
       `[v2]: MySQL mirror backfill completed - ${totalSynced} records upserted, ${totalOrphansRemoved} orphan rows removed`,
     );
   } catch (error) {
-    loggerV2.error('[v2]: MySQL mirror backfill failed:', error.message);
+    loggerV2.error(
+      `[v2]: MySQL mirror backfill failed: ${error?.message || error?.name || 'unknown error'}`,
+    );
+    loggerV2.debug(error?.stack || error);
     // Don't throw - allow main database to continue operating
   }
 };

--- a/src/models/audit/audit.model.mirror.js
+++ b/src/models/audit/audit.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './audit.modeltypes.js';
 
 class AuditMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   AuditMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'audit',

--- a/src/models/co-benefits/co-benefits.model.mirror.js
+++ b/src/models/co-benefits/co-benefits.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './co-benefits.modeltypes.js';
 
 class CoBenefitMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   CoBenefitMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'coBenefit',

--- a/src/models/estimations/estimations.model.mirror.js
+++ b/src/models/estimations/estimations.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './estimations.modeltypes.js';
 
 class EstimationMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   EstimationMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'estimation',

--- a/src/models/issuances/issuances.model.mirror.js
+++ b/src/models/issuances/issuances.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './issuances.modeltypes.js';
 
 class IssuanceMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   IssuanceMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'issuance',

--- a/src/models/labelUnits/labelUnits.model.mirror.js
+++ b/src/models/labelUnits/labelUnits.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './labelUnits.modeltypes.js';
 
 class LabelUnitMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   LabelUnitMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'label_unit',

--- a/src/models/labels/labels.model.mirror.js
+++ b/src/models/labels/labels.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './labels.modeltypes.js';
 
 class LabelMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   LabelMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'label',

--- a/src/models/locations/locations.model.mirror.js
+++ b/src/models/locations/locations.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './locations.modeltypes.js';
 
 class ProjectLocationMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   ProjectLocationMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'projectLocation',

--- a/src/models/projects/projects.model.mirror.js
+++ b/src/models/projects/projects.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './projects.modeltypes.js';
 
 class ProjectMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   ProjectMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'project',

--- a/src/models/ratings/ratings.model.mirror.js
+++ b/src/models/ratings/ratings.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './ratings.modeltypes.js';
 
 class RatingMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   RatingMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'projectRating',

--- a/src/models/related-projects/related-projects.model.mirror.js
+++ b/src/models/related-projects/related-projects.model.mirror.js
@@ -2,12 +2,12 @@
 
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './related-projects.modeltypes.js';
 
 class RelatedProjectMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   RelatedProjectMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'relatedProject',

--- a/src/models/units/units.model.mirror.js
+++ b/src/models/units/units.model.mirror.js
@@ -1,12 +1,12 @@
 'use strict';
 import { Model } from 'sequelize';
 
-import { sequelizeMirror, safeMirrorDbHandler } from '../../database';
+import { sequelizeMirror, initMirrorModel } from '../../database';
 import ModelTypes from './units.modeltypes.js';
 
 class UnitMirror extends Model {}
 
-safeMirrorDbHandler(() => {
+initMirrorModel(() => {
   UnitMirror.init(ModelTypes, {
     sequelize: sequelizeMirror,
     modelName: 'unit',

--- a/src/models/v2/aef-t1-submission-v2.model.mirror.js
+++ b/src/models/v2/aef-t1-submission-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class AefT1SubmissionV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   AefT1SubmissionV2Mirror.init(
     {
       cadTrustAefT1SubmissionId: {

--- a/src/models/v2/aef-t2-authorizations-v2.model.mirror.js
+++ b/src/models/v2/aef-t2-authorizations-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class AefT2AuthorizationsV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   AefT2AuthorizationsV2Mirror.init(
     {
       cadTrustAefT2AuthorizationsId: {

--- a/src/models/v2/aef-t3-actions-v2.model.mirror.js
+++ b/src/models/v2/aef-t3-actions-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class AefT3ActionsV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   AefT3ActionsV2Mirror.init(
   {
     cadTrustAefT3ActionsId: {

--- a/src/models/v2/aef-t4-holdings-v2.model.mirror.js
+++ b/src/models/v2/aef-t4-holdings-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class AefT4HoldingsV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   AefT4HoldingsV2Mirror.init(
   {
     cadTrustAefT4HoldingsId: {

--- a/src/models/v2/aef-t5-authorized-entities-v2.model.mirror.js
+++ b/src/models/v2/aef-t5-authorized-entities-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class AefT5AuthorizedEntitiesV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   AefT5AuthorizedEntitiesV2Mirror.init(
   {
     cadTrustAefT5AuthorizedEntitiesId: {

--- a/src/models/v2/audit-v2.model.mirror.js
+++ b/src/models/v2/audit-v2.model.mirror.js
@@ -1,12 +1,12 @@
 'use strict';
 
 import { Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 import ModelTypes from './audit-v2.modeltypes.js';
 
 class AuditV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   AuditV2Mirror.init(ModelTypes, {
     sequelize: sequelizeV2Mirror,
     modelName: 'AuditV2Mirror',

--- a/src/models/v2/co-benefit-v2.model.mirror.js
+++ b/src/models/v2/co-benefit-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class CoBenefitV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   CoBenefitV2Mirror.init(
     {
       cadTrustCoBenefitId: {

--- a/src/models/v2/estimation-v2.model.mirror.js
+++ b/src/models/v2/estimation-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class EstimationV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   EstimationV2Mirror.init(
     {
       cadTrustEstimationId: {

--- a/src/models/v2/issuance-v2.model.mirror.js
+++ b/src/models/v2/issuance-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class IssuanceV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   IssuanceV2Mirror.init(
     {
       cadTrustIssuanceId: {

--- a/src/models/v2/label-v2.model.mirror.js
+++ b/src/models/v2/label-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class LabelV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   LabelV2Mirror.init(
     {
       cadTrustLabelId: {

--- a/src/models/v2/location-v2.model.mirror.js
+++ b/src/models/v2/location-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class LocationV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   LocationV2Mirror.init(
     {
       cadTrustLocationId: {

--- a/src/models/v2/methodology-v2.model.mirror.js
+++ b/src/models/v2/methodology-v2.model.mirror.js
@@ -1,12 +1,12 @@
 'use strict';
 
 import { Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 import ModelTypes from './methodology-v2.modeltypes.js';
 
 class MethodologyV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   MethodologyV2Mirror.init(ModelTypes, {
     sequelize: sequelizeV2Mirror,
     modelName: 'MethodologyV2Mirror',

--- a/src/models/v2/organizations-v2.model.mirror.js
+++ b/src/models/v2/organizations-v2.model.mirror.js
@@ -1,12 +1,12 @@
 'use strict';
 
 import { Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 import ModelTypes from './organizations-v2.modeltypes.js';
 
 class OrganizationsV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   OrganizationsV2Mirror.init(ModelTypes, {
     sequelize: sequelizeV2Mirror,
     modelName: 'OrganizationsV2Mirror',

--- a/src/models/v2/program-v2.model.mirror.js
+++ b/src/models/v2/program-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class ProgramV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   ProgramV2Mirror.init(
     {
       cadTrustProgramId: {

--- a/src/models/v2/project-methodology-v2.model.mirror.js
+++ b/src/models/v2/project-methodology-v2.model.mirror.js
@@ -2,11 +2,11 @@
 
 import { Sequelize, Model } from 'sequelize';
 import { v4 as uuidv4 } from 'uuid';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class ProjectMethodologyV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   ProjectMethodologyV2Mirror.init(
     {
       cadTrustProjectMethodologyId: {

--- a/src/models/v2/project-v2.model.mirror.js
+++ b/src/models/v2/project-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class ProjectV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   ProjectV2Mirror.init(
     {
       cadTrustProjectId: {

--- a/src/models/v2/rating-v2.model.mirror.js
+++ b/src/models/v2/rating-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class RatingV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   RatingV2Mirror.init(
     {
       cadTrustRatingId: {

--- a/src/models/v2/stakeholder-projects-v2.model.mirror.js
+++ b/src/models/v2/stakeholder-projects-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class StakeholderProjectV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   StakeholderProjectV2Mirror.init(
     {
       cadTrustStakeholderProjectId: {

--- a/src/models/v2/stakeholder-v2.model.mirror.js
+++ b/src/models/v2/stakeholder-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class StakeholderV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   StakeholderV2Mirror.init(
     {
       cadTrustStakeholderId: {

--- a/src/models/v2/unit-label-v2.model.mirror.js
+++ b/src/models/v2/unit-label-v2.model.mirror.js
@@ -2,11 +2,11 @@
 
 import { Sequelize, Model } from 'sequelize';
 import { v4 as uuidv4 } from 'uuid';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class UnitLabelV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   UnitLabelV2Mirror.init(
     {
       cadTrustUnitLabelId: {

--- a/src/models/v2/unit-v2.model.mirror.js
+++ b/src/models/v2/unit-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class UnitV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   UnitV2Mirror.init(
     {
       cadTrustUnitId: {

--- a/src/models/v2/validation-v2.model.mirror.js
+++ b/src/models/v2/validation-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class ValidationV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   ValidationV2Mirror.init(
     {
       cadTrustValidationId: {

--- a/src/models/v2/verification-v2.model.mirror.js
+++ b/src/models/v2/verification-v2.model.mirror.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2Mirror, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2Mirror, initMirrorModelV2 } from '../../database/v2/index.js';
 
 class VerificationV2Mirror extends Model {}
 
-safeMirrorDbHandlerV2(() => {
+initMirrorModelV2(() => {
   VerificationV2Mirror.init(
     {
       cadTrustVerificationId: {

--- a/tests/integration/mirror-reconnect.spec.js
+++ b/tests/integration/mirror-reconnect.spec.js
@@ -1,0 +1,221 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { v4 as uuidv4 } from 'uuid';
+import { Sequelize } from 'sequelize';
+
+import {
+  prepareDb,
+  sequelize,
+  sequelizeMirror,
+  checkForMigrations,
+  backfillMirror,
+  safeMirrorDbHandler,
+  __setMirrorEnabledForTests,
+  __setMirrorSetupSucceededForTests,
+} from '../../src/database/index.js';
+import { ProjectMirror } from '../../src/models/projects/projects.model.mirror.js';
+
+/**
+ * Mirror Reconnect + Orphan Sweep Tests (V1)
+ *
+ * These tests exercise the outage-recovery additions to the V1 mirror:
+ *
+ *   1. backfillMirror (new for V1) runs at startup and on every reconnect
+ *      after an outage. It upserts missing/stale rows and sweeps orphan
+ *      rows (mirror rows whose primary key no longer exists in source).
+ *
+ *   2. safeMirrorDbHandler detects a reconnect and runs backfillMirror
+ *      before applying the current callback. Concurrent callers join the
+ *      same in-flight backfill promise.
+ *
+ * In test mode, mirrorDBEnabled() normally returns false (no MySQL) so
+ * backfill and the handler short-circuit. These tests use
+ * __setMirrorEnabledForTests(true) to drive the real code paths against
+ * the local SQLite fallback (sequelizeMirror / mirrorTest) without
+ * requiring a live MySQL instance.
+ */
+describe('Mirror Reconnect and Orphan Sweep (V1)', function () {
+  this.timeout(60000);
+
+  before(async function () {
+    await prepareDb();
+    await checkForMigrations(sequelizeMirror);
+  });
+
+  beforeEach(function () {
+    __setMirrorEnabledForTests(true);
+    // Pretend the one-time MySQL setup (CREATE DATABASE + migrations) has
+    // already succeeded so the reconnect path only performs the backfill.
+    __setMirrorSetupSucceededForTests(true);
+  });
+
+  afterEach(async function () {
+    __setMirrorEnabledForTests(null);
+    __setMirrorSetupSucceededForTests(false);
+    sinon.restore();
+
+    // Clean both databases between tests. We clear a minimal set of tables
+    // touched by these tests to keep the cleanup fast.
+    for (const t of ['projects']) {
+      try {
+        await sequelize.query(`DELETE FROM ${t}`);
+      } catch {
+        /* ignore */
+      }
+      try {
+        await sequelizeMirror.query(`DELETE FROM ${t}`);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  // Insert a project row into both source and mirror via raw SQL so the
+  // fire-and-forget mirror writer doesn't interfere with test setup.
+  const insertProjectIntoBoth = async ({ id, name, orgUid }) => {
+    const sql = `INSERT INTO projects
+        (warehouseProjectId, orgUid, currentRegistry, projectId, originProjectId,
+         registryOfOrigin, projectName, createdAt, updatedAt)
+      VALUES (:id, :orgUid, 'Test Registry', 'PRJ-001', 'PRJ-001',
+              'Test Registry', :name, datetime('now'), datetime('now'))`;
+    const opts = {
+      replacements: { id, name, orgUid },
+      type: Sequelize.QueryTypes.INSERT,
+    };
+    await sequelize.query(sql, opts);
+    await sequelizeMirror.query(sql, opts);
+  };
+
+  const deleteSourceProjectOnly = async (id) => {
+    await sequelize.query(
+      `DELETE FROM projects WHERE warehouseProjectId = :id`,
+      { replacements: { id }, type: Sequelize.QueryTypes.DELETE },
+    );
+  };
+
+  describe('Orphan sweep', function () {
+    it('should delete mirror rows whose primary key is no longer in source', async function () {
+      const keepId = uuidv4();
+      const deleteId = uuidv4();
+      const orgUid = uuidv4();
+
+      await insertProjectIntoBoth({ id: keepId, name: 'Keep', orgUid });
+      await insertProjectIntoBoth({
+        id: deleteId,
+        name: 'To Delete',
+        orgUid,
+      });
+
+      // Simulate an outage: the row is deleted from source, but the
+      // fire-and-forget mirror write was dropped, so mirror still has it.
+      await deleteSourceProjectOnly(deleteId);
+
+      const beforeMirrorCount = await ProjectMirror.count();
+      expect(
+        beforeMirrorCount,
+        'mirror should still have both rows before backfill',
+      ).to.equal(2);
+
+      await backfillMirror();
+
+      const keep = await ProjectMirror.findOne({
+        where: { warehouseProjectId: keepId },
+      });
+      const removed = await ProjectMirror.findOne({
+        where: { warehouseProjectId: deleteId },
+      });
+
+      expect(keep, 'row still in source should remain in mirror').to.not.be
+        .null;
+      expect(removed, 'row deleted from source should be removed from mirror')
+        .to.be.null;
+    });
+
+    it('should also insert missing rows (upsert pass still runs)', async function () {
+      const id = uuidv4();
+      const orgUid = uuidv4();
+      await sequelize.query(
+        `INSERT INTO projects
+          (warehouseProjectId, orgUid, currentRegistry, projectId, originProjectId,
+           registryOfOrigin, projectName, createdAt, updatedAt)
+        VALUES (:id, :orgUid, 'Test Registry', 'PRJ-002', 'PRJ-002',
+                'Test Registry', 'Source-only', datetime('now'), datetime('now'))`,
+        {
+          replacements: { id, orgUid },
+          type: Sequelize.QueryTypes.INSERT,
+        },
+      );
+
+      await backfillMirror();
+
+      const mirrorRow = await ProjectMirror.findOne({
+        where: { warehouseProjectId: id },
+      });
+      expect(mirrorRow, 'source row must be upserted into mirror').to.not.be
+        .null;
+      expect(mirrorRow.projectName).to.equal('Source-only');
+    });
+  });
+
+  describe('Reconnect-triggered backfill', function () {
+    it('should run backfill when authenticate transitions from failure to success', async function () {
+      // Source-only row simulates a write committed to SQLite during an
+      // outage window while the mirror write was silently dropped.
+      const id = uuidv4();
+      const orgUid = uuidv4();
+      await sequelize.query(
+        `INSERT INTO projects
+          (warehouseProjectId, orgUid, currentRegistry, projectId, originProjectId,
+           registryOfOrigin, projectName, createdAt, updatedAt)
+        VALUES (:id, :orgUid, 'Test Registry', 'PRJ-003', 'PRJ-003',
+                'Test Registry', 'Outage Row', datetime('now'), datetime('now'))`,
+        {
+          replacements: { id, orgUid },
+          type: Sequelize.QueryTypes.INSERT,
+        },
+      );
+
+      const mirrorBefore = await ProjectMirror.findOne({
+        where: { warehouseProjectId: id },
+      });
+      expect(mirrorBefore).to.be.null;
+
+      const authStub = sinon.stub(sequelizeMirror, 'authenticate');
+      authStub.onCall(0).rejects(new Error('ECONNREFUSED'));
+      authStub.resolves();
+
+      // Call 1: disconnects. state -> 'disconnected', callback skipped.
+      let cb1Ran = false;
+      await safeMirrorDbHandler(async () => {
+        cb1Ran = true;
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      expect(cb1Ran, 'callback must not run while disconnected').to.equal(
+        false,
+      );
+
+      // Call 2: reconnects, triggers backfill, runs callback. Backfill
+      // covers all V1 mirror tables and can take a moment with other test
+      // data in the source DB - poll until both the callback fires and the
+      // recovered row is visible in the mirror.
+      let cb2Ran = false;
+      await safeMirrorDbHandler(async () => {
+        cb2Ran = true;
+      });
+
+      const deadline = Date.now() + 15000;
+      let mirrorAfter = null;
+      while (Date.now() < deadline) {
+        mirrorAfter = await ProjectMirror.findOne({
+          where: { warehouseProjectId: id },
+        });
+        if (cb2Ran && mirrorAfter) break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+
+      expect(cb2Ran, 'callback must run after reconnect').to.equal(true);
+      expect(mirrorAfter, 'reconnect backfill must recover missing row').to.not
+        .be.null;
+    });
+  });
+});

--- a/tests/integration/mirror-reconnect.spec.js
+++ b/tests/integration/mirror-reconnect.spec.js
@@ -12,6 +12,8 @@ import {
   safeMirrorDbHandler,
   __setMirrorEnabledForTests,
   __setMirrorSetupSucceededForTests,
+  __setMysqlConfiguredForReconnectForTests,
+  __resetMirrorAuthStateForTests,
 } from '../../src/database/index.js';
 import { ProjectMirror } from '../../src/models/projects/projects.model.mirror.js';
 
@@ -52,6 +54,12 @@ describe('Mirror Reconnect and Orphan Sweep (V1)', function () {
   afterEach(async function () {
     __setMirrorEnabledForTests(null);
     __setMirrorSetupSucceededForTests(false);
+    __setMysqlConfiguredForReconnectForTests(null);
+    // Reset auth-state machine so downstream specs running in the same
+    // mocha session (project.spec.js, unit.spec.js, etc.) don't observe a
+    // leaked 'disconnected' state and enter the reconnect path on their
+    // first mirror write.
+    __resetMirrorAuthStateForTests();
     sinon.restore();
 
     // Clean both databases between tests. We clear a minimal set of tables
@@ -216,6 +224,45 @@ describe('Mirror Reconnect and Orphan Sweep (V1)', function () {
       expect(cb2Ran, 'callback must run after reconnect').to.equal(true);
       expect(mirrorAfter, 'reconnect backfill must recover missing row').to.not
         .be.null;
+    });
+
+    // Placed last in this block because it intentionally leaves
+    // mirrorAuthState in the 'disconnected' state (startReconnectBackfill
+    // does so on setup failure). Running another reconnect-related test
+    // after this one would observe that stale state and behave differently.
+    it('should skip the callback when MySQL is configured but setup has not completed yet', async function () {
+      // Regression guard for the post-reconnect skip-callback branch in
+      // safeMirrorDbHandler. When the mirror is "enabled" and authenticate()
+      // succeeds but the one-time setup (CREATE DATABASE + migrations) has
+      // not yet completed, running the callback would hit tables that don't
+      // exist and produce a confusing swallowed error. The handler must
+      // skip the callback silently in that window. Symmetric with V2.
+      //
+      // Forces both prongs of the guard true:
+      //   - isMysqlMirrorConfiguredForReconnect() -> true
+      //   - mirrorSetupSucceeded                  -> false
+      __setMysqlConfiguredForReconnectForTests(true);
+      __setMirrorSetupSucceededForTests(false);
+
+      // Happy-path authenticate so the handler reaches the guard without
+      // going through the disconnected-catch branch. The handler will first
+      // call startReconnectBackfill (because setupNeverRan is true), which
+      // calls prepareMysqlMirror. prepareMysqlMirror reads config.yaml
+      // directly (not via the override above) and, with no real MIRROR_DB
+      // in the test config, returns false. That leaves mirrorSetupSucceeded
+      // still false, so the new guard trips.
+      sinon.stub(sequelizeMirror, 'authenticate').resolves();
+
+      let cbRan = false;
+      await safeMirrorDbHandler(async () => {
+        cbRan = true;
+      });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(
+        cbRan,
+        'callback must not run while MySQL setup is still pending',
+      ).to.equal(false);
     });
   });
 });

--- a/tests/v1/live-api/data-short.js
+++ b/tests/v1/live-api/data-short.js
@@ -2,11 +2,21 @@
 /**
  * Orchestration file for short test mode (batch commits)
  * Runs all POST requests first, then commits, then PUT requests, then commits, then DELETE requests, then commits
+ *
+ * MySQL Mirror Database Testing:
+ * When CADT is configured with a V1 MySQL mirror database (V1.MIRROR_DB in
+ * config.yaml), this test runner will also verify that data is correctly
+ * mirrored to MySQL after each commit phase.
  */
 
 import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import {
+  isMirrorDbEnabled,
+  verifyMirrorRecordsBatch,
+  closeMirrorDbPool,
+} from './helpers/mysql-mirror-helpers.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -179,6 +189,40 @@ async function commitAndWait(phase) {
     console.log('No records to verify');
   }
 
+  // MySQL Mirror Database Verification
+  // When V1.MIRROR_DB is configured, assert each tracked record appears in
+  // the MySQL mirror with matching data (or is absent for DELETEs). This is
+  // how we catch regressions in:
+  //   - the V1 safeMirrorDbHandler init race (mirror models not init'd),
+  //   - outage-replay gaps (writes dropped during MySQL outage),
+  //   - DELETE handling in the reconnect backfill.
+  if (isMirrorDbEnabled()) {
+    console.log(`\n[${verifyTimestamp}] Verifying MySQL mirror database (V1)...`);
+
+    const mirrorRecordsToVerify = [];
+    for (const [type, typeRecords] of Object.entries(verificationRecords)) {
+      for (const [id, recordInfo] of Object.entries(typeRecords)) {
+        mirrorRecordsToVerify.push({
+          type,
+          id,
+          operation: recordInfo.operation,
+          expectedData: recordInfo.expectedData,
+        });
+      }
+    }
+
+    if (mirrorRecordsToVerify.length > 0) {
+      const mirrorResult = await verifyMirrorRecordsBatch(mirrorRecordsToVerify);
+      if (mirrorResult.failed > 0) {
+        console.error(`\n❌ MySQL Mirror (V1) verification failed: ${mirrorResult.failed} record(s) failed`);
+        console.error('MySQL Mirror Failures:');
+        mirrorResult.failures.forEach(failure => console.error(`  - ${failure}`));
+        throw new Error(`MySQL Mirror (V1) verification failed: ${mirrorResult.failed} of ${mirrorResult.verified + mirrorResult.failed} record(s) failed`);
+      }
+      console.log(`✓ MySQL Mirror (V1): All ${mirrorResult.verified} record(s) verified successfully`);
+    }
+  }
+
   clearBatchVerificationRecords();
   console.log(`[${verifyTimestamp}] ✓ ${phase} phase complete\n`);
 }
@@ -186,6 +230,12 @@ async function commitAndWait(phase) {
 async function main() {
   try {
     console.log('\n=== Short Test Mode (Batch Commits) ===\n');
+
+    if (isMirrorDbEnabled()) {
+      console.log('✓ V1 MySQL mirror database is enabled - will verify mirror data after commits');
+    } else {
+      console.log('ℹ V1 MySQL mirror database is not configured - skipping mirror verification');
+    }
 
     // Clear staging table and verification state before starting tests
     const { getLiveApiRequest, clearStagingTable } = await import('./helpers/live-api-helpers.js');
@@ -215,8 +265,23 @@ async function main() {
     await commitAndWait('DELETE');
 
     console.log('\n=== All phases complete ===\n');
+
+    // Close MySQL mirror connection pool to let the process exit cleanly.
+    // Wrap so a cleanup failure doesn't flip a successful test run into a
+    // perceived error - closeMirrorDbPool is defensive internally, this
+    // is belt-and-suspenders.
+    try {
+      await closeMirrorDbPool();
+    } catch (cleanupError) {
+      console.warn(`Error closing MySQL mirror pool (ignored): ${cleanupError.message}`);
+    }
   } catch (error) {
     console.error('Error running short mode tests:', error);
+    try {
+      await closeMirrorDbPool();
+    } catch (cleanupError) {
+      console.warn(`Error closing MySQL mirror pool (ignored): ${cleanupError.message}`);
+    }
     process.exit(1);
   }
 }

--- a/tests/v1/live-api/helpers/mysql-mirror-helpers.js
+++ b/tests/v1/live-api/helpers/mysql-mirror-helpers.js
@@ -1,0 +1,412 @@
+/**
+ * MySQL Mirror Database Test Helpers (V1)
+ *
+ * Provides utilities for testing V1 MySQL mirror database functionality.
+ * When the CADT config has a V1 MySQL mirror database enabled
+ * (V1.MIRROR_DB in config.yaml), these helpers verify that data is
+ * correctly mirrored to MySQL after POST/PUT/DELETE operations.
+ *
+ * Ported from tests/v2/live-api/helpers/mysql-mirror-helpers.js, adapted
+ * for V1 table names (which use camelCase plurals like 'projectRatings',
+ * 'coBenefits') and V1 primary keys (warehouseProjectId / warehouseUnitId).
+ */
+
+import mysql from 'mysql2/promise';
+import yaml from 'js-yaml';
+import fs from 'fs';
+import path from 'path';
+import { getChiaRoot } from '../../../../src/utils/chia-root.js';
+
+let cachedConfig = null;
+let connectionPool = null;
+
+const getTimestamp = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const seconds = String(now.getSeconds()).padStart(2, '0');
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+};
+
+/**
+ * Read the V1 MySQL mirror database config from CADT config.yaml.
+ * Returns null when V1.MIRROR_DB is not fully configured.
+ */
+export const getMirrorDbConfig = () => {
+  if (cachedConfig !== null) {
+    return cachedConfig;
+  }
+
+  const chiaRoot = getChiaRoot();
+  const configFile = path.resolve(`${chiaRoot}/cadt/config.yaml`);
+
+  try {
+    if (!fs.existsSync(configFile)) {
+      console.log(
+        `[${getTimestamp()}] MySQL Mirror (V1): Config file not found at ${configFile}`,
+      );
+      cachedConfig = false;
+      return null;
+    }
+
+    const config = yaml.load(fs.readFileSync(configFile, 'utf8'));
+
+    const mirrorDb = config?.V1?.MIRROR_DB;
+    if (
+      !mirrorDb?.DB_HOST ||
+      !mirrorDb?.DB_USERNAME ||
+      !mirrorDb?.DB_PASSWORD ||
+      !mirrorDb?.DB_NAME
+    ) {
+      console.log(
+        `[${getTimestamp()}] MySQL Mirror (V1): V1.MIRROR_DB not fully configured in config.yaml`,
+      );
+      cachedConfig = false;
+      return null;
+    }
+
+    cachedConfig = {
+      host: mirrorDb.DB_HOST,
+      user: mirrorDb.DB_USERNAME,
+      password: mirrorDb.DB_PASSWORD,
+      database: mirrorDb.DB_NAME,
+    };
+
+    console.log(
+      `[${getTimestamp()}] MySQL Mirror (V1): Found config - host=${cachedConfig.host}, database=${cachedConfig.database}`,
+    );
+    return cachedConfig;
+  } catch (error) {
+    console.error(
+      `[${getTimestamp()}] MySQL Mirror (V1): Error reading config - ${error.message}`,
+    );
+    cachedConfig = false;
+    return null;
+  }
+};
+
+export const isMirrorDbEnabled = () => {
+  const config = getMirrorDbConfig();
+  return config !== null && config !== false;
+};
+
+export const getMirrorDbPool = async () => {
+  const config = getMirrorDbConfig();
+  if (!config) {
+    return null;
+  }
+
+  if (connectionPool) {
+    return connectionPool;
+  }
+
+  try {
+    connectionPool = mysql.createPool({
+      host: config.host,
+      user: config.user,
+      password: config.password,
+      database: config.database,
+      waitForConnections: true,
+      connectionLimit: 5,
+      queueLimit: 0,
+    });
+
+    const connection = await connectionPool.getConnection();
+    connection.release();
+    console.log(
+      `[${getTimestamp()}] MySQL Mirror (V1): Connection pool created successfully`,
+    );
+    return connectionPool;
+  } catch (error) {
+    console.error(
+      `[${getTimestamp()}] MySQL Mirror (V1): Failed to create connection pool - ${error.message}`,
+    );
+    connectionPool = null;
+    return null;
+  }
+};
+
+export const closeMirrorDbPool = async () => {
+  if (!connectionPool) return;
+  const pool = connectionPool;
+  // Drop the reference first so a throw in .end() doesn't leave us in a
+  // state where a second call keeps invoking end() on a broken pool.
+  connectionPool = null;
+  try {
+    await pool.end();
+    console.log(
+      `[${getTimestamp()}] MySQL Mirror (V1): Connection pool closed`,
+    );
+  } catch (error) {
+    // Teardown is best-effort; swallow-and-log so test results are
+    // not clobbered by connection-cleanup noise.
+    console.warn(
+      `[${getTimestamp()}] MySQL Mirror (V1): Error closing pool (ignored): ${error.message}`,
+    );
+  }
+};
+
+/**
+ * Map of V1 test-tracking types to V1 MySQL mirror table names. V1 uses
+ * camelCase plural table names (not snake_case) because the V1 mirror
+ * migrations were authored without `underscored: true`.
+ */
+const TYPE_TO_TABLE = {
+  project: 'projects',
+  unit: 'units',
+  issuance: 'issuances',
+  label: 'labels',
+  rating: 'projectRatings',
+  projectRating: 'projectRatings',
+  coBenefit: 'coBenefits',
+  'co-benefit': 'coBenefits',
+  location: 'projectLocations',
+  projectLocation: 'projectLocations',
+  estimation: 'estimations',
+  relatedProject: 'relatedProjects',
+  'related-project': 'relatedProjects',
+  labelUnit: 'label_unit',
+  'label-unit': 'label_unit',
+  audit: 'audit',
+  organization: 'organizations',
+};
+
+/**
+ * Primary-key column names for each V1 mirror table. Only tables that V1
+ * live-api tests currently track need explicit entries; others default to
+ * 'id' which matches the Sequelize autoIncrement PK in the V1 mirror
+ * migrations.
+ */
+const TYPE_TO_PRIMARY_KEY = {
+  project: 'warehouseProjectId',
+  unit: 'warehouseUnitId',
+  organization: 'orgUid',
+};
+
+const DEFAULT_PRIMARY_KEY = 'id';
+
+const getTable = (type) => TYPE_TO_TABLE[type];
+const getPrimaryKey = (type) =>
+  TYPE_TO_PRIMARY_KEY[type] || DEFAULT_PRIMARY_KEY;
+
+export const getMirrorRecord = async (type, id) => {
+  const pool = await getMirrorDbPool();
+  if (!pool) {
+    return null;
+  }
+
+  const tableName = getTable(type);
+  const primaryKey = getPrimaryKey(type);
+
+  if (!tableName) {
+    console.error(
+      `[${getTimestamp()}] MySQL Mirror (V1): Unknown type '${type}'`,
+    );
+    return null;
+  }
+
+  try {
+    const [rows] = await pool.execute(
+      `SELECT * FROM \`${tableName}\` WHERE \`${primaryKey}\` = ?`,
+      [id],
+    );
+    return rows.length > 0 ? rows[0] : null;
+  } catch (error) {
+    if (error.code === 'ER_NO_SUCH_TABLE') {
+      console.log(
+        `[${getTimestamp()}] MySQL Mirror (V1): Table ${tableName} does not exist yet`,
+      );
+      return null;
+    }
+    console.error(
+      `[${getTimestamp()}] MySQL Mirror (V1): Error querying ${tableName} - ${error.message}`,
+    );
+    return null;
+  }
+};
+
+export const mirrorRecordExists = async (type, id) => {
+  const record = await getMirrorRecord(type, id);
+  return record !== null;
+};
+
+export const verifyMirrorRecord = async (type, id, expectedData = null) => {
+  const result = { exists: false, dataMatches: true, errors: [] };
+
+  const record = await getMirrorRecord(type, id);
+  if (!record) {
+    result.dataMatches = false;
+    result.errors.push(`Record ${type}/${id} not found in MySQL mirror (V1)`);
+    return result;
+  }
+
+  result.exists = true;
+
+  if (!expectedData) {
+    return result;
+  }
+
+  // V1 mirror columns are camelCase; expectedData keys are camelCase too,
+  // so no translation is needed (unlike V2).
+  for (const [key, expectedValue] of Object.entries(expectedData)) {
+    const actualValue = record[key];
+
+    if (expectedValue && typeof expectedValue === 'object') {
+      continue;
+    }
+
+    if (
+      expectedValue === null &&
+      (actualValue === null || actualValue === undefined)
+    ) {
+      continue;
+    }
+    if (expectedValue === undefined) {
+      continue;
+    }
+
+    if (expectedValue && actualValue) {
+      const expectedIsDate = /^\d{4}-\d{2}-\d{2}/.test(String(expectedValue));
+      if (expectedIsDate) {
+        const expectedDatePart = String(expectedValue).substring(0, 10);
+        let actualDatePart;
+        if (actualValue instanceof Date) {
+          actualDatePart = actualValue.toISOString().substring(0, 10);
+        } else {
+          actualDatePart = String(actualValue).substring(0, 10);
+        }
+        if (expectedDatePart === actualDatePart) {
+          continue;
+        }
+        // Dates didn't match on the YYYY-MM-DD prefix. Record the mismatch
+        // and skip the fallback comparisons: falling through to the
+        // parseFloat branch below would compare '2024-01-01' and
+        // '2024-06-15' as both equal to the year 2024 and silently
+        // suppress the mismatch.
+        result.dataMatches = false;
+        result.errors.push(
+          `Field '${key}' mismatch: expected '${expectedValue}', got '${actualValue}'`,
+        );
+        continue;
+      }
+    }
+
+    if (typeof actualValue === 'string' && actualValue.startsWith('[')) {
+      try {
+        const parsedActual = JSON.parse(actualValue);
+        if (Array.isArray(expectedValue) && Array.isArray(parsedActual)) {
+          if (
+            JSON.stringify(expectedValue.slice().sort()) ===
+            JSON.stringify(parsedActual.slice().sort())
+          ) {
+            continue;
+          }
+        }
+      } catch {
+        /* not JSON */
+      }
+    }
+
+    const expectedNum = parseFloat(expectedValue);
+    const actualNum = parseFloat(actualValue);
+    if (!isNaN(expectedNum) && !isNaN(actualNum)) {
+      if (expectedNum === actualNum) {
+        continue;
+      }
+    }
+
+    if (String(actualValue) !== String(expectedValue)) {
+      result.dataMatches = false;
+      result.errors.push(
+        `Field '${key}' mismatch: expected '${expectedValue}', got '${actualValue}'`,
+      );
+    }
+  }
+
+  return result;
+};
+
+export const verifyMirrorRecordDeleted = async (type, id) => {
+  const result = { deleted: true, errors: [] };
+  const record = await getMirrorRecord(type, id);
+  if (record !== null) {
+    result.deleted = false;
+    result.errors.push(
+      `Record ${type}/${id} still exists in MySQL mirror (V1) after DELETE`,
+    );
+  }
+  return result;
+};
+
+export const verifyMirrorRecordsBatch = async (records) => {
+  const result = { verified: 0, failed: 0, failures: [] };
+
+  if (!isMirrorDbEnabled()) {
+    console.log(
+      `[${getTimestamp()}] MySQL Mirror (V1): Skipping batch verification - mirror DB not enabled`,
+    );
+    return result;
+  }
+
+  console.log(
+    `[${getTimestamp()}] MySQL Mirror (V1): Verifying ${records.length} record(s) in mirror database...`,
+  );
+
+  for (const { type, id, operation, expectedData } of records) {
+    try {
+      if (operation === 'DELETE') {
+        const deleteResult = await verifyMirrorRecordDeleted(type, id);
+        if (deleteResult.deleted) {
+          result.verified++;
+          console.log(`  ✓ MySQL Mirror (V1): Verified DELETE ${type}/${id}`);
+        } else {
+          result.failed++;
+          result.failures.push(...deleteResult.errors);
+          console.error(
+            `  ❌ MySQL Mirror (V1): ${deleteResult.errors.join(', ')}`,
+          );
+        }
+      } else {
+        const verifyResult = await verifyMirrorRecord(type, id, expectedData);
+        if (verifyResult.exists && verifyResult.dataMatches) {
+          result.verified++;
+          console.log(
+            `  ✓ MySQL Mirror (V1): Verified ${operation} ${type}/${id}`,
+          );
+        } else {
+          result.failed++;
+          result.failures.push(...verifyResult.errors);
+          console.error(
+            `  ❌ MySQL Mirror (V1): ${verifyResult.errors.join(', ')}`,
+          );
+        }
+      }
+    } catch (error) {
+      result.failed++;
+      result.failures.push(`${operation} ${type}/${id}: ${error.message}`);
+      console.error(
+        `  ❌ MySQL Mirror (V1): Error verifying ${type}/${id} - ${error.message}`,
+      );
+    }
+  }
+
+  console.log(
+    `[${getTimestamp()}] MySQL Mirror (V1): Batch verification complete - ${result.verified} verified, ${result.failed} failed`,
+  );
+  return result;
+};
+
+export default {
+  isMirrorDbEnabled,
+  getMirrorDbConfig,
+  getMirrorDbPool,
+  closeMirrorDbPool,
+  getMirrorRecord,
+  mirrorRecordExists,
+  verifyMirrorRecord,
+  verifyMirrorRecordDeleted,
+  verifyMirrorRecordsBatch,
+};

--- a/tests/v2/integration/mirror-datetime-format.spec.js
+++ b/tests/v2/integration/mirror-datetime-format.spec.js
@@ -1,45 +1,84 @@
 import { expect } from 'chai';
 import Sequelize from 'sequelize';
 
+// Import config.js so its DATE._stringify patch is applied before
+// we exercise it here. The patch runs once at module load.
+// eslint-disable-next-line no-unused-vars
+import _config from '../../../src/config/config.js';
+
 /**
  * Regression test for the Sequelize mirror datetime format.
  *
- * Recent MariaDB strict mode rejects Sequelize's base DATE serialization
- * ("YYYY-MM-DD HH:mm:ss.SSS Z", e.g. "2026-04-17 17:07:13.399 +00:00")
- * with "Incorrect datetime value".
+ * Recent MariaDB strict mode rejects Sequelize's default DATE serialization
+ * ("YYYY-MM-DD HH:mm:ss.SSS Z", e.g. "2026-04-17 19:12:48.720 +00:00")
+ * with "Incorrect datetime value". `src/config/config.js` patches
+ * `Sequelize.DataTypes.DATE.prototype._stringify` to drop the trailing
+ * offset (emitting "YYYY-MM-DD HH:mm:ss.SSS"), which MariaDB strict mode
+ * accepts. The mysql dialect subclass already emits a safe format on its
+ * own ("YYYY-MM-DD HH:mm:ss") so direct mysql attribute writes are
+ * unaffected by the patch.
  *
- * Normal mirror writes are safe because Sequelize dispatches to the
- * dialect-specific mysql.DATE class, which emits "YYYY-MM-DD HH:mm:ss"
- * (no offset, no fractional seconds). Empirically verified: single
- * INSERT, bulk INSERT, and INSERT ... ON DUPLICATE KEY UPDATE all route
- * through mysql.DATE._stringify and never touch the base-class method.
- *
- * This test pins that contract so a future Sequelize upgrade that changes
- * the mysql subclass serialiser (e.g. to emit an ISO "T" separator, or
- * to re-introduce a trailing offset) is caught here rather than silently
- * in a live-api run.
- *
- * Separately, backfill's findAll({ raw: true }) path would have returned
- * SQLite DATE values as offset-bearing strings and forwarded them to
- * MariaDB verbatim - that class of bug is prevented by the
- * `.get({ plain: true, raw: true })` call in backfillMirror[V2], which
- * has its own coverage in the V1/V2 reconnect specs.
+ * If this test fails, CADT's MySQL mirror writes will silently drop every
+ * insert that touches a DATE/DATETIME column in strict-mode MariaDB.
  */
-describe('Mirror datetime serialization (mysql subclass contract)', function () {
-  const sampleDate = new Date('2026-04-17T17:07:13.399Z');
+describe('Mirror datetime serialization', function () {
+  const sampleDate = new Date('2026-04-17T19:12:48.720Z');
+
+  it('BASE DATE._stringify must emit a MariaDB-safe format (no " +00:00" offset)', function () {
+    const out = Sequelize.DataTypes.DATE.prototype.stringify(sampleDate, {
+      timezone: '+00:00',
+    });
+    expect(out).to.not.include('+');
+    expect(out).to.not.include('Z');
+    // Expected exact format (millisecond precision is kept so that
+    // SQLite round-trips via sqlite.DATE.parse preserve sub-second
+    // precision that tests and source writers depend on).
+    expect(out).to.equal('2026-04-17 19:12:48.720');
+  });
+
+  it('BASE DATE._stringify must honour the constructor-level timezone option', function () {
+    const out = Sequelize.DataTypes.DATE.prototype.stringify(sampleDate, {
+      timezone: '+05:30',
+    });
+    expect(out).to.equal('2026-04-18 00:42:48.720');
+  });
+
+  it('SQLite DATE round-trip via parse() must reconstruct an equivalent Date', function () {
+    // SQLite inherits the patched _stringify (no own override). Its
+    // DATE.parse appends options.timezone when the string lacks a
+    // "+"/"-" offset, so the round-trip is lossless when the Sequelize
+    // instance defaults timezone to "+00:00" (which it does).
+    const out = Sequelize.DataTypes.sqlite.DATE.prototype.stringify(
+      sampleDate,
+      { timezone: '+00:00' },
+    );
+    expect(out).to.equal('2026-04-17 19:12:48.720');
+    const parsed = Sequelize.DataTypes.sqlite.DATE.parse(out, {
+      timezone: '+00:00',
+    });
+    expect(parsed.toISOString()).to.equal('2026-04-17T19:12:48.720Z');
+  });
+
+  it('SQLite DATE.parse must still round-trip pre-patch rows (legacy " +00:00" form)', function () {
+    // Existing CADT databases have dates like
+    // "2026-04-17 19:12:48.720 +00:00" from before the patch.
+    // sqlite.DATE.parse returns `new Date(str)` directly when the
+    // string already contains "+", so legacy rows keep parsing.
+    const legacy = '2026-04-17 19:12:48.720 +00:00';
+    const parsed = Sequelize.DataTypes.sqlite.DATE.parse(legacy, {
+      timezone: '+00:00',
+    });
+    expect(parsed.toISOString()).to.equal('2026-04-17T19:12:48.720Z');
+  });
 
   it('mysql DATE._stringify must emit "YYYY-MM-DD HH:mm:ss" (no offset, no fractional seconds)', function () {
+    // mysql subclass has its own _stringify. Pin its exact output so a
+    // future Sequelize upgrade that changes the mysql subclass (e.g.
+    // ISO "T" separator, or re-introducing a trailing offset) is
+    // caught here rather than silently in a live-api run.
     const out = Sequelize.DataTypes.mysql.DATE.prototype.stringify(sampleDate, {
       timezone: '+00:00',
     });
-    expect(out).to.equal('2026-04-17 17:07:13');
-  });
-
-  it('mysql DATE._stringify must honour the constructor-level timezone option', function () {
-    // Non-UTC timezone must shift the formatted wall-clock time.
-    const out = Sequelize.DataTypes.mysql.DATE.prototype.stringify(sampleDate, {
-      timezone: '+05:30',
-    });
-    expect(out).to.equal('2026-04-17 22:37:13');
+    expect(out).to.equal('2026-04-17 19:12:48');
   });
 });

--- a/tests/v2/integration/mirror-datetime-format.spec.js
+++ b/tests/v2/integration/mirror-datetime-format.spec.js
@@ -1,54 +1,45 @@
 import { expect } from 'chai';
 import Sequelize from 'sequelize';
 
-// Import config.js (via the barrel) to install the DATE._stringify patch.
-// The patch is applied once at module load; this file only exercises it.
-// eslint-disable-next-line no-unused-vars
-import _config from '../../../src/config/config.js';
-
 /**
  * Regression test for the Sequelize mirror datetime format.
  *
- * Recent MariaDB strict mode rejects Sequelize's default DATE serialization
- * of "YYYY-MM-DD HH:mm:ss.SSS Z" (e.g. "2026-04-17 17:07:13.399 +00:00")
- * with "Incorrect datetime value". `src/config/config.js` patches the base
- * DATE._stringify to emit "YYYY-MM-DD HH:mm:ss" for MySQL/MariaDB while
- * retaining the original format for SQLite (whose parse() depends on the
- * trailing offset for round-trip).
+ * Recent MariaDB strict mode rejects Sequelize's base DATE serialization
+ * ("YYYY-MM-DD HH:mm:ss.SSS Z", e.g. "2026-04-17 17:07:13.399 +00:00")
+ * with "Incorrect datetime value".
  *
- * If this test fails, CADT's MySQL mirror writes will silently drop every
- * insert that touches a DATE/DATETIME column in strict-mode MariaDB.
+ * Normal mirror writes are safe because Sequelize dispatches to the
+ * dialect-specific mysql.DATE class, which emits "YYYY-MM-DD HH:mm:ss"
+ * (no offset, no fractional seconds). Empirically verified: single
+ * INSERT, bulk INSERT, and INSERT ... ON DUPLICATE KEY UPDATE all route
+ * through mysql.DATE._stringify and never touch the base-class method.
+ *
+ * This test pins that contract so a future Sequelize upgrade that changes
+ * the mysql subclass serialiser (e.g. to emit an ISO "T" separator, or
+ * to re-introduce a trailing offset) is caught here rather than silently
+ * in a live-api run.
+ *
+ * Separately, backfill's findAll({ raw: true }) path would have returned
+ * SQLite DATE values as offset-bearing strings and forwarded them to
+ * MariaDB verbatim - that class of bug is prevented by the
+ * `.get({ plain: true, raw: true })` call in backfillMirror[V2], which
+ * has its own coverage in the V1/V2 reconnect specs.
  */
-describe('Mirror datetime serialization', function () {
+describe('Mirror datetime serialization (mysql subclass contract)', function () {
   const sampleDate = new Date('2026-04-17T17:07:13.399Z');
 
-  it('BASE DATE._stringify must emit the MariaDB-safe format (no offset, no fractional seconds)', function () {
-    const out = Sequelize.DataTypes.DATE.prototype.stringify(sampleDate, {
-      timezone: '+00:00',
-    });
-    expect(out).to.equal('2026-04-17 17:07:13');
-    expect(out).to.not.include('+');
-    expect(out).to.not.include('Z');
-    expect(out).to.not.include('.');
-  });
-
-  it('SQLite DATE._stringify must retain the original format (with trailing offset) for round-trip', function () {
-    const out = Sequelize.DataTypes.sqlite.DATE.prototype.stringify(
-      sampleDate,
-      { timezone: '+00:00' },
-    );
-    // SQLite's own parse() needs this offset suffix to reconstruct a Date
-    expect(out).to.include('+00:00');
-    const parsed = Sequelize.DataTypes.sqlite.DATE.parse(out, {
-      timezone: '+00:00',
-    });
-    expect(parsed.getTime()).to.equal(sampleDate.getTime());
-  });
-
-  it('mysql DATE._stringify must continue to emit the MariaDB-safe format', function () {
+  it('mysql DATE._stringify must emit "YYYY-MM-DD HH:mm:ss" (no offset, no fractional seconds)', function () {
     const out = Sequelize.DataTypes.mysql.DATE.prototype.stringify(sampleDate, {
       timezone: '+00:00',
     });
     expect(out).to.equal('2026-04-17 17:07:13');
+  });
+
+  it('mysql DATE._stringify must honour the constructor-level timezone option', function () {
+    // Non-UTC timezone must shift the formatted wall-clock time.
+    const out = Sequelize.DataTypes.mysql.DATE.prototype.stringify(sampleDate, {
+      timezone: '+05:30',
+    });
+    expect(out).to.equal('2026-04-17 22:37:13');
   });
 });

--- a/tests/v2/integration/mirror-datetime-format.spec.js
+++ b/tests/v2/integration/mirror-datetime-format.spec.js
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import Sequelize from 'sequelize';
+
+// Import config.js (via the barrel) to install the DATE._stringify patch.
+// The patch is applied once at module load; this file only exercises it.
+// eslint-disable-next-line no-unused-vars
+import _config from '../../../src/config/config.js';
+
+/**
+ * Regression test for the Sequelize mirror datetime format.
+ *
+ * Recent MariaDB strict mode rejects Sequelize's default DATE serialization
+ * of "YYYY-MM-DD HH:mm:ss.SSS Z" (e.g. "2026-04-17 17:07:13.399 +00:00")
+ * with "Incorrect datetime value". `src/config/config.js` patches the base
+ * DATE._stringify to emit "YYYY-MM-DD HH:mm:ss" for MySQL/MariaDB while
+ * retaining the original format for SQLite (whose parse() depends on the
+ * trailing offset for round-trip).
+ *
+ * If this test fails, CADT's MySQL mirror writes will silently drop every
+ * insert that touches a DATE/DATETIME column in strict-mode MariaDB.
+ */
+describe('Mirror datetime serialization', function () {
+  const sampleDate = new Date('2026-04-17T17:07:13.399Z');
+
+  it('BASE DATE._stringify must emit the MariaDB-safe format (no offset, no fractional seconds)', function () {
+    const out = Sequelize.DataTypes.DATE.prototype.stringify(sampleDate, {
+      timezone: '+00:00',
+    });
+    expect(out).to.equal('2026-04-17 17:07:13');
+    expect(out).to.not.include('+');
+    expect(out).to.not.include('Z');
+    expect(out).to.not.include('.');
+  });
+
+  it('SQLite DATE._stringify must retain the original format (with trailing offset) for round-trip', function () {
+    const out = Sequelize.DataTypes.sqlite.DATE.prototype.stringify(
+      sampleDate,
+      { timezone: '+00:00' },
+    );
+    // SQLite's own parse() needs this offset suffix to reconstruct a Date
+    expect(out).to.include('+00:00');
+    const parsed = Sequelize.DataTypes.sqlite.DATE.parse(out, {
+      timezone: '+00:00',
+    });
+    expect(parsed.getTime()).to.equal(sampleDate.getTime());
+  });
+
+  it('mysql DATE._stringify must continue to emit the MariaDB-safe format', function () {
+    const out = Sequelize.DataTypes.mysql.DATE.prototype.stringify(sampleDate, {
+      timezone: '+00:00',
+    });
+    expect(out).to.equal('2026-04-17 17:07:13');
+  });
+});

--- a/tests/v2/integration/mirror-model-init.spec.js
+++ b/tests/v2/integration/mirror-model-init.spec.js
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+
+import * as v2ModelsIndex from '../../../src/models/v2/index.js';
+
+import { AuditMirror } from '../../../src/models/audit/audit.model.mirror.js';
+import { CoBenefitMirror } from '../../../src/models/co-benefits/co-benefits.model.mirror.js';
+import { EstimationMirror } from '../../../src/models/estimations/estimations.model.mirror.js';
+import { IssuanceMirror } from '../../../src/models/issuances/issuances.model.mirror.js';
+import { LabelUnitMirror } from '../../../src/models/labelUnits/labelUnits.model.mirror.js';
+import { LabelMirror } from '../../../src/models/labels/labels.model.mirror.js';
+import { ProjectLocationMirror } from '../../../src/models/locations/locations.model.mirror.js';
+import { ProjectMirror } from '../../../src/models/projects/projects.model.mirror.js';
+import { RatingMirror } from '../../../src/models/ratings/ratings.model.mirror.js';
+import { RelatedProjectMirror } from '../../../src/models/related-projects/related-projects.model.mirror.js';
+import { UnitMirror } from '../../../src/models/units/units.model.mirror.js';
+
+/**
+ * Mirror Model Initialization Tests
+ *
+ * Regression guard for the startup race condition fixed in
+ * `fix/mirror-init-startup-race`: previously, each `*.model.mirror.js` file
+ * wrapped `Model.init(...)` inside `safeMirrorDbHandler[V2](() => ...)`, which
+ * only invokes its callback AFTER `sequelize.authenticate()` resolves. When
+ * the MySQL sidecar container lost the startup race against CADT (observed
+ * on k8s), authenticate() failed with ECONNREFUSED, the .then() never fired,
+ * the models were never initialized, and every subsequent mirror write threw
+ * "Cannot read properties of undefined (reading 'constructor')" from deep
+ * inside Sequelize (this.sequelize was undefined on uninitialized Models).
+ *
+ * After the fix, mirror `Model.init()` runs synchronously at module load via
+ * `initMirrorModel[V2]`, which does not require a live connection. Once init
+ * has run, `rawAttributes` is populated and stays populated for the life of
+ * the process, regardless of connection state.
+ *
+ * These tests assert that every *Mirror model has a populated `rawAttributes`
+ * map immediately after module import. If someone re-wraps an init() in
+ * `safeMirrorDbHandler[V2]` by accident, this test will fail.
+ */
+describe('Mirror Model Initialization', function () {
+  const assertInitialized = (name, model) => {
+    expect(model, `${name} is undefined`).to.exist;
+    expect(model.rawAttributes, `${name}.rawAttributes is missing`).to.exist;
+    expect(
+      Object.keys(model.rawAttributes).length,
+      `${name}.rawAttributes is empty (Model.init() did not run)`,
+    ).to.be.greaterThan(0);
+  };
+
+  // backfillMirror[V2]'s orphan sweep and paginated ORDER BY both require
+  // a single-column primary key and silently skip composite-PK tables.
+  // Every existing mirror model has a single-column PK today; this
+  // assertion guards that invariant so a future composite-PK mirror can't
+  // silently bypass outage-delete recovery.
+  const assertSingleColumnPrimaryKey = (name, model) => {
+    const pkAttrs = model.primaryKeyAttributes || [];
+    expect(
+      pkAttrs.length,
+      `${name} must have exactly one primary key column (has ${pkAttrs.length}: ${pkAttrs.join(', ')}). ` +
+        `Mirror backfill's orphan sweep and paginated ORDER BY currently skip ` +
+        `composite-PK tables - add composite-key support or keep PKs single-column.`,
+    ).to.equal(1);
+  };
+
+  describe('V2 mirror models', function () {
+    const v2MirrorModelNames = Object.keys(v2ModelsIndex).filter((k) =>
+      k.endsWith('Mirror'),
+    );
+
+    it('should discover every V2 mirror model via the v2 models barrel', function () {
+      expect(v2MirrorModelNames.length).to.be.greaterThan(0);
+    });
+
+    v2MirrorModelNames.forEach((name) => {
+      it(`${name} should have rawAttributes populated after module load`, function () {
+        assertInitialized(name, v2ModelsIndex[name]);
+      });
+      it(`${name} should have a single-column primary key (orphan-sweep invariant)`, function () {
+        assertSingleColumnPrimaryKey(name, v2ModelsIndex[name]);
+      });
+    });
+  });
+
+  describe('V1 mirror models', function () {
+    const v1MirrorModels = {
+      AuditMirror,
+      CoBenefitMirror,
+      EstimationMirror,
+      IssuanceMirror,
+      LabelUnitMirror,
+      LabelMirror,
+      ProjectLocationMirror,
+      ProjectMirror,
+      RatingMirror,
+      RelatedProjectMirror,
+      UnitMirror,
+    };
+
+    Object.entries(v1MirrorModels).forEach(([name, model]) => {
+      it(`${name} should have rawAttributes populated after module load`, function () {
+        assertInitialized(name, model);
+      });
+      it(`${name} should have a single-column primary key (orphan-sweep invariant)`, function () {
+        assertSingleColumnPrimaryKey(name, model);
+      });
+    });
+  });
+});

--- a/tests/v2/integration/mirror-reconnect-v2.spec.js
+++ b/tests/v2/integration/mirror-reconnect-v2.spec.js
@@ -1,0 +1,270 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { v4 as uuidv4 } from 'uuid';
+import { Sequelize } from 'sequelize';
+
+import {
+  prepareV2Db,
+  sequelizeV2,
+  sequelizeV2Mirror,
+  checkForV2Migrations,
+  backfillMirrorV2,
+  safeMirrorDbHandlerV2,
+  __setMirrorEnabledForTestsV2,
+  __setMirrorSetupSucceededForTestsV2,
+} from '../../../src/database/v2/index.js';
+import { loggerV2 } from '../../../src/config/logger.js';
+import {
+  ProgramV2,
+  ProgramV2Mirror,
+  OrganizationsV2Mirror,
+} from '../../../src/models/v2/index.js';
+
+/**
+ * Mirror Reconnect + Orphan Sweep Tests (V2)
+ *
+ * These tests exercise the outage-recovery additions to the V2 mirror:
+ *
+ *   1. backfillMirrorV2 now sweeps orphan rows - mirror rows whose primary
+ *      key no longer exists in source are deleted, so DELETEs issued during
+ *      an outage eventually propagate to the mirror.
+ *
+ *   2. safeMirrorDbHandlerV2 detects a reconnect (authenticate() success
+ *      following a prior failure) and runs backfillMirrorV2 before applying
+ *      the current callback. Subsequent concurrent callers wait on the same
+ *      backfill promise so all writes land on a caught-up mirror.
+ *
+ * In test mode, mirrorDBEnabledV2() normally returns false (no MySQL) so
+ * backfill and the handler short-circuit. These tests use
+ * __setMirrorEnabledForTestsV2(true) to drive the real code paths against
+ * the local SQLite fallback (sequelizeV2Mirror / v2MirrorTest) without
+ * requiring a live MySQL instance.
+ *
+ * Data setup uses raw SQL against sequelizeV2 / sequelizeV2Mirror directly
+ * so we avoid the fire-and-forget mirror write on the source models (which
+ * would race with our test setup and cause unique-constraint failures).
+ */
+describe('Mirror Reconnect and Orphan Sweep (V2)', function () {
+  this.timeout(60000);
+
+  before(async function () {
+    await prepareV2Db();
+    await checkForV2Migrations(sequelizeV2Mirror);
+  });
+
+  beforeEach(function () {
+    __setMirrorEnabledForTestsV2(true);
+    // Pretend the one-time MySQL setup (CREATE DATABASE + migrations) has
+    // already succeeded so the reconnect path only performs the backfill.
+    // In production this is set by prepareMysqlMirrorV2 itself; in tests
+    // we use the SQLite fallback mirror whose schema was created by the
+    // before() hook's checkForV2Migrations call.
+    __setMirrorSetupSucceededForTestsV2(true);
+  });
+
+  afterEach(async function () {
+    __setMirrorEnabledForTestsV2(null);
+    __setMirrorSetupSucceededForTestsV2(false);
+    sinon.restore();
+
+    for (const t of ['program', 'organizations']) {
+      try {
+        await sequelizeV2.query(`DELETE FROM ${t}`);
+      } catch {
+        /* ignore */
+      }
+      try {
+        await sequelizeV2Mirror.query(`DELETE FROM ${t}`);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  // Insert a program row into both source and mirror via raw SQL so the
+  // fire-and-forget mirror writer doesn't interfere with test setup.
+  const insertProgramIntoBoth = async ({ id, name }) => {
+    const sql = `INSERT INTO program
+        (cad_trust_program_id, program_name, program_registry, program_registry_activity_id, program_description, created_at, updated_at)
+      VALUES (:id, :name, 'Reg', 'ACT-001', 'seed', datetime('now'), datetime('now'))`;
+    const opts = {
+      replacements: { id, name },
+      type: Sequelize.QueryTypes.INSERT,
+    };
+    await sequelizeV2.query(sql, opts);
+    await sequelizeV2Mirror.query(sql, opts);
+  };
+
+  // Delete from source only, leaving mirror untouched - simulates the
+  // MySQL outage window where SQLite was updated but the mirror write was
+  // silently dropped by safeMirrorDbHandlerV2.
+  const deleteSourceRowOnly = async (id) => {
+    await sequelizeV2.query(
+      `DELETE FROM program WHERE cad_trust_program_id = :id`,
+      { replacements: { id }, type: Sequelize.QueryTypes.DELETE },
+    );
+  };
+
+  describe('Orphan sweep', function () {
+    it('should delete mirror rows whose primary key is no longer in source', async function () {
+      const keepId = uuidv4();
+      const deleteId = uuidv4();
+
+      await insertProgramIntoBoth({ id: keepId, name: 'Keep' });
+      await insertProgramIntoBoth({ id: deleteId, name: 'To Delete' });
+
+      await deleteSourceRowOnly(deleteId);
+
+      const beforeMirrorCount = await ProgramV2Mirror.count();
+      expect(
+        beforeMirrorCount,
+        'mirror should still have both rows before backfill',
+      ).to.equal(2);
+
+      await backfillMirrorV2();
+
+      const keep = await ProgramV2Mirror.findOne({
+        where: { cadTrustProgramId: keepId },
+      });
+      const removed = await ProgramV2Mirror.findOne({
+        where: { cadTrustProgramId: deleteId },
+      });
+
+      expect(keep, 'row still in source should remain in mirror').to.not.be
+        .null;
+      expect(removed, 'row deleted from source should be removed from mirror')
+        .to.be.null;
+    });
+
+    it('should not delete rows when source and mirror are identical', async function () {
+      const id = uuidv4();
+      await insertProgramIntoBoth({ id, name: 'Identical' });
+
+      await backfillMirrorV2();
+
+      const mirrorRow = await ProgramV2Mirror.findOne({
+        where: { cadTrustProgramId: id },
+      });
+      expect(mirrorRow, 'identical row must not be swept').to.not.be.null;
+    });
+
+    it('should also insert missing rows (upsert pass still runs)', async function () {
+      const id = uuidv4();
+      await sequelizeV2.query(
+        `INSERT INTO program
+          (cad_trust_program_id, program_name, program_registry, program_registry_activity_id, program_description, created_at, updated_at)
+        VALUES (:id, 'Source-only', 'Reg', 'ACT-002', 'Must backfill', datetime('now'), datetime('now'))`,
+        { replacements: { id }, type: Sequelize.QueryTypes.INSERT },
+      );
+
+      await backfillMirrorV2();
+
+      const mirrorRow = await ProgramV2Mirror.findOne({
+        where: { cadTrustProgramId: id },
+      });
+      expect(mirrorRow, 'source row must be upserted into mirror').to.not.be
+        .null;
+      expect(mirrorRow.programName).to.equal('Source-only');
+    });
+  });
+
+  describe('Reconnect-triggered backfill', function () {
+    it('should run backfill when authenticate transitions from failure to success', async function () {
+      // Row exists in source only (simulates a write during outage that was
+      // committed to SQLite but whose mirror write was silently dropped).
+      const orgUid = uuidv4();
+      await sequelizeV2.query(
+        `INSERT INTO organizations
+          (org_uid, name, synced, is_home, created_at, updated_at)
+        VALUES (:orgUid, 'Outage Org', 0, 0, datetime('now'), datetime('now'))`,
+        {
+          replacements: { orgUid },
+          type: Sequelize.QueryTypes.INSERT,
+        },
+      );
+
+      const mirrorBefore = await OrganizationsV2Mirror.findOne({
+        where: { org_uid: orgUid },
+      });
+      expect(mirrorBefore).to.be.null;
+
+      // Stub: first authenticate rejects (disconnected), subsequent succeed.
+      const authStub = sinon.stub(sequelizeV2Mirror, 'authenticate');
+      authStub.onCall(0).rejects(new Error('ECONNREFUSED'));
+      authStub.resolves();
+
+      // Call 1: authenticate rejects -> state becomes 'disconnected',
+      // callback is silently skipped.
+      let cb1Ran = false;
+      await safeMirrorDbHandlerV2(async () => {
+        cb1Ran = true;
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      expect(cb1Ran, 'callback must not run while disconnected').to.equal(
+        false,
+      );
+
+      // Call 2: authenticate succeeds -> detects reconnect, runs backfill,
+      // then runs callback on a caught-up mirror. Backfill covers all 23
+      // mirror tables and can take a couple of seconds when other tests
+      // have left data in source tables, so poll until both the callback
+      // runs and the backfill-restored row is visible in the mirror.
+      let cb2Ran = false;
+      await safeMirrorDbHandlerV2(async () => {
+        cb2Ran = true;
+      });
+
+      const deadline = Date.now() + 15000;
+      let mirrorAfter = null;
+      while (Date.now() < deadline) {
+        mirrorAfter = await OrganizationsV2Mirror.findOne({
+          where: { org_uid: orgUid },
+        });
+        if (cb2Ran && mirrorAfter) break;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+
+      expect(cb2Ran, 'callback must run after reconnect').to.equal(true);
+      expect(mirrorAfter, 'reconnect backfill must recover missing row').to.not
+        .be.null;
+    });
+
+    it('should not trigger backfill on a successful authenticate with no prior failure', async function () {
+      // Steady-state: authenticate succeeds first try, no reconnect detected.
+      sinon.stub(sequelizeV2Mirror, 'authenticate').resolves();
+
+      // Spy on the exact info-log line emitted at the entry point of the
+      // reconnect backfill. This is how we assert the reconnect path was
+      // NOT taken - without this, a regression that made backfill run on
+      // every call (not just on reconnect) would still leave cbRan=true
+      // and pass the test silently.
+      const loggerSpy = sinon.spy(loggerV2, 'info');
+      const backfillSpy = sinon.spy(loggerV2, 'error');
+
+      let cbRan = false;
+      await safeMirrorDbHandlerV2(async () => {
+        cbRan = true;
+      });
+      // Give any mis-triggered reconnect backfill time to log
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(cbRan, 'callback must run on steady-state connected handler').to
+        .equal(true);
+
+      const reconnectLogged = loggerSpy
+        .getCalls()
+        .some((call) =>
+          /Mirror DB reconnected, running catch-up recovery/.test(
+            String(call.args[0] ?? ''),
+          ),
+        );
+      expect(
+        reconnectLogged,
+        'backfill must not run on a steady-state authenticate success',
+      ).to.equal(false);
+
+      loggerSpy.restore();
+      backfillSpy.restore();
+    });
+  });
+});

--- a/tests/v2/integration/mirror-reconnect-v2.spec.js
+++ b/tests/v2/integration/mirror-reconnect-v2.spec.js
@@ -12,6 +12,8 @@ import {
   safeMirrorDbHandlerV2,
   __setMirrorEnabledForTestsV2,
   __setMirrorSetupSucceededForTestsV2,
+  __setMysqlConfiguredForReconnectForTestsV2,
+  __resetMirrorAuthStateForTestsV2,
 } from '../../../src/database/v2/index.js';
 import { loggerV2 } from '../../../src/config/logger.js';
 import {
@@ -65,6 +67,11 @@ describe('Mirror Reconnect and Orphan Sweep (V2)', function () {
   afterEach(async function () {
     __setMirrorEnabledForTestsV2(null);
     __setMirrorSetupSucceededForTestsV2(false);
+    __setMysqlConfiguredForReconnectForTestsV2(null);
+    // Reset auth-state machine so downstream specs running in the same
+    // mocha session don't observe a leaked 'disconnected' state and enter
+    // the reconnect path on their first mirror write.
+    __resetMirrorAuthStateForTestsV2();
     sinon.restore();
 
     for (const t of ['program', 'organizations']) {
@@ -265,6 +272,45 @@ describe('Mirror Reconnect and Orphan Sweep (V2)', function () {
 
       loggerSpy.restore();
       backfillSpy.restore();
+    });
+
+    // Placed last in this block because it intentionally leaves
+    // v2MirrorAuthState in the 'disconnected' state (startV2ReconnectBackfill
+    // does so on setup failure). Running another reconnect-related test
+    // after this one would observe that stale state and behave differently.
+    it('should skip the callback when MySQL is configured but setup has not completed yet', async function () {
+      // Regression guard for the post-reconnect skip-callback branch in
+      // safeMirrorDbHandlerV2. When the mirror is "enabled" and
+      // authenticate() succeeds but the one-time setup (CREATE DATABASE +
+      // migrations) has not yet completed, running the callback would hit
+      // tables that don't exist and produce a confusing swallowed error.
+      // The handler must skip the callback silently in that window.
+      //
+      // Forces both prongs of the guard true:
+      //   - isMysqlMirrorConfiguredForReconnectV2() -> true
+      //   - v2MirrorSetupSucceeded                  -> false
+      __setMysqlConfiguredForReconnectForTestsV2(true);
+      __setMirrorSetupSucceededForTestsV2(false);
+
+      // Happy-path authenticate so the handler reaches the guard without
+      // going through the disconnected-catch branch. The handler will first
+      // call startV2ReconnectBackfill (because setupNeverRan is true), which
+      // in turn calls prepareMysqlMirrorV2. prepareMysqlMirrorV2 reads
+      // config.yaml directly (not via the override above) and, with no real
+      // MIRROR_DB in the test config, returns false. That leaves
+      // v2MirrorSetupSucceeded still false, so the new guard trips.
+      sinon.stub(sequelizeV2Mirror, 'authenticate').resolves();
+
+      let cbRan = false;
+      await safeMirrorDbHandlerV2(async () => {
+        cbRan = true;
+      });
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(
+        cbRan,
+        'callback must not run while MySQL setup is still pending',
+      ).to.equal(false);
     });
   });
 });

--- a/tests/v2/live-api/helpers/datalayer-test-helpers.js
+++ b/tests/v2/live-api/helpers/datalayer-test-helpers.js
@@ -6,18 +6,23 @@
 import fs from 'fs';
 import path from 'path';
 import superagent from 'superagent';
-import { getChiaRoot } from '../../../../src/utils/chia-root.js';
-import { getLiveApiConfig } from './live-api-helpers.js';
+import {
+  getLiveApiConfig,
+  getChiaCertificateFolderPath,
+} from './live-api-helpers.js';
 
 // Disable TLS certificate validation for self-signed certs
 process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
 
 /**
- * Get base options for datalayer RPC calls (certs, keys, timeout)
+ * Get base options for datalayer RPC calls (certs, keys, timeout).
+ *
+ * Uses getChiaCertificateFolderPath so this helper honours
+ * CERTIFICATE_FOLDER_PATH the same way src/datalayer/wallet.js does, rather
+ * than hardcoding ${chiaRoot}/config/ssl.
  */
 const getBaseOptions = () => {
-  const chiaRoot = getChiaRoot();
-  const certificateFolderPath = `${chiaRoot}/config/ssl`;
+  const certificateFolderPath = getChiaCertificateFolderPath();
 
   const certFile = path.resolve(
     `${certificateFolderPath}/data_layer/private_data_layer.crt`,

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -73,6 +73,33 @@ export const getLiveApiConfig = () => {
 };
 
 /**
+ * Resolve the Chia SSL certificate folder used by RPC clients in live tests.
+ *
+ * Mirrors the resolution performed by src/datalayer/wallet.js (and the
+ * equivalent logic for DataLayer RPC) so that tests honour the
+ * `CERTIFICATE_FOLDER_PATH` override. Without this, tests that hardcode
+ * `${chiaRoot}/config/ssl` fail in environments where CADT is correctly
+ * configured to use a non-default Chia SSL directory, giving a false
+ * negative even though production code would successfully reach the RPC.
+ *
+ * Matches production semantics exactly: an explicit override is returned
+ * verbatim (whether absolute or relative), and only the default fallback
+ * is expanded to an absolute path via getChiaRoot(). This keeps relative
+ * override paths - which production code forwards directly to fs.readFileSync
+ * against the CADT process cwd - resolved the same way in tests.
+ *
+ * @returns {string} path to the Chia SSL certificate folder
+ */
+export const getChiaCertificateFolderPath = () => {
+  const { config } = getLiveApiConfig();
+  const override = config?.APP?.CERTIFICATE_FOLDER_PATH;
+  if (override && override !== '') {
+    return override;
+  }
+  return `${getChiaRoot()}/config/ssl`;
+};
+
+/**
  * Create supertest instance pointing to localhost API
  */
 export const createLiveApiRequest = () => {

--- a/tests/v2/live-api/helpers/mysql-mirror-helpers.js
+++ b/tests/v2/live-api/helpers/mysql-mirror-helpers.js
@@ -328,6 +328,16 @@ export const verifyMirrorRecord = async (type, id, expectedData = null) => {
         if (expectedDatePart === actualDatePart) {
           continue;
         }
+        // Dates didn't match on the YYYY-MM-DD prefix. Record the mismatch
+        // and skip the fallback comparisons: falling through to the
+        // parseFloat branch below would compare '2024-01-01' and
+        // '2024-06-15' as both equal to the year 2024 and silently
+        // suppress the mismatch.
+        result.dataMatches = false;
+        result.errors.push(
+          `Field '${snakeKey}' mismatch: expected '${expectedValue}', got '${actualValue}'`
+        );
+        continue;
       }
     }
 

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -2,8 +2,11 @@ import { expect } from 'chai';
 import fs from 'fs';
 import path from 'path';
 import superagent from 'superagent';
-import { getLiveApiRequest, getLiveApiConfig } from './helpers/live-api-helpers.js';
-import { getChiaRoot } from '../../../src/utils/chia-root.js';
+import {
+  getLiveApiRequest,
+  getLiveApiConfig,
+  getChiaCertificateFolderPath,
+} from './helpers/live-api-helpers.js';
 import wallet from '../../../src/datalayer/wallet.js';
 
 process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
@@ -14,9 +17,19 @@ const getWalletRpcUrl = () => {
 };
 
 const getWalletBaseOptions = () => {
-  const chiaRoot = getChiaRoot();
-  const certPath = path.resolve(`${chiaRoot}/config/ssl/wallet/private_wallet.crt`);
-  const keyPath = path.resolve(`${chiaRoot}/config/ssl/wallet/private_wallet.key`);
+  // Resolve via getChiaCertificateFolderPath so this test honours
+  // CERTIFICATE_FOLDER_PATH the same way src/datalayer/wallet.js does.
+  // Hardcoding ${chiaRoot}/config/ssl here would cause a false-negative
+  // test failure in any deployment that uses a non-default Chia SSL
+  // directory, even though production code would successfully reach
+  // the wallet RPC.
+  const certificateFolderPath = getChiaCertificateFolderPath();
+  const certPath = path.resolve(
+    `${certificateFolderPath}/wallet/private_wallet.crt`,
+  );
+  const keyPath = path.resolve(
+    `${certificateFolderPath}/wallet/private_wallet.key`,
+  );
   return {
     cert: fs.readFileSync(certPath),
     key: fs.readFileSync(keyPath),


### PR DESCRIPTION
## Summary

Fixes a silent startup race in CADT's MySQL mirror: if MySQL wasn't reachable when CADT started, every mirror `Model.init()` call was permanently skipped and subsequent mirror writes threw `Cannot read properties of undefined (reading 'constructor')` from deep inside Sequelize. The mirror stayed non-functional for the life of the process. Observed on the `chiamanaged-cadt-testneta-observer-official` k8s namespace — `cadt_mirror_v1` and `cadt_mirror_v2` databases contained zero tables despite ~60 mirror errors per sync cycle.

This PR addresses both the immediate init race AND the broader durability gap where writes during a MySQL outage are silently dropped.

## Core fix (V1 + V2)

- `safeMirrorDbHandler[V2]` no longer wraps `Model.init()`. A new `initMirrorModel[V2]` helper runs init synchronously at module load — safe because `Sequelize.init()` is pure metadata registration and doesn't need a live connection. All 34 V1+V2 `*.model.mirror.js` files updated.
- `safeMirrorDbHandler[V2]` now detects `disconnected → connected` transitions (and "setup never ran at startup") and runs `prepareMysqlMirror[V2]` + `backfillMirror[V2]` before the current callback. Writes dropped during an outage are recovered without a CADT restart.
- `backfillMirror[V2]` now also sweeps orphan rows (mirror rows whose PK is no longer in source) so `DELETE`s issued during an outage eventually propagate. Pagination now has `ORDER BY` on the PK so concurrent writes don't cause skipped rows. **V1 previously had no backfill at all — added in this PR.**
- `validateMirrorDbNames` fails loud on startup instead of being swallowed by the mirror-setup `try/catch`.

## Tests

- New integration tests assert: every mirror model is initialised at module load (with a single-column-PK invariant that guards the orphan sweep); orphan sweep removes source-deleted rows from the mirror; reconnect detection runs backfill; steady-state connects do NOT run backfill.
- V1 live-api `data-short.js` now verifies records land in the V1 MySQL mirror (symmetric with V2). Ports `mysql-mirror-helpers` to V1 and fixes a date-then-numeric fallback in both helpers so `'2024-01-01'` no longer equals `'2024-06-15'` via `parseFloat`.

## CI

- `test-v2-live-api` and `test-v1-live-api` now stop MariaDB mid-setup and restart it ~30s after CADT starts, exercising the startup race + reconnect+backfill recovery end-to-end.
- Both jobs hard-fail if MariaDB is still reachable after `service mariadb stop` so a degraded race test cannot silently pass.
- V1 `Start CADT` polls the V1 API with exit-on-timeout, matching V2's `/health` polling.

## Related fix (same test surface)

`wallet-health.live.spec.js` and `datalayer-test-helpers.js` now honour `CERTIFICATE_FOLDER_PATH` via a new shared live-api helper, matching `src/datalayer/wallet.js`. The previous hardcoded `${chiaRoot}/config/ssl` gave a false-negative in deployments using a non-default Chia SSL directory.

## Test plan

- [x] `npm run test:v2` passes (1465 tests, +34 from new single-PK invariant guards)
- [x] `npm run test:v1` passes (115 tests)
- [x] Targeted `mirror-model-init` + `mirror-reconnect` + `mirror-backfill` suites pass × 3 stability runs
- [x] `node --check` all 46 changed files
- [x] Zero new lint errors / warnings introduced (verified against `origin/v2-rc2` baseline)
- [x] `js-yaml` validation of `.github/workflows/tests.yaml`
- [x] Two rounds of adversarial `pre-push-diff-review` (4 slices × 2 = 8 subagent reviews); all critical + high-impact findings fixed; info-level findings triaged and filed for follow-up where appropriate
- [ ] `test-v2-live-api` CI job exercises the delayed-MariaDB race path
- [ ] `test-v1-live-api` CI job exercises the V1 delayed-MariaDB race path and verifies V1 mirror record landing

## Context

- Observer impact analysis: [agent transcript](5d4ff1a7-4d1a-4b68-b5c4-e3c4a86ec5bc)
- Related fixes already on `v2-rc2`: `c0eb64fb` (handle MySQL mirror connection failure gracefully in v1 prepareDb). This PR's reconnect logic supersedes the `"will be retried by safeMirrorDbHandler"` assumption in that commit's message — retries now actually work because models are initialised independently of authenticate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes V1/V2 mirror database enablement, setup/migration, and outage recovery paths, which can affect data consistency and startup behavior under partial MySQL availability.
> 
> **Overview**
> Fixes MySQL mirror startup and outage durability by **initializing mirror models eagerly** (new `initMirrorModel`/`initMirrorModelV2`) and adding **reconnect-aware recovery** in `safeMirrorDbHandler`/`safeMirrorDbHandlerV2` that retries mirror setup and runs catch-up backfills before applying new writes.
> 
> Adds/expands mirror backfill logic: V1 gains a full `backfillMirror` implementation; V2’s `backfillMirrorV2` is upgraded to keyset pagination and now also **sweeps orphan rows** to propagate deletes missed during outages, with guards/overrides for tests and consistent mirror enablement snapshots.
> 
> Hardens CI and tests around these scenarios: live-api workflows now deliberately start CADT with MariaDB down then restart it to assert recovery; new integration specs cover model-init, datetime serialization, reconnect backfill, and orphan sweep; V1 live-api runner now verifies MySQL-mirror contents and closes the mirror pool; live-api TLS helpers now honor `CERTIFICATE_FOLDER_PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfab7961faf1621e12b2c743c3f2af2bce3a8c3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->