### PR TITLE
fix: doc indent fix

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -4031,9 +4031,9 @@ Response
   "cadTrustProjectId": "9b9bb857-c71b-4649-b805-a289db27dc1c",
   "ratingType": "CCQI",
   "ratingName": "Quality Assessment Rating",
-      "ratingValue": "97",
-      "ratingLink": "https://www.example.com/rating-report",
-      "createdAt": "2022-03-11T05:17:55.427Z",
+  "ratingValue": "97",
+  "ratingLink": "https://www.example.com/rating-report",
+  "createdAt": "2022-03-11T05:17:55.427Z",
   "updatedAt": "2022-03-11T05:17:55.427Z"
 }
 ```


### PR DESCRIPTION
indent correction for v2 api doc in rating section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting fix to the `rating` GET example response; no runtime or API behavior changes.
> 
> **Overview**
> Fixes indentation in `docs/cadt_rpc_api_v2.md` so the `GET /v2/rating/{id}` response example shows `ratingValue`, `ratingLink`, and `createdAt` at the correct JSON nesting level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa723209a5c2cf28284ecf59cc17f94dd331f57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->