### PR TITLE
fix: restore cadt process name in Linux top

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import { logger } from './config/logger.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
+process.title = 'cadt';
 logger.info('CADT:server');
 
 const port = getConfig().APP.CW_PORT || 3030;


### PR DESCRIPTION
## Summary
- set `process.title` to `cadt` during server startup
- restore the expected process name in Linux tools like `top` and `ps`

## Test plan
- `eval "$(fnm env)" && node --check src/server.js`
- verified locally that a Node process reports as `cadt` after setting `process.title = 'cadt'`
- fresh-context pre-push diff review: no issues found

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single startup-time change to `process.title` that only affects how the process name appears in OS tools, not request handling or data flow.
> 
> **Overview**
> Restores the expected Linux process name by setting `process.title = 'cadt'` during server startup in `src/server.js`, so tools like `top`/`ps` show the correct label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77351e7bb5dc9a876ea8f20670a995f26bf79fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->