### PR TITLE
fix: restore cadt process name in Linux top

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ import { logger } from './config/logger.js';
 import dotenv from 'dotenv';
 
 dotenv.config({ quiet: true });
+process.title = 'cadt';
 logger.info('CADT:server');
 
 const port = getConfig().APP.CW_PORT || 3030;


### PR DESCRIPTION
## Summary
- set `process.title` to `cadt` during server startup
- restore the expected process name in Linux tools like `top` and `ps`

## Test plan
- `eval "$(fnm env)" && node --check src/server.js`
- verified earlier that a Node process reports as `cadt` after setting `process.title = 'cadt'`
- fresh-context pre-push diff review: no issues found

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single startup-time `process.title` assignment with no effect on request handling, data, or security.
> 
> **Overview**
> Restores the expected OS-level process name by setting `process.title = 'cadt'` during server startup so Linux tools like `top`/`ps` show the correct name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a6ee919ed91cca1906b3259759efa348ea0097f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->