### PR TITLE
fix(V2): stabilize CSV batch upload and XLSX staging

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -2420,7 +2420,7 @@ CSV batch upload is for **flat parent records only** — each row represents one
 
 CSV headers may use either camelCase attribute names (e.g., `cadTrustProjectId`) or snake_case DB column names (e.g., `cad_trust_project_id`).
 
-**Update behavior**: When a row includes a `cadTrustProjectId` that matches an existing project, the CSV row is **merged** with the existing DB record — fields present in the CSV overwrite the existing values; fields absent from the CSV retain their current values. This differs from the REST `PUT` endpoint, which requires all fields.
+**Update behavior**: When a row includes a `cadTrustProjectId` that matches an existing project, the CSV row is **merged** with the latest pending state for that project — existing DB values plus any already-staged uncommitted edits for the same project. Fields present in the CSV overwrite that merged state; fields absent from the CSV retain their current values. This differs from the REST `PUT` endpoint, which requires all fields.
 
 **Validation**: INSERT rows are validated for required fields (`projectRegistryName`, `projectId`, `projectName`) and foreign key existence (`cadTrustProgramId` must reference an existing or staged program). UPDATE rows skip required-field checks since missing fields are merged from the existing record. Rows that fail validation are skipped and their errors are returned in the response with row numbers. The CSV validation is intentionally more lenient than the REST API — fields like `projectLink` and `projectStatusDate` that are required in the REST schema are optional in CSV batch upload. If **all** rows fail validation, the response returns HTTP 400 with `success: false`.
 
@@ -2480,6 +2480,10 @@ Response (failure — no rows staged, HTTP 400)
   ]
 }
 ```
+
+Other 400 responses:
+- Missing file upload: `{ "message": "Cannot find the required csv file in request", "success": false }`
+- Parser/runtime failure: `{ "message": "Batch Upload Failed.", "error": "<details>", "success": false }`
 
 ---
 
@@ -2592,7 +2596,7 @@ curl --location -g --request DELETE 'http://localhost:31310/v2/project/693d37f6-
 Response
 ```json
 {
-  "message": "Project deletion staged successfully",
+  "message": "Project delete staged successfully",
   "success": true
 }
 ```
@@ -3732,9 +3736,9 @@ CSV batch upload is for **flat parent records only** — each row represents one
 
 CSV headers may use either camelCase attribute names (e.g., `cadTrustUnitId`) or snake_case DB column names (e.g., `cad_trust_unit_id`).
 
-**Update behavior**: When a row includes a `cadTrustUnitId` that matches an existing unit, the CSV row is **merged** with the existing DB record — fields present in the CSV overwrite the existing values; fields absent from the CSV retain their current values. This differs from the REST `PUT` endpoint, which requires all fields.
+**Update behavior**: When a row includes a `cadTrustUnitId` that matches an existing unit, the CSV row is **merged** with the latest pending state for that unit — existing DB values plus any already-staged uncommitted edits for the same unit. Fields present in the CSV overwrite that merged state; fields absent from the CSV retain their current values. This differs from the REST `PUT` endpoint, which requires all fields.
 
-**Serial ID derivation**: If `unitSerialId` is not provided but `unitStartBlock` and `unitEndBlock` are, the serial ID is automatically derived as `<unitStartBlock>-<unitEndBlock>`.
+**Serial ID derivation**: If `unitSerialId` is not provided but `unitStartBlock` and `unitEndBlock` are, the serial ID is automatically derived as `<unitStartBlock>-<unitEndBlock>`. This also applies to UPDATE rows after merge: if you change one block boundary and omit `unitSerialId`, the serial ID is recomputed from the merged start/end block values.
 
 **Validation**: INSERT rows are validated for required fields (`unitStartBlock`, `unitEndBlock`, `unitVintageYear`, `cadTrustIssuanceId`) and foreign key existence (`cadTrustIssuanceId` must reference an existing or staged issuance). `unitSerialId` is not required if `unitStartBlock` and `unitEndBlock` are provided (it is derived automatically). UPDATE rows skip required-field checks since missing fields are merged from the existing record. Rows that fail validation are skipped and their errors are returned in the response with row numbers. If **all** rows fail validation, the response returns HTTP 400 with `success: false`.
 
@@ -3780,6 +3784,10 @@ Response (failure — no rows staged, HTTP 400)
   ]
 }
 ```
+
+Other 400 responses:
+- Missing file upload: `{ "message": "Cannot find the required csv file", "success": false }`
+- Parser/runtime failure: `{ "message": "Batch Upload Failed.", "error": "<details>", "success": false }`
 
 ---
 
@@ -3870,7 +3878,7 @@ curl --location -g --request DELETE 'localhost:31310/v2/unit/104b082c-b112-4c39-
 Response
 ```json
 {
-  "message": "Unit deletion staged successfully",
+  "message": "Unit delete staged successfully",
   "success": true
 }
 ```

--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -2416,6 +2416,16 @@ Response
 
 #### Batch upload projects from CSV
 
+CSV batch upload is for **flat parent records only** — each row represents one project. Child records (locations, estimations, ratings, co-benefits, validations, verifications, etc.) must be created via their own REST endpoints or via the [XLSX multi-sheet import](#update-projects-from-xlsx-file) workflow. Unrecognized columns (including child entity names like `locations` or `estimations`) are silently stripped.
+
+CSV headers may use either camelCase attribute names (e.g., `cadTrustProjectId`) or snake_case DB column names (e.g., `cad_trust_project_id`).
+
+**Update behavior**: When a row includes a `cadTrustProjectId` that matches an existing project, the CSV row is **merged** with the existing DB record — fields present in the CSV overwrite the existing values; fields absent from the CSV retain their current values. This differs from the REST `PUT` endpoint, which requires all fields.
+
+**Validation**: Rows are validated for foreign key existence (`cadTrustProgramId` must reference an existing program or a staged program record). Rows that fail validation are skipped and their errors are returned in the response. The CSV validation is intentionally more lenient than the REST API — fields like `projectLink` and `projectStatusDate` that are required in the REST schema are optional in CSV batch upload.
+
+**Ownership**: UPDATE rows are verified to belong to the home organization. Attempting to update a project owned by another organization will produce an error for that row.
+
 **Array Field Formatting**: For array fields like `projectType` and `projectSector`, the CSV can use any of these formats:
 - **Single value**: `Solar` → becomes `["Solar"]`
 - **JSON array**: `["Solar","Wind"]` → becomes `["Solar","Wind"]`
@@ -2434,11 +2444,22 @@ Request
 curl --location --request POST 'http://localhost:31310/v2/project/batch' --form 'csv=@"./createProject.csv"'
 ```
 
-Response
+Response (success, no row-level errors)
 ```json
 {
-  "message":"CSV processing complete, your records have been added to the staging table.",
+  "message": "CSV processing complete, your records have been added to the staging table.",
   "success": true
+}
+```
+
+Response (success with row-level errors — valid rows are still staged)
+```json
+{
+  "message": "CSV processing complete, your records have been added to the staging table.",
+  "success": true,
+  "errors": [
+    { "row": 3, "error": "cadTrustProgramId 'invalid-id' does not exist" }
+  ]
 }
 ```
 
@@ -3689,16 +3710,39 @@ Response
 
 #### Batch upload units from CSV
 
+CSV batch upload is for **flat parent records only** — each row represents one unit. Child records (unit labels, etc.) must be created via their own REST endpoints or via the [XLSX multi-sheet import](#update-units-from-xlsx-file) workflow. Unrecognized columns are silently stripped.
+
+CSV headers may use either camelCase attribute names (e.g., `cadTrustUnitId`) or snake_case DB column names (e.g., `cad_trust_unit_id`).
+
+**Update behavior**: When a row includes a `cadTrustUnitId` that matches an existing unit, the CSV row is **merged** with the existing DB record — fields present in the CSV overwrite the existing values; fields absent from the CSV retain their current values. This differs from the REST `PUT` endpoint, which requires all fields.
+
+**Serial ID derivation**: If `unitSerialId` is not provided but `unitStartBlock` and `unitEndBlock` are, the serial ID is automatically derived as `<unitStartBlock>-<unitEndBlock>`.
+
+**Validation**: Rows are validated for foreign key existence (`cadTrustIssuanceId` must reference an existing issuance or a staged issuance record). Rows that fail validation are skipped and their errors are returned in the response.
+
+**Ownership**: UPDATE rows are verified to belong to the home organization. Attempting to update a unit owned by another organization will produce an error for that row.
+
 Request
 ```shell
 curl --location --request POST 'http://localhost:31310/v2/unit/batch' --form 'csv=@"./createUnit.csv"'
 ```
 
-Response
+Response (success, no row-level errors)
 ```json
 {
-  "message":"CSV processing complete, your records have been added to the staging table.",
+  "message": "CSV processing complete, your records have been added to the staging table.",
   "success": true
+}
+```
+
+Response (success with row-level errors — valid rows are still staged)
+```json
+{
+  "message": "CSV processing complete, your records have been added to the staging table.",
+  "success": true,
+  "errors": [
+    { "row": 4, "error": "cadTrustIssuanceId 'invalid-id' does not exist" }
+  ]
 }
 ```
 

--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -2422,7 +2422,7 @@ CSV headers may use either camelCase attribute names (e.g., `cadTrustProjectId`)
 
 **Update behavior**: When a row includes a `cadTrustProjectId` that matches an existing project, the CSV row is **merged** with the existing DB record — fields present in the CSV overwrite the existing values; fields absent from the CSV retain their current values. This differs from the REST `PUT` endpoint, which requires all fields.
 
-**Validation**: Rows are validated for foreign key existence (`cadTrustProgramId` must reference an existing program or a staged program record). Rows that fail validation are skipped and their errors are returned in the response. The CSV validation is intentionally more lenient than the REST API — fields like `projectLink` and `projectStatusDate` that are required in the REST schema are optional in CSV batch upload.
+**Validation**: INSERT rows are validated for required fields (`projectRegistryName`, `projectId`, `projectName`) and foreign key existence (`cadTrustProgramId` must reference an existing or staged program). UPDATE rows skip required-field checks since missing fields are merged from the existing record. Rows that fail validation are skipped and their errors are returned in the response with row numbers. The CSV validation is intentionally more lenient than the REST API — fields like `projectLink` and `projectStatusDate` that are required in the REST schema are optional in CSV batch upload. If **all** rows fail validation, the response returns HTTP 400 with `success: false`.
 
 **Ownership**: UPDATE rows are verified to belong to the home organization. Attempting to update a project owned by another organization will produce an error for that row.
 
@@ -2444,20 +2444,38 @@ Request
 curl --location --request POST 'http://localhost:31310/v2/project/batch' --form 'csv=@"./createProject.csv"'
 ```
 
-Response (success, no row-level errors)
-```json
-{
-  "message": "CSV processing complete, your records have been added to the staging table.",
-  "success": true
-}
-```
-
-Response (success with row-level errors — valid rows are still staged)
+Response (full success — all rows staged)
 ```json
 {
   "message": "CSV processing complete, your records have been added to the staging table.",
   "success": true,
+  "stagedCount": 3,
+  "errorCount": 0
+}
+```
+
+Response (partial success — some rows staged, some failed)
+```json
+{
+  "message": "CSV processing complete. 2 row(s) staged, 1 row(s) skipped due to errors.",
+  "success": true,
+  "stagedCount": 2,
+  "errorCount": 1,
   "errors": [
+    { "row": 3, "error": "cadTrustProgramId 'invalid-id' does not exist" }
+  ]
+}
+```
+
+Response (failure — no rows staged, HTTP 400)
+```json
+{
+  "message": "No rows were staged. All rows failed validation.",
+  "success": false,
+  "stagedCount": 0,
+  "errorCount": 2,
+  "errors": [
+    { "row": 2, "error": "Missing required field(s): projectName" },
     { "row": 3, "error": "cadTrustProgramId 'invalid-id' does not exist" }
   ]
 }
@@ -3718,7 +3736,7 @@ CSV headers may use either camelCase attribute names (e.g., `cadTrustUnitId`) or
 
 **Serial ID derivation**: If `unitSerialId` is not provided but `unitStartBlock` and `unitEndBlock` are, the serial ID is automatically derived as `<unitStartBlock>-<unitEndBlock>`.
 
-**Validation**: Rows are validated for foreign key existence (`cadTrustIssuanceId` must reference an existing issuance or a staged issuance record). Rows that fail validation are skipped and their errors are returned in the response.
+**Validation**: INSERT rows are validated for required fields (`unitStartBlock`, `unitEndBlock`, `unitVintageYear`, `cadTrustIssuanceId`) and foreign key existence (`cadTrustIssuanceId` must reference an existing or staged issuance). `unitSerialId` is not required if `unitStartBlock` and `unitEndBlock` are provided (it is derived automatically). UPDATE rows skip required-field checks since missing fields are merged from the existing record. Rows that fail validation are skipped and their errors are returned in the response with row numbers. If **all** rows fail validation, the response returns HTTP 400 with `success: false`.
 
 **Ownership**: UPDATE rows are verified to belong to the home organization. Attempting to update a unit owned by another organization will produce an error for that row.
 
@@ -3727,21 +3745,38 @@ Request
 curl --location --request POST 'http://localhost:31310/v2/unit/batch' --form 'csv=@"./createUnit.csv"'
 ```
 
-Response (success, no row-level errors)
-```json
-{
-  "message": "CSV processing complete, your records have been added to the staging table.",
-  "success": true
-}
-```
-
-Response (success with row-level errors — valid rows are still staged)
+Response (full success — all rows staged)
 ```json
 {
   "message": "CSV processing complete, your records have been added to the staging table.",
   "success": true,
+  "stagedCount": 3,
+  "errorCount": 0
+}
+```
+
+Response (partial success — some rows staged, some failed)
+```json
+{
+  "message": "CSV processing complete. 2 row(s) staged, 1 row(s) skipped due to errors.",
+  "success": true,
+  "stagedCount": 2,
+  "errorCount": 1,
   "errors": [
     { "row": 4, "error": "cadTrustIssuanceId 'invalid-id' does not exist" }
+  ]
+}
+```
+
+Response (failure — no rows staged, HTTP 400)
+```json
+{
+  "message": "No rows were staged. All rows failed validation.",
+  "success": false,
+  "stagedCount": 0,
+  "errorCount": 1,
+  "errors": [
+    { "row": 2, "error": "Missing required field(s): unitStartBlock, unitEndBlock" }
   ]
 }
 ```

--- a/src/controllers/v2/project-v2.controller.js
+++ b/src/controllers/v2/project-v2.controller.js
@@ -958,14 +958,19 @@ export const batchUpload = async (req, res) => {
       });
     }
 
-    // Use the model's batchUpload method
-    await ProjectV2.batchUpload({ data: req.file.buffer });
+    const result = await ProjectV2.batchUpload({ data: req.file.buffer });
 
-    res.json({
+    const response = {
       message:
         'CSV processing complete, your records have been added to the staging table.',
       success: true,
-    });
+    };
+
+    if (result.errors && result.errors.length > 0) {
+      response.errors = result.errors;
+    }
+
+    res.json(response);
   } catch (error) {
     loggerV2.error('[v2]: Batch Upload Failed.', error);
     res.status(400).json({

--- a/src/controllers/v2/project-v2.controller.js
+++ b/src/controllers/v2/project-v2.controller.js
@@ -961,13 +961,25 @@ export const batchUpload = async (req, res) => {
     const result = await ProjectV2.batchUpload({ data: req.file.buffer });
 
     const response = {
-      message:
-        'CSV processing complete, your records have been added to the staging table.',
-      success: true,
+      stagedCount: result.stagedCount,
+      errorCount: result.errorCount,
     };
 
-    if (result.errors && result.errors.length > 0) {
+    if (result.errorCount > 0) {
       response.errors = result.errors;
+    }
+
+    if (result.stagedCount === 0) {
+      response.success = false;
+      response.message = 'No rows were staged. All rows failed validation.';
+      return res.status(400).json(response);
+    }
+
+    response.success = true;
+    if (result.errorCount > 0) {
+      response.message = `CSV processing complete. ${result.stagedCount} row(s) staged, ${result.errorCount} row(s) skipped due to errors.`;
+    } else {
+      response.message = 'CSV processing complete, your records have been added to the staging table.';
     }
 
     res.json(response);

--- a/src/controllers/v2/unit-v2.controller.js
+++ b/src/controllers/v2/unit-v2.controller.js
@@ -938,14 +938,19 @@ export const batchUpload = async (req, res) => {
       });
     }
 
-    // Use the model's batchUpload method
-    await UnitV2.batchUpload({ data: req.file.buffer });
+    const result = await UnitV2.batchUpload({ data: req.file.buffer });
 
-    res.json({
+    const response = {
       message:
         'CSV processing complete, your records have been added to the staging table.',
       success: true,
-    });
+    };
+
+    if (result.errors && result.errors.length > 0) {
+      response.errors = result.errors;
+    }
+
+    res.json(response);
   } catch (error) {
     loggerV2.error('[v2]: Batch Upload Failed.', error);
     res.status(400).json({

--- a/src/controllers/v2/unit-v2.controller.js
+++ b/src/controllers/v2/unit-v2.controller.js
@@ -941,13 +941,25 @@ export const batchUpload = async (req, res) => {
     const result = await UnitV2.batchUpload({ data: req.file.buffer });
 
     const response = {
-      message:
-        'CSV processing complete, your records have been added to the staging table.',
-      success: true,
+      stagedCount: result.stagedCount,
+      errorCount: result.errorCount,
     };
 
-    if (result.errors && result.errors.length > 0) {
+    if (result.errorCount > 0) {
       response.errors = result.errors;
+    }
+
+    if (result.stagedCount === 0) {
+      response.success = false;
+      response.message = 'No rows were staged. All rows failed validation.';
+      return res.status(400).json(response);
+    }
+
+    response.success = true;
+    if (result.errorCount > 0) {
+      response.message = `CSV processing complete. ${result.stagedCount} row(s) staged, ${result.errorCount} row(s) skipped due to errors.`;
+    } else {
+      response.message = 'CSV processing complete, your records have been added to the staging table.';
     }
 
     res.json(response);

--- a/src/models/v2/project-v2.model.js
+++ b/src/models/v2/project-v2.model.js
@@ -16,6 +16,7 @@ import {
   normalizeCsvHeaders,
   toDbFieldNames,
   stripUnknownDbFields,
+  validateRequiredFields,
 } from '../../utils/v2-xls.js';
 import { assertRecordExistanceOrStaged } from '../../utils/v2-data-assertions.js';
 import { ProgramV2 } from './program-v2.model.js';
@@ -373,7 +374,7 @@ class ProjectV2 extends Model {
    *   6. Upsert into StagingV2
    *
    * @param {Object} csvFile - CSV file object with data buffer
-   * @returns {Promise<Object>} Result with errors array (may be empty)
+   * @returns {Promise<Object>} { stagedCount, errorCount, errors }
    */
   static async batchUpload(csvFile) {
     const buffer = csvFile.data;
@@ -402,6 +403,7 @@ class ProjectV2 extends Model {
     const orgUid = homeOrg.org_uid;
 
     const errors = [];
+    let stagedCount = 0;
 
     await sequelizeV2.transaction(async (transaction) => {
       for (let i = 0; i < rawRows.length; i++) {
@@ -431,6 +433,15 @@ class ProjectV2 extends Model {
             row.cadTrustProjectId = uuidv4();
             action = 'INSERT';
             mergedRecord = { ...row };
+          }
+
+          // Required-field validation for INSERT rows
+          if (action === 'INSERT') {
+            const missing = validateRequiredFields(mergedRecord, ProjectV2);
+            if (missing.length > 0) {
+              errors.push({ row: rowNum, error: `Missing required field(s): ${missing.join(', ')}` });
+              continue;
+            }
           }
 
           // FK existence check for cadTrustProgramId
@@ -467,13 +478,14 @@ class ProjectV2 extends Model {
             },
             { transaction },
           );
+          stagedCount++;
         } catch (err) {
           errors.push({ row: rowNum, error: err.message });
         }
       }
     });
 
-    return { errors };
+    return { stagedCount, errorCount: errors.length, errors };
   }
 
   /**

--- a/src/models/v2/project-v2.model.js
+++ b/src/models/v2/project-v2.model.js
@@ -419,15 +419,21 @@ class ProjectV2 extends Model {
           let action;
           let mergedRecord;
 
+          let pendingRows = [];
           if (projectId) {
             const existing = await ProjectV2.findByPk(projectId);
+            const mergeResult = await buildPendingCsvMergeBase(
+              ProjectV2,
+              projectId,
+              existing,
+              { transaction },
+            );
             const {
               mergedBase,
               hasPendingDelete,
               hasMultiRecordPendingRow,
-            } = await buildPendingCsvMergeBase(ProjectV2, projectId, existing, {
-              transaction,
-            });
+            } = mergeResult;
+            pendingRows = mergeResult.pendingRows;
 
             if (hasPendingDelete) {
               errors.push({
@@ -499,6 +505,7 @@ class ProjectV2 extends Model {
             action,
             cleaned,
             transaction,
+            { pendingRows },
           );
           stagedCount++;
         } catch (err) {

--- a/src/models/v2/project-v2.model.js
+++ b/src/models/v2/project-v2.model.js
@@ -17,6 +17,8 @@ import {
   toDbFieldNames,
   stripUnknownDbFields,
   validateRequiredFields,
+  buildPendingCsvMergeBase,
+  stageConsolidatedCsvRecord,
 } from '../../utils/v2-xls.js';
 import { assertRecordExistanceOrStaged } from '../../utils/v2-data-assertions.js';
 import { ProgramV2 } from './program-v2.model.js';
@@ -419,16 +421,38 @@ class ProjectV2 extends Model {
 
           if (projectId) {
             const existing = await ProjectV2.findByPk(projectId);
-            if (!existing) {
+            const {
+              mergedBase,
+              hasPendingDelete,
+              hasMultiRecordPendingRow,
+            } = await buildPendingCsvMergeBase(ProjectV2, projectId, existing, {
+              transaction,
+            });
+
+            if (hasPendingDelete) {
+              errors.push({
+                row: rowNum,
+                error: `Cannot update project ${projectId}: it already has a pending staged delete`,
+              });
+              continue;
+            }
+            if (hasMultiRecordPendingRow) {
+              errors.push({
+                row: rowNum,
+                error: `Cannot update project ${projectId}: it already has a complex pending staged update`,
+              });
+              continue;
+            }
+            if (!existing && Object.keys(mergedBase).length === 0) {
               errors.push({ row: rowNum, error: `Project with cadTrustProjectId ${projectId} does not exist` });
               continue;
             }
-            if (existing.orgUid !== orgUid) {
+            if (mergedBase.orgUid !== orgUid) {
               errors.push({ row: rowNum, error: `Cannot update project ${projectId}: belongs to a different organization` });
               continue;
             }
-            action = 'UPDATE';
-            mergedRecord = { ...existing.toJSON(), ...row };
+            action = existing ? 'UPDATE' : 'INSERT';
+            mergedRecord = { ...mergedBase, ...row };
           } else {
             row.cadTrustProjectId = uuidv4();
             action = 'INSERT';
@@ -469,14 +493,12 @@ class ProjectV2 extends Model {
 
           cleaned.org_uid = orgUid;
 
-          await StagingV2.upsert(
-            {
-              uuid: mergedRecord.cadTrustProjectId,
-              action,
-              table: 'project',
-              data: JSON.stringify([cleaned]),
-            },
-            { transaction },
+          await stageConsolidatedCsvRecord(
+            ProjectV2,
+            mergedRecord.cadTrustProjectId,
+            action,
+            cleaned,
+            transaction,
           );
           stagedCount++;
         } catch (err) {

--- a/src/models/v2/project-v2.model.js
+++ b/src/models/v2/project-v2.model.js
@@ -10,7 +10,15 @@ import {
   createXlsFromSequelizeResults,
   transformFullXslsToChangeList,
 } from '../../utils/xls.js';
-import { parseV2Xlsx, stageV2XlsRecords } from '../../utils/v2-xls.js';
+import {
+  parseV2Xlsx,
+  stageV2XlsRecords,
+  normalizeCsvHeaders,
+  toDbFieldNames,
+  stripUnknownDbFields,
+} from '../../utils/v2-xls.js';
+import { assertRecordExistanceOrStaged } from '../../utils/v2-data-assertions.js';
+import { ProgramV2 } from './program-v2.model.js';
 import { getDeletedItems } from '../../utils/model-utils.js';
 import { keyValueToChangeList } from '../../utils/datalayer-utils.js';
 import { LocationV2 } from './location-v2.model.js';
@@ -353,92 +361,128 @@ class ProjectV2 extends Model {
   }
 
   /**
-   * Batch upload projects from CSV file
-   * Parses CSV and creates staging records
+   * Batch upload projects from CSV file.
+   *
+   * Collects all CSV rows synchronously, then processes each row sequentially
+   * inside a transaction.  For each row the pipeline is:
+   *   1. Normalize snake_case headers → camelCase attribute names
+   *   2. Parse array fields (projectType / projectSector)
+   *   3. Determine INSERT vs UPDATE, merge with existing record on UPDATE
+   *   4. Validate ownership and FK references
+   *   5. Convert to DB field names, strip unknown keys
+   *   6. Upsert into StagingV2
+   *
    * @param {Object} csvFile - CSV file object with data buffer
-   * @returns {Promise<void>}
-   * @throws {Error} If CSV parsing or staging fails
+   * @returns {Promise<Object>} Result with errors array (may be empty)
    */
   static async batchUpload(csvFile) {
     const buffer = csvFile.data;
     const stream = Readable.from(buffer.toString('utf8'));
 
-    const recordsToCreate = [];
+    const rawRows = [];
 
-    return new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
       csv()
         .fromStream(stream)
-        .subscribe(async (newRecord) => {
-          let action = 'UPDATE';
+        .subscribe((row) => {
+          rawRows.push(row);
+        })
+        .on('error', (error) => reject(error))
+        .on('done', () => resolve());
+    });
 
-          // Convert camelCase to snake_case for V2
-          const projectId = newRecord.cadTrustProjectId || newRecord.cad_trust_project_id;
+    if (rawRows.length === 0) {
+      throw new Error('There were no valid records to parse');
+    }
+
+    const homeOrg = await OrganizationsV2.getHomeOrg();
+    if (!homeOrg) {
+      throw new Error('No home organization found');
+    }
+    const orgUid = homeOrg.org_uid;
+
+    const errors = [];
+
+    await sequelizeV2.transaction(async (transaction) => {
+      for (let i = 0; i < rawRows.length; i++) {
+        const rowNum = i + 2; // +2: 1-indexed + header row
+        try {
+          let row = normalizeCsvHeaders(rawRows[i], ProjectV2);
+
+          ProjectV2.parseProjectArrayFields(row);
+
+          const projectId = row.cadTrustProjectId;
+          let action;
+          let mergedRecord;
 
           if (projectId) {
-            // Check if project exists
-            const possibleExistingRecord = await ProjectV2.findByPk(projectId);
-
-            if (!possibleExistingRecord) {
-              reject(
-                new Error(
-                  `Project with cadTrustProjectId ${projectId} does not exist`,
-                ),
-              );
-              return;
+            const existing = await ProjectV2.findByPk(projectId);
+            if (!existing) {
+              errors.push({ row: rowNum, error: `Project with cadTrustProjectId ${projectId} does not exist` });
+              continue;
             }
-
-            // Verify it belongs to home org (for updates)
-            const homeOrg = await OrganizationsV2.getHomeOrg();
-            if (!homeOrg) {
-              reject(new Error('No home organization found'));
-              return;
+            if (existing.orgUid !== orgUid) {
+              errors.push({ row: rowNum, error: `Cannot update project ${projectId}: belongs to a different organization` });
+              continue;
             }
+            action = 'UPDATE';
+            mergedRecord = { ...existing.toJSON(), ...row };
           } else {
-            // New project - generate UUID
-            newRecord.cadTrustProjectId = uuidv4();
-            const homeOrg = await OrganizationsV2.getHomeOrg();
-            if (!homeOrg) {
-              reject(new Error('No home organization found'));
-              return;
-            }
+            row.cadTrustProjectId = uuidv4();
             action = 'INSERT';
+            mergedRecord = { ...row };
           }
 
-          // Update project properties (handle child records)
-          ProjectV2.updateProjectPropertiesV2(newRecord);
-
-          const stagedData = {
-            uuid: newRecord.cadTrustProjectId,
-            action: action,
-            table: 'project',
-            data: JSON.stringify([newRecord]),
-          };
-
-          recordsToCreate.push(stagedData);
-        })
-        .on('error', (error) => {
-          reject(error);
-        })
-        .on('done', async () => {
-          if (recordsToCreate.length) {
-            await StagingV2.bulkCreate(recordsToCreate, {
-              logging: (msg) => loggerV2.info(msg),
-            });
-
-            resolve();
-          } else {
-            reject(new Error('There were no valid records to parse'));
+          // FK existence check for cadTrustProgramId
+          if (mergedRecord.cadTrustProgramId) {
+            try {
+              await assertRecordExistanceOrStaged(
+                ProgramV2,
+                mergedRecord.cadTrustProgramId,
+                `cadTrustProgramId '${mergedRecord.cadTrustProgramId}' does not exist`,
+              );
+            } catch (err) {
+              errors.push({ row: rowNum, error: err.message });
+              continue;
+            }
           }
-        });
+
+          // Remove timestamps (managed by Sequelize)
+          delete mergedRecord.createdAt;
+          delete mergedRecord.updatedAt;
+          delete mergedRecord.created_at;
+          delete mergedRecord.updated_at;
+
+          const dbRecord = toDbFieldNames(mergedRecord, ProjectV2);
+          const cleaned = stripUnknownDbFields(dbRecord, ProjectV2, loggerV2);
+
+          cleaned.org_uid = orgUid;
+
+          await StagingV2.upsert(
+            {
+              uuid: mergedRecord.cadTrustProjectId,
+              action,
+              table: 'project',
+              data: JSON.stringify([cleaned]),
+            },
+            { transaction },
+          );
+        } catch (err) {
+          errors.push({ row: rowNum, error: err.message });
+        }
+      }
     });
+
+    return { errors };
   }
 
   /**
-   * Helper to update project properties from CSV
-   * Handles conversion of string fields to arrays for batch upload
+   * Parse projectType and projectSector from CSV string representations
+   * into arrays.  These are JSON array columns on the project table, not
+   * child entities — they belong in the flat CSV row.
    * @private
    */
-  static updateProjectPropertiesV2(project) {
+  static parseProjectArrayFields(project) {
     if (typeof project !== 'object') return;
 
     const arrayFields = ['projectType', 'projectSector'];
@@ -467,25 +511,6 @@ class ProjectV2 extends Model {
         } else if (!Array.isArray(project[key])) {
           project[key] = [project[key]];
         }
-      }
-    });
-
-    const childRecordKeys = ['locations', 'estimations', 'ratings', 'coBenefits'];
-    childRecordKeys.forEach((key) => {
-      if (project[key] && typeof project[key] === 'string') {
-        try {
-          project[key] = JSON.parse(project[key]);
-        } catch {
-          // If not JSON, leave as is
-        }
-      }
-
-      if (Array.isArray(project[key])) {
-        project[key].forEach((item) => {
-          if (!item.cadTrustProjectId) {
-            item.cadTrustProjectId = project.cadTrustProjectId;
-          }
-        });
       }
     });
   }

--- a/src/models/v2/unit-v2.model.js
+++ b/src/models/v2/unit-v2.model.js
@@ -484,15 +484,21 @@ class UnitV2 extends Model {
           let action;
           let mergedRecord;
 
+          let pendingRows = [];
           if (unitId) {
             const existing = await UnitV2.findByPk(unitId);
+            const mergeResult = await buildPendingCsvMergeBase(
+              UnitV2,
+              unitId,
+              existing,
+              { transaction },
+            );
             const {
               mergedBase,
               hasPendingDelete,
               hasMultiRecordPendingRow,
-            } = await buildPendingCsvMergeBase(UnitV2, unitId, existing, {
-              transaction,
-            });
+            } = mergeResult;
+            pendingRows = mergeResult.pendingRows;
 
             if (hasPendingDelete) {
               errors.push({
@@ -572,6 +578,7 @@ class UnitV2 extends Model {
             action,
             cleaned,
             transaction,
+            { pendingRows },
           );
           stagedCount++;
         } catch (err) {

--- a/src/models/v2/unit-v2.model.js
+++ b/src/models/v2/unit-v2.model.js
@@ -21,6 +21,8 @@ import {
   toDbFieldNames,
   stripUnknownDbFields,
   validateRequiredFields,
+  buildPendingCsvMergeBase,
+  stageConsolidatedCsvRecord,
 } from '../../utils/v2-xls.js';
 import { assertRecordExistanceOrStaged } from '../../utils/v2-data-assertions.js';
 import { IssuanceV2 } from './issuance-v2.model.js';
@@ -484,16 +486,46 @@ class UnitV2 extends Model {
 
           if (unitId) {
             const existing = await UnitV2.findByPk(unitId);
-            if (!existing) {
+            const {
+              mergedBase,
+              hasPendingDelete,
+              hasMultiRecordPendingRow,
+            } = await buildPendingCsvMergeBase(UnitV2, unitId, existing, {
+              transaction,
+            });
+
+            if (hasPendingDelete) {
+              errors.push({
+                row: rowNum,
+                error: `Cannot update unit ${unitId}: it already has a pending staged delete`,
+              });
+              continue;
+            }
+            if (hasMultiRecordPendingRow) {
+              errors.push({
+                row: rowNum,
+                error: `Cannot update unit ${unitId}: it already has a complex pending staged update`,
+              });
+              continue;
+            }
+            if (!existing && Object.keys(mergedBase).length === 0) {
               errors.push({ row: rowNum, error: `Unit with cadTrustUnitId ${unitId} does not exist` });
               continue;
             }
-            if (existing.orgUid !== orgUid) {
+            if (mergedBase.orgUid !== orgUid) {
               errors.push({ row: rowNum, error: `Cannot update unit ${unitId}: belongs to a different organization` });
               continue;
             }
-            action = 'UPDATE';
-            mergedRecord = { ...existing.toJSON(), ...row };
+            action = existing ? 'UPDATE' : 'INSERT';
+            mergedRecord = { ...mergedBase, ...row };
+
+            const changedBlockRange =
+              !row.unitSerialId &&
+              (row.unitStartBlock !== undefined || row.unitEndBlock !== undefined);
+            if (changedBlockRange) {
+              delete mergedRecord.unitSerialId;
+              UnitV2.prepareXlsRow(mergedRecord);
+            }
           } else {
             row.cadTrustUnitId = uuidv4();
             action = 'INSERT';
@@ -534,14 +566,12 @@ class UnitV2 extends Model {
 
           cleaned.org_uid = orgUid;
 
-          await StagingV2.upsert(
-            {
-              uuid: mergedRecord.cadTrustUnitId,
-              action,
-              table: 'unit',
-              data: JSON.stringify([cleaned]),
-            },
-            { transaction },
+          await stageConsolidatedCsvRecord(
+            UnitV2,
+            mergedRecord.cadTrustUnitId,
+            action,
+            cleaned,
+            transaction,
           );
           stagedCount++;
         } catch (err) {

--- a/src/models/v2/unit-v2.model.js
+++ b/src/models/v2/unit-v2.model.js
@@ -20,6 +20,7 @@ import {
   normalizeCsvHeaders,
   toDbFieldNames,
   stripUnknownDbFields,
+  validateRequiredFields,
 } from '../../utils/v2-xls.js';
 import { assertRecordExistanceOrStaged } from '../../utils/v2-data-assertions.js';
 import { IssuanceV2 } from './issuance-v2.model.js';
@@ -434,7 +435,7 @@ class UnitV2 extends Model {
    *   6. Upsert into StagingV2
    *
    * @param {Object} csvFile - CSV file object with data buffer
-   * @returns {Promise<Object>} Result with errors array (may be empty)
+   * @returns {Promise<Object>} { stagedCount, errorCount, errors }
    */
   static async batchUpload(csvFile) {
     const buffer = csvFile.data;
@@ -463,6 +464,10 @@ class UnitV2 extends Model {
     const orgUid = homeOrg.org_uid;
 
     const errors = [];
+    let stagedCount = 0;
+
+    // unitSerialId is derivable from blocks — don't require it if blocks are present
+    const unitSkipFields = new Set(['unitSerialId']);
 
     await sequelizeV2.transaction(async (transaction) => {
       for (let i = 0; i < rawRows.length; i++) {
@@ -493,6 +498,15 @@ class UnitV2 extends Model {
             row.cadTrustUnitId = uuidv4();
             action = 'INSERT';
             mergedRecord = { ...row };
+          }
+
+          // Required-field validation for INSERT rows
+          if (action === 'INSERT') {
+            const missing = validateRequiredFields(mergedRecord, UnitV2, unitSkipFields);
+            if (missing.length > 0) {
+              errors.push({ row: rowNum, error: `Missing required field(s): ${missing.join(', ')}` });
+              continue;
+            }
           }
 
           // FK existence check for cadTrustIssuanceId
@@ -529,13 +543,14 @@ class UnitV2 extends Model {
             },
             { transaction },
           );
+          stagedCount++;
         } catch (err) {
           errors.push({ row: rowNum, error: err.message });
         }
       }
     });
 
-    return { errors };
+    return { stagedCount, errorCount: errors.length, errors };
   }
 
 

--- a/src/models/v2/unit-v2.model.js
+++ b/src/models/v2/unit-v2.model.js
@@ -14,7 +14,15 @@ import {
   createXlsFromSequelizeResults,
   transformFullXslsToChangeList,
 } from '../../utils/xls.js';
-import { parseV2Xlsx, stageV2XlsRecords } from '../../utils/v2-xls.js';
+import {
+  parseV2Xlsx,
+  stageV2XlsRecords,
+  normalizeCsvHeaders,
+  toDbFieldNames,
+  stripUnknownDbFields,
+} from '../../utils/v2-xls.js';
+import { assertRecordExistanceOrStaged } from '../../utils/v2-data-assertions.js';
+import { IssuanceV2 } from './issuance-v2.model.js';
 import { getDeletedItems } from '../../utils/model-utils.js';
 import { UnitLabelV2 } from './unit-label-v2.model.js';
 import { loggerV2 } from '../../config/logger.js';
@@ -414,86 +422,120 @@ class UnitV2 extends Model {
   }
 
   /**
-   * Batch upload units from CSV file
-   * Parses CSV and creates staging records
+   * Batch upload units from CSV file.
+   *
+   * Collects all CSV rows synchronously, then processes each row sequentially
+   * inside a transaction.  For each row the pipeline is:
+   *   1. Normalize snake_case headers → camelCase attribute names
+   *   2. Apply domain transforms (prepareXlsRow derives unitSerialId)
+   *   3. Determine INSERT vs UPDATE, merge with existing record on UPDATE
+   *   4. Validate ownership and FK references
+   *   5. Convert to DB field names, strip unknown keys
+   *   6. Upsert into StagingV2
+   *
    * @param {Object} csvFile - CSV file object with data buffer
-   * @returns {Promise<void>}
-   * @throws {Error} If CSV parsing or staging fails
+   * @returns {Promise<Object>} Result with errors array (may be empty)
    */
   static async batchUpload(csvFile) {
     const buffer = csvFile.data;
     const stream = Readable.from(buffer.toString('utf8'));
 
-    const recordsToCreate = [];
+    const rawRows = [];
 
-    return new Promise((resolve, reject) => {
+    await new Promise((resolve, reject) => {
       csv()
         .fromStream(stream)
-        .subscribe(async (newRecord) => {
-          let action = 'UPDATE';
+        .subscribe((row) => {
+          rawRows.push(row);
+        })
+        .on('error', (error) => reject(error))
+        .on('done', () => resolve());
+    });
 
-          // Convert camelCase to snake_case for V2
-          const unitId = newRecord.cadTrustUnitId || newRecord.cad_trust_unit_id;
+    if (rawRows.length === 0) {
+      throw new Error('There were no valid records to parse');
+    }
+
+    const homeOrg = await OrganizationsV2.getHomeOrg();
+    if (!homeOrg) {
+      throw new Error('No home organization found');
+    }
+    const orgUid = homeOrg.org_uid;
+
+    const errors = [];
+
+    await sequelizeV2.transaction(async (transaction) => {
+      for (let i = 0; i < rawRows.length; i++) {
+        const rowNum = i + 2; // +2: 1-indexed + header row
+        try {
+          let row = normalizeCsvHeaders(rawRows[i], UnitV2);
+
+          // Derive unitSerialId from block range when not explicitly provided
+          UnitV2.prepareXlsRow(row);
+
+          const unitId = row.cadTrustUnitId;
+          let action;
+          let mergedRecord;
 
           if (unitId) {
-            // Check if unit exists
-            const possibleExistingRecord = await UnitV2.findByPk(unitId);
-
-            if (!possibleExistingRecord) {
-              reject(
-                new Error(
-                  `Unit with cadTrustUnitId ${unitId} does not exist`,
-                ),
-              );
-              return;
+            const existing = await UnitV2.findByPk(unitId);
+            if (!existing) {
+              errors.push({ row: rowNum, error: `Unit with cadTrustUnitId ${unitId} does not exist` });
+              continue;
             }
-
-            // Verify it belongs to home org (for updates)
-            const homeOrg = await OrganizationsV2.getHomeOrg();
-            if (!homeOrg) {
-              reject(new Error('No home organization found'));
-              return;
+            if (existing.orgUid !== orgUid) {
+              errors.push({ row: rowNum, error: `Cannot update unit ${unitId}: belongs to a different organization` });
+              continue;
             }
+            action = 'UPDATE';
+            mergedRecord = { ...existing.toJSON(), ...row };
           } else {
-            // New unit - generate UUID
-            newRecord.cadTrustUnitId = uuidv4();
-            const homeOrg = await OrganizationsV2.getHomeOrg();
-            if (!homeOrg) {
-              reject(new Error('No home organization found'));
-              return;
-            }
+            row.cadTrustUnitId = uuidv4();
             action = 'INSERT';
+            mergedRecord = { ...row };
           }
 
-          // Update unit properties (handle serial ID from blocks)
-          if (newRecord.unitStartBlock && newRecord.unitEndBlock) {
-            newRecord.unitSerialId = `${newRecord.unitStartBlock}-${newRecord.unitEndBlock}`;
+          // FK existence check for cadTrustIssuanceId
+          if (mergedRecord.cadTrustIssuanceId) {
+            try {
+              await assertRecordExistanceOrStaged(
+                IssuanceV2,
+                mergedRecord.cadTrustIssuanceId,
+                `cadTrustIssuanceId '${mergedRecord.cadTrustIssuanceId}' does not exist`,
+              );
+            } catch (err) {
+              errors.push({ row: rowNum, error: err.message });
+              continue;
+            }
           }
 
-          const stagedData = {
-            uuid: newRecord.cadTrustUnitId,
-            action: action,
-            table: 'unit',
-            data: JSON.stringify([newRecord]),
-          };
+          // Remove timestamps (managed by Sequelize)
+          delete mergedRecord.createdAt;
+          delete mergedRecord.updatedAt;
+          delete mergedRecord.created_at;
+          delete mergedRecord.updated_at;
 
-          recordsToCreate.push(stagedData);
-        })
-        .on('error', (error) => {
-          reject(error);
-        })
-        .on('done', async () => {
-          if (recordsToCreate.length) {
-            await StagingV2.bulkCreate(recordsToCreate, {
-              logging: (msg) => loggerV2.info(msg),
-            });
+          const dbRecord = toDbFieldNames(mergedRecord, UnitV2);
+          const cleaned = stripUnknownDbFields(dbRecord, UnitV2, loggerV2);
 
-            resolve();
-          } else {
-            reject(new Error('There were no valid records to parse'));
-          }
-        });
+          cleaned.org_uid = orgUid;
+
+          await StagingV2.upsert(
+            {
+              uuid: mergedRecord.cadTrustUnitId,
+              action,
+              table: 'unit',
+              data: JSON.stringify([cleaned]),
+            },
+            { transaction },
+          );
+        } catch (err) {
+          errors.push({ row: rowNum, error: err.message });
+        }
+      }
     });
+
+    return { errors };
   }
 
 

--- a/src/utils/v2-xls.js
+++ b/src/utils/v2-xls.js
@@ -167,6 +167,44 @@ function parseArrayFields(row) {
 }
 
 /**
+ * Build a reverse lookup from snake_case DB field names to camelCase Sequelize
+ * attribute names for a model.  Used to normalize CSV headers that may arrive
+ * in either convention.
+ *
+ * @param {import('sequelize').Model} modelClass
+ * @returns {Map<string, string>} snake_case field -> camelCase attribute
+ */
+function buildSnakeToCamelMap(modelClass) {
+  const map = new Map();
+  for (const [attrName, meta] of Object.entries(modelClass.rawAttributes)) {
+    const dbField = meta.field || attrName;
+    if (dbField !== attrName) {
+      map.set(dbField, attrName);
+    }
+  }
+  return map;
+}
+
+/**
+ * Normalize a CSV row so that every key is a camelCase Sequelize attribute
+ * name.  Accepts headers in either camelCase or snake_case.  Keys that don't
+ * map to any known attribute are left as-is so they can be stripped later.
+ *
+ * @param {Object} row
+ * @param {import('sequelize').Model} modelClass
+ * @returns {Object} row with normalized keys
+ */
+export function normalizeCsvHeaders(row, modelClass) {
+  const snakeToCamel = buildSnakeToCamelMap(modelClass);
+  const result = {};
+  for (const [key, value] of Object.entries(row)) {
+    const normalized = snakeToCamel.get(key) || key;
+    result[normalized] = value;
+  }
+  return result;
+}
+
+/**
  * Convert a row object from camelCase attribute names to snake_case DB field
  * names using the model's rawAttributes metadata. Keys not present in
  * rawAttributes are kept as-is (they may already be snake_case or custom).
@@ -178,7 +216,7 @@ function parseArrayFields(row) {
  * staging data to use snake_case field names, matching what the normal API
  * controllers produce.
  */
-function toDbFieldNames(row, modelClass) {
+export function toDbFieldNames(row, modelClass) {
   const attrs = modelClass.rawAttributes;
   const result = {};
   for (const [key, value] of Object.entries(row)) {
@@ -186,6 +224,36 @@ function toDbFieldNames(row, modelClass) {
     result[attr && attr.field ? attr.field : key] = value;
   }
   return result;
+}
+
+/**
+ * Strip keys from a snake_case DB-field row that are not valid DB column names
+ * for the given model.  Returns a new object containing only recognized fields.
+ * Logs a warning for every stripped key so users can catch CSV header mistakes.
+ *
+ * @param {Object} dbRow - Row already converted to snake_case via toDbFieldNames
+ * @param {import('sequelize').Model} modelClass
+ * @param {import('../config/logger.js').loggerV2} [logger] - optional logger
+ * @returns {Object} cleaned row
+ */
+export function stripUnknownDbFields(dbRow, modelClass, logger = null) {
+  const validFields = new Set();
+  for (const meta of Object.values(modelClass.rawAttributes)) {
+    validFields.add(meta.field || meta.fieldName);
+  }
+  // Also accept Sequelize-managed timestamp fields
+  validFields.add('created_at');
+  validFields.add('updated_at');
+
+  const cleaned = {};
+  for (const [key, value] of Object.entries(dbRow)) {
+    if (validFields.has(key)) {
+      cleaned[key] = value;
+    } else if (logger) {
+      logger.warn(`[v2]: Stripping unknown CSV column '${key}' — not a valid DB field`);
+    }
+  }
+  return cleaned;
 }
 
 /**

--- a/src/utils/v2-xls.js
+++ b/src/utils/v2-xls.js
@@ -383,11 +383,16 @@ export async function getPendingStagedRowsForPk(
  * rows on top of the committed DB row. This lets CSV batch uploads reconcile
  * with already-staged edits instead of clobbering them.
  *
+ * Performs a single staging table scan and buckets results by action client
+ * side, then returns the INSERT/UPDATE pending rows so the caller can hand
+ * them to stageConsolidatedCsvRecord without scanning the staging table a
+ * second time.
+ *
  * @param {import('sequelize').Model} modelClass
  * @param {string} pk
  * @param {Object|null} persistedRecord - Sequelize instance or null
  * @param {{ transaction?: import('sequelize').Transaction }} [options]
- * @returns {Promise<{ mergedBase: Object, pendingRows: Array, hasPendingDelete: boolean }>}
+ * @returns {Promise<{ mergedBase: Object, pendingRows: Array, hasPendingDelete: boolean, hasMultiRecordPendingRow: boolean }>}
  */
 export async function buildPendingCsvMergeBase(
   modelClass,
@@ -395,14 +400,20 @@ export async function buildPendingCsvMergeBase(
   persistedRecord,
   { transaction } = {},
 ) {
-  const pendingDeleteRows = await getPendingStagedRowsForPk(modelClass, pk, {
+  const allPendingRows = await getPendingStagedRowsForPk(modelClass, pk, {
     transaction,
-    actions: ['DELETE'],
+    actions: ['DELETE', 'INSERT', 'UPDATE'],
   });
-  const pendingRows = await getPendingStagedRowsForPk(modelClass, pk, {
-    transaction,
-    actions: ['INSERT', 'UPDATE'],
-  });
+
+  const pendingRows = [];
+  let hasPendingDelete = false;
+  for (const entry of allPendingRows) {
+    if (entry.stagingRecord.action === 'DELETE') {
+      hasPendingDelete = true;
+    } else {
+      pendingRows.push(entry);
+    }
+  }
 
   let mergedBase = persistedRecord ? persistedRecord.toJSON() : {};
   const hasMultiRecordPendingRow = pendingRows.some(
@@ -418,7 +429,7 @@ export async function buildPendingCsvMergeBase(
   return {
     mergedBase,
     pendingRows,
-    hasPendingDelete: pendingDeleteRows.length > 0,
+    hasPendingDelete,
     hasMultiRecordPendingRow,
   };
 }
@@ -432,11 +443,16 @@ export async function buildPendingCsvMergeBase(
  * If any existing pending row is an INSERT, the consolidated row remains an
  * INSERT because the record has not been committed yet.
  *
+ * Callers that already have the pending INSERT/UPDATE rows in hand (e.g. from
+ * buildPendingCsvMergeBase during the same row of a CSV batch) may pass them
+ * via options.pendingRows to avoid re-scanning the staging table.
+ *
  * @param {import('sequelize').Model} modelClass
  * @param {string} pk
  * @param {'INSERT'|'UPDATE'} action
  * @param {Object} cleanedRecord - DB-field (snake_case) row
  * @param {import('sequelize').Transaction} transaction
+ * @param {{ pendingRows?: Array<{ stagingRecord: Object }> }} [options]
  * @returns {Promise<void>}
  */
 export async function stageConsolidatedCsvRecord(
@@ -445,26 +461,39 @@ export async function stageConsolidatedCsvRecord(
   action,
   cleanedRecord,
   transaction,
+  { pendingRows } = {},
 ) {
-  const pendingRows = await getPendingStagedRowsForPk(modelClass, pk, {
-    transaction,
-    actions: ['INSERT', 'UPDATE'],
-  });
+  // Callers pass an Array (possibly empty) when they already know the
+  // pending INSERT/UPDATE rows. Anything else — undefined/null — means
+  // "unknown, please scan". Guarding on Array.isArray avoids accidentally
+  // re-scanning when a caller explicitly passes `[]` (known-empty).
+  const resolvedPendingRows = Array.isArray(pendingRows)
+    ? pendingRows
+    : await getPendingStagedRowsForPk(modelClass, pk, {
+        transaction,
+        actions: ['INSERT', 'UPDATE'],
+      });
 
-  const effectiveAction = pendingRows.some(
+  const effectiveAction = resolvedPendingRows.some(
     ({ stagingRecord }) => stagingRecord.action === 'INSERT',
   )
     ? 'INSERT'
     : action;
 
-  if (pendingRows.length > 0) {
-    const targetRow = pendingRows[pendingRows.length - 1].stagingRecord;
-    const duplicateIds = pendingRows
+  if (resolvedPendingRows.length > 0) {
+    const targetRow = resolvedPendingRows[resolvedPendingRows.length - 1].stagingRecord;
+    const duplicateIds = resolvedPendingRows
       .slice(0, -1)
       .map(({ stagingRecord }) => stagingRecord.id);
 
+    // Keep the staging row's uuid column in sync with the entity PK. The
+    // staging table convention is that uuid === entity primary key, and
+    // downstream commit logic uses it as the datalayer changelist key; a
+    // stale uuid from a prior staging row would produce the wrong changelist
+    // entry.
     await StagingV2.update(
       {
+        uuid: pk,
         action: effectiveAction,
         data: JSON.stringify([cleanedRecord]),
       },

--- a/src/utils/v2-xls.js
+++ b/src/utils/v2-xls.js
@@ -205,6 +205,25 @@ export function normalizeCsvHeaders(row, modelClass) {
 }
 
 /**
+ * Convert a DB-field row (snake_case) back to Sequelize attribute names
+ * (camelCase). This is used when reconciling pending staging rows with a new
+ * CSV batch row so we can merge everything in one consistent key space before
+ * converting back to DB field names for staging.
+ *
+ * @param {Object} row
+ * @param {import('sequelize').Model} modelClass
+ * @returns {Object} row with attribute-style keys where possible
+ */
+export function toAttributeNames(row, modelClass) {
+  const snakeToCamel = buildSnakeToCamelMap(modelClass);
+  const result = {};
+  for (const [key, value] of Object.entries(row)) {
+    result[snakeToCamel.get(key) || key] = value;
+  }
+  return result;
+}
+
+/**
  * Convert a row object from camelCase attribute names to snake_case DB field
  * names using the model's rawAttributes metadata. Keys not present in
  * rawAttributes are kept as-is (they may already be snake_case or custom).
@@ -290,6 +309,189 @@ export function validateRequiredFields(row, modelClass, skipFields = new Set()) 
     }
   }
   return missing;
+}
+
+function getPrimaryKeyDbField(modelClass) {
+  const pkAttr = modelClass.primaryKeyAttribute;
+  return modelClass.rawAttributes[pkAttr]?.field || pkAttr;
+}
+
+function extractMatchingStagedRecord(stagingRecord, pk, modelClass, primaryKeyDbField) {
+  try {
+    const parsedData = JSON.parse(stagingRecord.data);
+    const records = Array.isArray(parsedData) ? parsedData : [parsedData];
+    const primaryKeyAttr = modelClass.primaryKeyAttribute;
+    const matchedIndex = records.findIndex(
+      (record) =>
+        record && (record[primaryKeyDbField] === pk || record[primaryKeyAttr] === pk),
+    );
+    if (matchedIndex === -1) {
+      return null;
+    }
+
+    return {
+      stagingRecord,
+      recordData: records[matchedIndex],
+      recordCount: records.length,
+    };
+  } catch (error) {
+    loggerV2.warn('[v2]: Failed to parse pending staging row during CSV merge', {
+      stagingId: stagingRecord.id,
+      uuid: stagingRecord.uuid,
+      table: stagingRecord.table,
+      error: error.message,
+    });
+    return null;
+  }
+}
+
+/**
+ * Return pending staging rows for a specific model primary key. Results are
+ * sorted oldest to newest so callers can replay staged edits in order.
+ *
+ * @param {import('sequelize').Model} modelClass
+ * @param {string} pk
+ * @param {{ transaction?: import('sequelize').Transaction, actions?: string[] }} [options]
+ * @returns {Promise<Array<{ stagingRecord: Object, recordData: Object }>>}
+ */
+export async function getPendingStagedRowsForPk(
+  modelClass,
+  pk,
+  { transaction, actions = ['INSERT', 'UPDATE'] } = {},
+) {
+  const primaryKeyDbField = getPrimaryKeyDbField(modelClass);
+  const stagedRows = await StagingV2.findAll({
+    where: {
+      table: modelClass.getTableName(),
+      committed: false,
+      failed_commit: false,
+      is_transfer: false,
+      action: actions,
+    },
+    order: [['id', 'ASC']],
+    transaction,
+  });
+
+  return stagedRows
+    .map((stagingRecord) =>
+      extractMatchingStagedRecord(stagingRecord, pk, modelClass, primaryKeyDbField))
+    .filter(Boolean);
+}
+
+/**
+ * Build the latest logical row for a record by replaying any pending staging
+ * rows on top of the committed DB row. This lets CSV batch uploads reconcile
+ * with already-staged edits instead of clobbering them.
+ *
+ * @param {import('sequelize').Model} modelClass
+ * @param {string} pk
+ * @param {Object|null} persistedRecord - Sequelize instance or null
+ * @param {{ transaction?: import('sequelize').Transaction }} [options]
+ * @returns {Promise<{ mergedBase: Object, pendingRows: Array, hasPendingDelete: boolean }>}
+ */
+export async function buildPendingCsvMergeBase(
+  modelClass,
+  pk,
+  persistedRecord,
+  { transaction } = {},
+) {
+  const pendingDeleteRows = await getPendingStagedRowsForPk(modelClass, pk, {
+    transaction,
+    actions: ['DELETE'],
+  });
+  const pendingRows = await getPendingStagedRowsForPk(modelClass, pk, {
+    transaction,
+    actions: ['INSERT', 'UPDATE'],
+  });
+
+  let mergedBase = persistedRecord ? persistedRecord.toJSON() : {};
+  const hasMultiRecordPendingRow = pendingRows.some(
+    ({ recordCount }) => recordCount > 1,
+  );
+  for (const { recordData } of pendingRows) {
+    mergedBase = {
+      ...mergedBase,
+      ...toAttributeNames(recordData, modelClass),
+    };
+  }
+
+  return {
+    mergedBase,
+    pendingRows,
+    hasPendingDelete: pendingDeleteRows.length > 0,
+    hasMultiRecordPendingRow,
+  };
+}
+
+/**
+ * Write a single consolidated pending staging row for the given record. If
+ * prior pending INSERT/UPDATE rows exist for the same PK, update the newest
+ * one in place and delete older duplicates so the changelist sees one final
+ * staged row.
+ *
+ * If any existing pending row is an INSERT, the consolidated row remains an
+ * INSERT because the record has not been committed yet.
+ *
+ * @param {import('sequelize').Model} modelClass
+ * @param {string} pk
+ * @param {'INSERT'|'UPDATE'} action
+ * @param {Object} cleanedRecord - DB-field (snake_case) row
+ * @param {import('sequelize').Transaction} transaction
+ * @returns {Promise<void>}
+ */
+export async function stageConsolidatedCsvRecord(
+  modelClass,
+  pk,
+  action,
+  cleanedRecord,
+  transaction,
+) {
+  const pendingRows = await getPendingStagedRowsForPk(modelClass, pk, {
+    transaction,
+    actions: ['INSERT', 'UPDATE'],
+  });
+
+  const effectiveAction = pendingRows.some(
+    ({ stagingRecord }) => stagingRecord.action === 'INSERT',
+  )
+    ? 'INSERT'
+    : action;
+
+  if (pendingRows.length > 0) {
+    const targetRow = pendingRows[pendingRows.length - 1].stagingRecord;
+    const duplicateIds = pendingRows
+      .slice(0, -1)
+      .map(({ stagingRecord }) => stagingRecord.id);
+
+    await StagingV2.update(
+      {
+        action: effectiveAction,
+        data: JSON.stringify([cleanedRecord]),
+      },
+      {
+        where: { id: targetRow.id },
+        transaction,
+      },
+    );
+
+    if (duplicateIds.length > 0) {
+      await StagingV2.destroy({
+        where: { id: duplicateIds },
+        transaction,
+      });
+    }
+    return;
+  }
+
+  await StagingV2.upsert(
+    {
+      uuid: pk,
+      action: effectiveAction,
+      table: modelClass.getTableName(),
+      data: JSON.stringify([cleanedRecord]),
+    },
+    { transaction },
+  );
 }
 
 /**

--- a/src/utils/v2-xls.js
+++ b/src/utils/v2-xls.js
@@ -257,6 +257,42 @@ export function stripUnknownDbFields(dbRow, modelClass, logger = null) {
 }
 
 /**
+ * Validate that a camelCase row destined for INSERT contains all fields
+ * marked `allowNull: false` in the model definition.  Skips fields that
+ * are auto-managed (primary key, orgUid, timestamps) and any fields listed
+ * in the optional `skipFields` set (e.g. `unitSerialId` when it can be
+ * derived from other fields).
+ *
+ * @param {Object} row - camelCase row to validate
+ * @param {import('sequelize').Model} modelClass
+ * @param {Set<string>} [skipFields] - attribute names to skip
+ * @returns {string[]} array of missing field names (empty if valid)
+ */
+export function validateRequiredFields(row, modelClass, skipFields = new Set()) {
+  const autoManaged = new Set([
+    modelClass.primaryKeyAttribute,
+    'orgUid',
+    'createdAt',
+    'updatedAt',
+    // Models with underscored:true and custom timestamp mappings use
+    // snake_case attribute names in rawAttributes
+    'created_at',
+    'updated_at',
+  ]);
+
+  const missing = [];
+  for (const [attrName, meta] of Object.entries(modelClass.rawAttributes)) {
+    if (meta.allowNull === false && !autoManaged.has(attrName) && !skipFields.has(attrName)) {
+      const val = row[attrName];
+      if (val === undefined || val === null || val === '') {
+        missing.push(attrName);
+      }
+    }
+  }
+  return missing;
+}
+
+/**
  * Create StagingV2 records from parsed XLSX data.
  * Parent rows and child rows each get their own staging entry, matching the
  * V2 architecture where every model has its own staging / changelist flow.

--- a/src/utils/xls.js
+++ b/src/utils/xls.js
@@ -925,8 +925,14 @@ function getExcludedColumns(items) {
 export const transformMetaUid = (xlsxParsed) => {
   let xlsxParseSerialized = JSON.stringify(xlsxParsed, 2, 2);
   const metaUids = _.uniq(
-    [...xlsxParseSerialized.matchAll(/(NEW-[0-9])/g)].map((item) => item[0]),
-  );
+    [...xlsxParseSerialized.matchAll(/(NEW-[0-9]+)/g)].map((item) => item[0]),
+  ).sort((a, b) => {
+    // Replace longer/higher-numbered placeholders first to avoid
+    // NEW-1 matching inside NEW-10, NEW-11, etc.
+    const numA = parseInt(a.slice(4), 10);
+    const numB = parseInt(b.slice(4), 10);
+    return numB - numA;
+  });
   metaUids.forEach((metaId) => {
     const uuid = uuidv4();
     xlsxParseSerialized = xlsxParseSerialized.replace(

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -1831,6 +1831,11 @@ ${project.cadTrustProjectId},CSV Updated Name`;
         expect(merged.project_name).to.equal('CSV Updated Name');
         expect(merged.project_description).to.equal('Already staged description');
         expect(merged.project_registry_name).to.equal('Test Registry');
+        // Staging row's uuid column must equal the entity PK; downstream
+        // commit logic uses it as the datalayer changelist key. The pre-
+        // seeded row above had a deliberately-mismatched random uuid, so
+        // this asserts the consolidation code rewrote it to the PK.
+        expect(staged[0].uuid).to.equal(project.cadTrustProjectId);
       });
 
       it('should merge CSV updates into an already-staged project INSERT and keep it as INSERT', async function () {

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -1630,8 +1630,7 @@ describe('V2 Project API - Basic CRUD Tests', function () {
     });
 
     describe('POST /v2/project/batch', function () {
-      it('should batch upload new projects from CSV file (INSERT)', async function () {
-        // Create a CSV file buffer without cadTrustProjectId to trigger INSERT
+      it('should batch upload new projects from CSV file (INSERT) with snake_case staging data', async function () {
         const csvContent = `projectRegistryName,projectId,projectName,projectSector,projectType,projectStatus,projectUnitMetric,cadTrustProgramId
 Test Registry,CSV-001,CSV Test Project 1,Agriculture,Landfill gas,Listed,tCO2e,${testProgram.cadTrustProgramId}
 Test Registry,CSV-002,CSV Test Project 2,Energy,Energy efficiency,Registered,tCO2e,${testProgram.cadTrustProgramId}`;
@@ -1646,19 +1645,20 @@ Test Registry,CSV-002,CSV Test Project 2,Energy,Energy efficiency,Registered,tCO
         expect(response.body.success).to.be.true;
         expect(response.body.message).to.include('CSV processing complete');
 
-        // Verify records were staged
         const stagingRecords = await StagingV2.findAll({
-          where: {
-            table: 'project',
-            action: 'INSERT',
-          },
+          where: { table: 'project', action: 'INSERT' },
         });
 
         expect(stagingRecords.length).to.be.at.least(2);
+
+        // Verify staging data uses snake_case DB field names
+        const data = JSON.parse(stagingRecords[0].data)[0];
+        expect(data).to.have.property('project_registry_name');
+        expect(data).to.have.property('project_name');
+        expect(data).to.have.property('org_uid');
       });
 
-      it('should batch update existing projects from CSV file (UPDATE)', async function () {
-        // Create projects first
+      it('should batch update existing projects from CSV file (UPDATE) and merge with existing data', async function () {
         const homeOrgId = await getV2HomeOrgId();
         const project1 = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
           projectRegistryName: 'Test Registry',
@@ -1668,6 +1668,7 @@ Test Registry,CSV-002,CSV Test Project 2,Energy,Energy efficiency,Registered,tCO
           projectType: ['Landfill gas'],
           projectStatus: 'Listed',
           projectUnitMetric: 'tCO2e',
+          projectDescription: 'Original description that should be preserved',
           cadTrustProgramId: testProgram.cadTrustProgramId,
           orgUid: homeOrgId,
         }));
@@ -1684,10 +1685,10 @@ Test Registry,CSV-002,CSV Test Project 2,Energy,Energy efficiency,Registered,tCO
           orgUid: homeOrgId,
         }));
 
-        // Create a CSV file buffer with cadTrustProjectId to trigger UPDATE
-        const csvContent = `cadTrustProjectId,projectRegistryName,projectId,projectName,projectSector,projectType,projectStatus,projectUnitMetric,cadTrustProgramId
-${project1.cadTrustProjectId},Test Registry,CSV-UPDATE-001,Updated Name 1,Agriculture,Landfill gas,Listed,tCO2e,${testProgram.cadTrustProgramId}
-${project2.cadTrustProjectId},Test Registry,CSV-UPDATE-002,Updated Name 2,Energy,Energy efficiency,Registered,tCO2e,${testProgram.cadTrustProgramId}`;
+        // CSV only updates projectName — other fields should be merged from DB
+        const csvContent = `cadTrustProjectId,projectName
+${project1.cadTrustProjectId},Updated Name 1
+${project2.cadTrustProjectId},Updated Name 2`;
 
         const csvBuffer = Buffer.from(csvContent, 'utf8');
 
@@ -1699,15 +1700,22 @@ ${project2.cadTrustProjectId},Test Registry,CSV-UPDATE-002,Updated Name 2,Energy
         expect(response.body.success).to.be.true;
         expect(response.body.message).to.include('CSV processing complete');
 
-        // Verify records were staged as UPDATE
         const stagingRecords = await StagingV2.findAll({
-          where: {
-            table: 'project',
-            action: 'UPDATE',
-          },
+          where: { table: 'project', action: 'UPDATE' },
         });
 
         expect(stagingRecords.length).to.be.at.least(2);
+
+        // Verify merge: staged data should contain ALL project fields
+        const staged1 = stagingRecords.find(r => r.uuid === project1.cadTrustProjectId);
+        expect(staged1).to.exist;
+        const data1 = JSON.parse(staged1.data)[0];
+        expect(data1.project_name).to.equal('Updated Name 1');
+        // Fields NOT in CSV should be preserved from the DB
+        expect(data1.project_registry_name).to.equal('Test Registry');
+        expect(data1.project_description).to.equal('Original description that should be preserved');
+        expect(data1.project_unit_metric).to.equal('tCO2e');
+        expect(data1.org_uid).to.equal(homeOrgId);
       });
 
       it('should return error if no CSV file is provided', async function () {
@@ -1717,6 +1725,208 @@ ${project2.cadTrustProjectId},Test Registry,CSV-UPDATE-002,Updated Name 2,Energy
 
         expect(response.body.success).to.be.false;
         expect(response.body.message).to.include('Cannot find the required csv file');
+      });
+
+      it('should reject UPDATE for project belonging to another org', async function () {
+        // Create a project with a different org_uid
+        const otherOrgProject = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Other Org Registry',
+          projectId: 'OTHER-ORG-001',
+          projectName: 'Other Org Project',
+          orgUid: 'other-org-uid-12345',
+        }));
+
+        const csvContent = `cadTrustProjectId,projectName
+${otherOrgProject.cadTrustProjectId},Should Not Update`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.errors[0].error).to.include('belongs to a different organization');
+
+        // Verify no staging record was created
+        const staged = await StagingV2.findAll({ where: { uuid: otherOrgProject.cadTrustProjectId } });
+        expect(staged).to.have.lengthOf(0);
+      });
+
+      it('should handle duplicate PK in same CSV gracefully (upsert)', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Test Registry',
+          projectId: 'DUP-001',
+          projectName: 'Duplicate Test',
+          orgUid: homeOrgId,
+        }));
+
+        // Same PK appears twice — second row should win
+        const csvContent = `cadTrustProjectId,projectName
+${project.cadTrustProjectId},First Update
+${project.cadTrustProjectId},Second Update`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { uuid: project.cadTrustProjectId } });
+        expect(staged).to.have.lengthOf(1);
+        const data = JSON.parse(staged[0].data)[0];
+        expect(data.project_name).to.equal('Second Update');
+      });
+
+      it('should strip unknown/child columns from staged data', async function () {
+        const csvContent = `projectRegistryName,projectId,projectName,locations,estimations,foobar,cadTrustProgramId
+Test Registry,STRIP-001,Strip Test,"[{""country"":""US""}]","[{""count"":100}]",garbage,${testProgram.cadTrustProgramId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'project', action: 'INSERT' } });
+        expect(staged.length).to.be.at.least(1);
+
+        const data = JSON.parse(staged[0].data)[0];
+        // Child/unknown columns must NOT appear in staged data
+        expect(data).to.not.have.property('locations');
+        expect(data).to.not.have.property('estimations');
+        expect(data).to.not.have.property('foobar');
+        // Real columns should be present
+        expect(data).to.have.property('project_name', 'Strip Test');
+      });
+
+      it('should report error for non-existent cadTrustProgramId (FK check)', async function () {
+        const csvContent = `projectRegistryName,projectId,projectName,cadTrustProgramId
+Test Registry,FK-001,FK Test,non-existent-program-id`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.errors[0].error).to.include('does not exist');
+      });
+
+      it('should handle large batch (15+ rows) without race condition', async function () {
+        const rows = [];
+        for (let i = 1; i <= 15; i++) {
+          rows.push(`Test Registry,RACE-${String(i).padStart(3, '0')},Race Test Project ${i},Agriculture,tCO2e,${testProgram.cadTrustProgramId}`);
+        }
+        const csvContent = `projectRegistryName,projectId,projectName,projectSector,projectUnitMetric,cadTrustProgramId\n${rows.join('\n')}`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'project', action: 'INSERT' } });
+        expect(staged.length).to.equal(15);
+      });
+
+      it('should handle mixed INSERT + UPDATE in same CSV', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const existingProject = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Test Registry',
+          projectId: 'MIX-EXISTING',
+          projectName: 'Existing Project',
+          orgUid: homeOrgId,
+        }));
+
+        const csvContent = `cadTrustProjectId,projectRegistryName,projectId,projectName,cadTrustProgramId
+${existingProject.cadTrustProjectId},Test Registry,MIX-EXISTING,Updated Existing,${testProgram.cadTrustProgramId}
+,Test Registry,MIX-NEW,New Project,${testProgram.cadTrustProgramId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const updates = await StagingV2.findAll({ where: { table: 'project', action: 'UPDATE' } });
+        expect(updates.length).to.equal(1);
+
+        const inserts = await StagingV2.findAll({ where: { table: 'project', action: 'INSERT' } });
+        expect(inserts.length).to.equal(1);
+      });
+
+      it('should accept snake_case CSV headers', async function () {
+        const csvContent = `project_registry_name,project_id,project_name,cad_trust_program_id
+Test Registry,SNAKE-001,Snake Case Test,${testProgram.cadTrustProgramId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'project', action: 'INSERT' } });
+        expect(staged.length).to.be.at.least(1);
+        const data = JSON.parse(staged[0].data)[0];
+        expect(data.project_name).to.equal('Snake Case Test');
+        expect(data.project_registry_name).to.equal('Test Registry');
+      });
+
+      it('should upsert over existing staging record on re-upload', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Test Registry',
+          projectId: 'REUPL-001',
+          projectName: 'Original',
+          orgUid: homeOrgId,
+        }));
+
+        // First upload
+        let csvContent = `cadTrustProjectId,projectName
+${project.cadTrustProjectId},First Upload`;
+        let csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        // Second upload of same PK
+        csvContent = `cadTrustProjectId,projectName
+${project.cadTrustProjectId},Second Upload`;
+        csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        // Should have exactly 1 staging record (upsert, not duplicate)
+        const staged = await StagingV2.findAll({ where: { uuid: project.cadTrustProjectId } });
+        expect(staged).to.have.lengthOf(1);
+        const data = JSON.parse(staged[0].data)[0];
+        expect(data.project_name).to.equal('Second Upload');
       });
     });
 

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -1784,6 +1784,137 @@ ${project.cadTrustProjectId},Second Update`;
         expect(data.project_name).to.equal('Second Update');
       });
 
+      it('should merge CSV updates into an already-staged project update instead of creating duplicate staged rows', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Test Registry',
+          projectId: 'STAGED-MERGE-001',
+          projectName: 'Original Name',
+          projectDescription: 'Original description',
+          orgUid: homeOrgId,
+        }));
+
+        await StagingV2.create({
+          uuid: uuidv4(),
+          table: 'project',
+          action: 'UPDATE',
+          data: JSON.stringify([{
+            cad_trust_project_id: project.cadTrustProjectId,
+            project_description: 'Already staged description',
+          }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `cadTrustProjectId,projectName
+${project.cadTrustProjectId},CSV Updated Name`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+
+        const staged = await StagingV2.findAll({
+          where: { table: 'project', committed: false, failed_commit: false },
+        });
+        expect(staged.filter((row) => {
+          const data = JSON.parse(row.data)[0];
+          return data.cad_trust_project_id === project.cadTrustProjectId;
+        })).to.have.lengthOf(1);
+
+        const merged = JSON.parse(staged[0].data)[0];
+        expect(merged.project_name).to.equal('CSV Updated Name');
+        expect(merged.project_description).to.equal('Already staged description');
+        expect(merged.project_registry_name).to.equal('Test Registry');
+      });
+
+      it('should merge CSV updates into an already-staged project INSERT and keep it as INSERT', async function () {
+        const stagedProjectId = uuidv4();
+        await StagingV2.create({
+          uuid: stagedProjectId,
+          table: 'project',
+          action: 'INSERT',
+          data: JSON.stringify([{
+            cad_trust_project_id: stagedProjectId,
+            org_uid: await getV2HomeOrgId(),
+            project_registry_name: 'Staged Registry',
+            project_id: 'STAGED-INSERT-001',
+            project_name: 'Staged Insert Name',
+            project_description: 'Staged insert description',
+          }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `cadTrustProjectId,projectName
+${stagedProjectId},CSV Updated Insert Name`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+
+        const staged = await StagingV2.findAll({
+          where: { table: 'project', committed: false, failed_commit: false },
+        });
+        const matching = staged.filter((row) => {
+          const data = JSON.parse(row.data)[0];
+          return data.cad_trust_project_id === stagedProjectId;
+        });
+        expect(matching).to.have.lengthOf(1);
+        expect(matching[0].action).to.equal('INSERT');
+
+        const data = JSON.parse(matching[0].data)[0];
+        expect(data.project_name).to.equal('CSV Updated Insert Name');
+        expect(data.project_description).to.equal('Staged insert description');
+      });
+
+      it('should reject CSV update when the project already has a pending staged delete', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Test Registry',
+          projectId: 'PENDING-DELETE-001',
+          projectName: 'Delete Pending Project',
+          orgUid: homeOrgId,
+        }));
+
+        await StagingV2.create({
+          uuid: uuidv4(),
+          table: 'project',
+          action: 'DELETE',
+          data: JSON.stringify([{
+            cad_trust_project_id: project.cadTrustProjectId,
+          }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `cadTrustProjectId,projectName
+${project.cadTrustProjectId},Should Fail`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(400);
+
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors[0].error).to.include('pending staged delete');
+      });
+
       it('should strip unknown/child columns from staged data', async function () {
         const csvContent = `projectRegistryName,projectId,projectName,locations,estimations,foobar,cadTrustProgramId
 Test Registry,STRIP-001,Strip Test,"[{""country"":""US""}]","[{""count"":100}]",garbage,${testProgram.cadTrustProgramId}`;
@@ -1824,6 +1955,35 @@ Test Registry,FK-001,FK Test,non-existent-program-id`;
         expect(response.body.stagedCount).to.equal(0);
         expect(response.body.errorCount).to.equal(1);
         expect(response.body.errors[0].error).to.include('does not exist');
+      });
+
+      it('should accept cadTrustProgramId that exists only in pending staging', async function () {
+        const stagedProgramId = uuidv4();
+        await StagingV2.create({
+          uuid: stagedProgramId,
+          table: 'program',
+          action: 'INSERT',
+          data: JSON.stringify([{
+            cad_trust_program_id: stagedProgramId,
+          }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `projectRegistryName,projectId,projectName,cadTrustProgramId
+Test Registry,FK-STAGED-001,Uses Staged Program,${stagedProgramId}`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'project', action: 'INSERT' } });
+        expect(staged).to.have.lengthOf(1);
       });
 
       it('should handle large batch (15+ rows) without race condition', async function () {
@@ -1982,6 +2142,41 @@ Test Registry,PARTIAL-002,Invalid FK Project,non-existent-program-id`;
 
         const staged = await StagingV2.findAll({ where: { table: 'project', action: 'INSERT' } });
         expect(staged).to.have.lengthOf(1);
+      });
+
+      it('should return partial success when a valid update is mixed with a wrong-owner update', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const ownedProject = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Test Registry',
+          projectId: 'PARTIAL-UPD-OK',
+          projectName: 'Owned Project',
+          orgUid: homeOrgId,
+        }));
+        const otherOrgProject = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Other Registry',
+          projectId: 'PARTIAL-UPD-BAD',
+          projectName: 'Other Org Project',
+          orgUid: 'other-org-uid-12345',
+        }));
+
+        const csvContent = `cadTrustProjectId,projectName
+${ownedProject.cadTrustProjectId},Updated Owned Project
+${otherOrgProject.cadTrustProjectId},Should Fail`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors[0].error).to.include('belongs to a different organization');
+
+        const staged = await StagingV2.findAll({ where: { table: 'project', action: 'UPDATE' } });
+        expect(staged).to.have.lengthOf(1);
+        expect(staged[0].uuid).to.equal(ownedProject.cadTrustProjectId);
       });
 
       it('should upsert over existing staging record on re-upload', async function () {

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -1630,7 +1630,7 @@ describe('V2 Project API - Basic CRUD Tests', function () {
     });
 
     describe('POST /v2/project/batch', function () {
-      it('should batch upload new projects from CSV file (INSERT) with snake_case staging data', async function () {
+      it('should batch upload new projects from CSV file (INSERT) with snake_case staging data and counts', async function () {
         const csvContent = `projectRegistryName,projectId,projectName,projectSector,projectType,projectStatus,projectUnitMetric,cadTrustProgramId
 Test Registry,CSV-001,CSV Test Project 1,Agriculture,Landfill gas,Listed,tCO2e,${testProgram.cadTrustProgramId}
 Test Registry,CSV-002,CSV Test Project 2,Energy,Energy efficiency,Registered,tCO2e,${testProgram.cadTrustProgramId}`;
@@ -1644,14 +1644,15 @@ Test Registry,CSV-002,CSV Test Project 2,Energy,Energy efficiency,Registered,tCO
 
         expect(response.body.success).to.be.true;
         expect(response.body.message).to.include('CSV processing complete');
+        expect(response.body.stagedCount).to.equal(2);
+        expect(response.body.errorCount).to.equal(0);
 
         const stagingRecords = await StagingV2.findAll({
           where: { table: 'project', action: 'INSERT' },
         });
 
-        expect(stagingRecords.length).to.be.at.least(2);
+        expect(stagingRecords.length).to.equal(2);
 
-        // Verify staging data uses snake_case DB field names
         const data = JSON.parse(stagingRecords[0].data)[0];
         expect(data).to.have.property('project_registry_name');
         expect(data).to.have.property('project_name');
@@ -1727,8 +1728,7 @@ ${project2.cadTrustProjectId},Updated Name 2`;
         expect(response.body.message).to.include('Cannot find the required csv file');
       });
 
-      it('should reject UPDATE for project belonging to another org', async function () {
-        // Create a project with a different org_uid
+      it('should reject UPDATE for project belonging to another org (400 when all rows fail)', async function () {
         const otherOrgProject = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
           projectRegistryName: 'Other Org Registry',
           projectId: 'OTHER-ORG-001',
@@ -1744,13 +1744,13 @@ ${otherOrgProject.cadTrustProjectId},Should Not Update`;
         const response = await supertest(app)
           .post('/v2/project/batch')
           .attach('csv', csvBuffer, 'test.csv')
-          .expect(200);
+          .expect(400);
 
-        expect(response.body.success).to.be.true;
-        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
         expect(response.body.errors[0].error).to.include('belongs to a different organization');
 
-        // Verify no staging record was created
         const staged = await StagingV2.findAll({ where: { uuid: otherOrgProject.cadTrustProjectId } });
         expect(staged).to.have.lengthOf(0);
       });
@@ -1809,7 +1809,7 @@ Test Registry,STRIP-001,Strip Test,"[{""country"":""US""}]","[{""count"":100}]",
         expect(data).to.have.property('project_name', 'Strip Test');
       });
 
-      it('should report error for non-existent cadTrustProgramId (FK check)', async function () {
+      it('should report error for non-existent cadTrustProgramId (FK check, 400 when all rows fail)', async function () {
         const csvContent = `projectRegistryName,projectId,projectName,cadTrustProgramId
 Test Registry,FK-001,FK Test,non-existent-program-id`;
 
@@ -1818,10 +1818,11 @@ Test Registry,FK-001,FK Test,non-existent-program-id`;
         const response = await supertest(app)
           .post('/v2/project/batch')
           .attach('csv', csvBuffer, 'test.csv')
-          .expect(200);
+          .expect(400);
 
-        expect(response.body.success).to.be.true;
-        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
         expect(response.body.errors[0].error).to.include('does not exist');
       });
 
@@ -1891,6 +1892,96 @@ Test Registry,SNAKE-001,Snake Case Test,${testProgram.cadTrustProgramId}`;
         const data = JSON.parse(staged[0].data)[0];
         expect(data.project_name).to.equal('Snake Case Test');
         expect(data.project_registry_name).to.equal('Test Registry');
+      });
+
+      it('should return 400 when all rows fail validation (all-rows-invalid)', async function () {
+        const csvContent = `cadTrustProjectId,projectName
+non-existent-id-1,Bad Project 1
+non-existent-id-2,Bad Project 2`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(400);
+
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(2);
+        expect(response.body.errors).to.have.lengthOf(2);
+        expect(response.body.message).to.include('No rows were staged');
+
+        const staged = await StagingV2.findAll({ where: { table: 'project' } });
+        expect(staged).to.have.lengthOf(0);
+      });
+
+      it('should reject INSERT rows missing required fields', async function () {
+        // Missing projectName (required)
+        const csvContent = `projectRegistryName,projectId,cadTrustProgramId
+Test Registry,REQ-001,${testProgram.cadTrustProgramId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(400);
+
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors[0].error).to.include('Missing required field(s)');
+        expect(response.body.errors[0].error).to.include('projectName');
+      });
+
+      it('should accept UPDATE rows that omit required INSERT fields (merged from DB)', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Test Registry',
+          projectId: 'UPD-REQ-001',
+          projectName: 'Full Project',
+          orgUid: homeOrgId,
+        }));
+
+        // CSV omits projectName — fine for UPDATE since it merges from DB
+        const csvContent = `cadTrustProjectId,projectStatus
+${project.cadTrustProjectId},Listed`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+        expect(response.body.errorCount).to.equal(0);
+      });
+
+      it('should return partial success with correct counts for mixed valid/invalid rows', async function () {
+        // Row 1: valid INSERT, Row 2: bad FK
+        const csvContent = `projectRegistryName,projectId,projectName,cadTrustProgramId
+Test Registry,PARTIAL-001,Valid Project,${testProgram.cadTrustProgramId}
+Test Registry,PARTIAL-002,Invalid FK Project,non-existent-program-id`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/project/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors).to.have.lengthOf(1);
+        expect(response.body.message).to.include('1 row(s) staged');
+        expect(response.body.message).to.include('1 row(s) skipped');
+
+        const staged = await StagingV2.findAll({ where: { table: 'project', action: 'INSERT' } });
+        expect(staged).to.have.lengthOf(1);
       });
 
       it('should upsert over existing staging record on re-upload', async function () {

--- a/tests/v2/integration/unit-v2.spec.js
+++ b/tests/v2/integration/unit-v2.spec.js
@@ -1728,6 +1728,164 @@ ${unit.cadTrustUnitId},20`;
         expect(data.unit_count).to.equal('20');
       });
 
+      it('should merge CSV updates into an already-staged unit update instead of creating duplicate staged rows', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'STAGED-MERGE-UNIT',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitCount: 50,
+          unitVintageYear: 2024,
+          unitLink: 'https://example.com/original-unit',
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+
+        await StagingV2.create({
+          uuid: uuidv4(),
+          table: 'unit',
+          action: 'UPDATE',
+          data: JSON.stringify([{
+            cad_trust_unit_id: unit.cadTrustUnitId,
+            unit_link: 'https://example.com/already-staged-unit',
+          }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `cadTrustUnitId,unitCount
+${unit.cadTrustUnitId},75`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+
+        const staged = await StagingV2.findAll({
+          where: { table: 'unit', committed: false, failed_commit: false },
+        });
+        expect(staged.filter((row) => {
+          const data = JSON.parse(row.data)[0];
+          return data.cad_trust_unit_id === unit.cadTrustUnitId;
+        })).to.have.lengthOf(1);
+
+        const merged = JSON.parse(staged[0].data)[0];
+        expect(merged.unit_count).to.equal('75');
+        expect(merged.unit_link).to.equal('https://example.com/already-staged-unit');
+        expect(merged.unit_serial_id).to.equal('STAGED-MERGE-UNIT');
+      });
+
+      it('should merge CSV updates into an already-staged unit INSERT and keep it as INSERT', async function () {
+        const stagedUnitId = uuidv4();
+        await StagingV2.create({
+          uuid: stagedUnitId,
+          table: 'unit',
+          action: 'INSERT',
+          data: JSON.stringify([{
+            cad_trust_unit_id: stagedUnitId,
+            org_uid: await getV2HomeOrgId(),
+            unit_serial_id: 'STAGED-INSERT-UNIT',
+            unit_start_block: '100',
+            unit_end_block: '200',
+            unit_vintage_year: 2024,
+            cad_trust_issuance_id: testIssuanceForAdvanced.cadTrustIssuanceId,
+            unit_link: 'https://example.com/staged-unit',
+          }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `cadTrustUnitId,unitCount
+${stagedUnitId},75`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+
+        const staged = await StagingV2.findAll({
+          where: { table: 'unit', committed: false, failed_commit: false },
+        });
+        const matching = staged.filter((row) => {
+          const data = JSON.parse(row.data)[0];
+          return data.cad_trust_unit_id === stagedUnitId;
+        });
+        expect(matching).to.have.lengthOf(1);
+        expect(matching[0].action).to.equal('INSERT');
+
+        const data = JSON.parse(matching[0].data)[0];
+        expect(data.unit_count).to.equal('75');
+        expect(data.unit_link).to.equal('https://example.com/staged-unit');
+      });
+
+      it('should reject CSV update when the unit already has a multi-record pending staged update', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'PENDING-SPLIT-UNIT',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitCount: 100,
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+
+        await StagingV2.create({
+          uuid: uuidv4(),
+          table: 'unit',
+          action: 'UPDATE',
+          data: JSON.stringify([
+            {
+              cadTrustUnitId: unit.cadTrustUnitId,
+              orgUid: homeOrgId,
+              unitSerialId: '100-150',
+              unitStartBlock: '100',
+              unitEndBlock: '150',
+              unitCount: 50,
+              unitVintageYear: 2024,
+              cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+            },
+            {
+              cadTrustUnitId: uuidv4(),
+              orgUid: homeOrgId,
+              unitSerialId: '151-200',
+              unitStartBlock: '151',
+              unitEndBlock: '200',
+              unitCount: 50,
+              unitVintageYear: 2024,
+              cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+            },
+          ]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `cadTrustUnitId,unitCount
+${unit.cadTrustUnitId},75`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(400);
+
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors[0].error).to.include('complex pending staged update');
+      });
+
       it('should strip unknown columns from staged data', async function () {
         const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId,foobar,unitLabels
 STRIP-UNIT-001,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId},garbage,"[{""id"":""x""}]"`;
@@ -1784,6 +1942,35 @@ FK-UNIT-OK,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
 
         const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
         expect(staged.length).to.be.at.least(1);
+      });
+
+      it('should accept cadTrustIssuanceId that exists only in pending staging', async function () {
+        const stagedIssuanceId = uuidv4();
+        await StagingV2.create({
+          uuid: stagedIssuanceId,
+          table: 'issuance',
+          action: 'INSERT',
+          data: JSON.stringify([{
+            cad_trust_issuance_id: stagedIssuanceId,
+          }]),
+          committed: false,
+          failed_commit: false,
+          is_transfer: false,
+        });
+
+        const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitCount,unitType,unitVintageYear,unitStatus,cadTrustIssuanceId
+FK-STAGED-UNIT,100,200,50,Avoidance - nature,2024,Issued,${stagedIssuanceId}`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(staged).to.have.lengthOf(1);
       });
 
       it('should handle large batch (15+ rows) without race condition', async function () {
@@ -1946,6 +2133,45 @@ PARTIAL-UNIT-002,300,400,2024,non-existent-issuance-id`;
         expect(staged).to.have.lengthOf(1);
       });
 
+      it('should return partial success when a valid update is mixed with a wrong-owner update', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const ownedUnit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'PARTIAL-OWNED-UNIT',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+        const otherOrgUnit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'PARTIAL-OTHER-UNIT',
+          unitStartBlock: '300',
+          unitEndBlock: '400',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: 'other-org-uid-12345',
+        }));
+
+        const csvContent = `cadTrustUnitId,unitCount
+${ownedUnit.cadTrustUnitId},88
+${otherOrgUnit.cadTrustUnitId},99`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors[0].error).to.include('belongs to a different organization');
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'UPDATE' } });
+        expect(staged).to.have.lengthOf(1);
+        expect(staged[0].uuid).to.equal(ownedUnit.cadTrustUnitId);
+      });
+
       it('should derive unitSerialId from start/end blocks in CSV', async function () {
         const csvContent = `unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId
 5000,6000,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
@@ -1963,6 +2189,70 @@ PARTIAL-UNIT-002,300,400,2024,non-existent-issuance-id`;
         expect(staged.length).to.be.at.least(1);
         const data = JSON.parse(staged[0].data)[0];
         expect(data.unit_serial_id).to.equal('5000-6000');
+      });
+
+      it('should recompute unitSerialId on UPDATE when one block boundary changes and unitSerialId is omitted', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: '100-200',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+
+        const csvContent = `cadTrustUnitId,unitEndBlock
+${unit.cadTrustUnitId},250`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findOne({
+          where: { table: 'unit', action: 'UPDATE', uuid: unit.cadTrustUnitId },
+        });
+        expect(staged).to.exist;
+
+        const data = JSON.parse(staged.data)[0];
+        expect(data.unit_end_block).to.equal('250');
+        expect(data.unit_serial_id).to.equal('100-250');
+      });
+
+      it('should recompute unitSerialId on UPDATE when a block boundary changes and unitSerialId is blank', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: '100-200',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+
+        const csvContent = `cadTrustUnitId,unitSerialId,unitEndBlock
+${unit.cadTrustUnitId},,260`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findOne({
+          where: { table: 'unit', action: 'UPDATE', uuid: unit.cadTrustUnitId },
+        });
+        expect(staged).to.exist;
+
+        const data = JSON.parse(staged.data)[0];
+        expect(data.unit_end_block).to.equal('260');
+        expect(data.unit_serial_id).to.equal('100-260');
       });
     });
 

--- a/tests/v2/integration/unit-v2.spec.js
+++ b/tests/v2/integration/unit-v2.spec.js
@@ -1778,6 +1778,11 @@ ${unit.cadTrustUnitId},75`;
         expect(merged.unit_count).to.equal('75');
         expect(merged.unit_link).to.equal('https://example.com/already-staged-unit');
         expect(merged.unit_serial_id).to.equal('STAGED-MERGE-UNIT');
+        // Staging row's uuid column must equal the entity PK; downstream
+        // commit logic uses it as the datalayer changelist key. The pre-
+        // seeded row above had a deliberately-mismatched random uuid, so
+        // this asserts the consolidation code rewrote it to the PK.
+        expect(staged[0].uuid).to.equal(unit.cadTrustUnitId);
       });
 
       it('should merge CSV updates into an already-staged unit INSERT and keep it as INSERT', async function () {

--- a/tests/v2/integration/unit-v2.spec.js
+++ b/tests/v2/integration/unit-v2.spec.js
@@ -1576,8 +1576,7 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
     });
 
     describe('POST /v2/unit/batch', function () {
-      it('should batch upload new units from CSV file (INSERT)', async function () {
-        // Create a CSV file buffer without cadTrustUnitId to trigger INSERT
+      it('should batch upload new units from CSV file (INSERT) with snake_case staging data', async function () {
         const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitCount,unitType,unitVintageYear,unitStatus,cadTrustIssuanceId
 CSV-UNIT-001,1000,2000,50,Avoidance - nature,2024,Issued,${testIssuanceForAdvanced.cadTrustIssuanceId}
 CSV-UNIT-002,2000,3000,75,Reduction - technical,2024,Held,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
@@ -1592,26 +1591,30 @@ CSV-UNIT-002,2000,3000,75,Reduction - technical,2024,Held,${testIssuanceForAdvan
         expect(response.body.success).to.be.true;
         expect(response.body.message).to.include('CSV processing complete');
 
-        // Verify records were staged
         const stagingRecords = await StagingV2.findAll({
-          where: {
-            table: 'unit',
-            action: 'INSERT',
-          },
+          where: { table: 'unit', action: 'INSERT' },
         });
 
         expect(stagingRecords.length).to.be.at.least(2);
+
+        // Verify staging data uses snake_case DB field names
+        const data = JSON.parse(stagingRecords[0].data)[0];
+        expect(data).to.have.property('unit_serial_id');
+        expect(data).to.have.property('unit_start_block');
+        expect(data).to.have.property('org_uid');
       });
 
-      it('should batch update existing units from CSV file (UPDATE)', async function () {
-        // Create units first
+      it('should batch update existing units from CSV file (UPDATE) and merge with existing data', async function () {
         const homeOrgId = await getV2HomeOrgId();
         const unit1 = await UnitV2.create(addUuidIfNeeded('UnitV2', {
           unitSerialId: 'CSV-UPDATE-001',
           unitStartBlock: '1000',
           unitEndBlock: '2000',
           unitCount: 50,
+          unitType: 'Avoidance - nature',
           unitVintageYear: 2024,
+          unitStatus: 'Issued',
+          unitLink: 'https://example.com/original-link',
           cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
           orgUid: homeOrgId,
         }));
@@ -1626,10 +1629,10 @@ CSV-UNIT-002,2000,3000,75,Reduction - technical,2024,Held,${testIssuanceForAdvan
           orgUid: homeOrgId,
         }));
 
-        // Create a CSV file buffer with cadTrustUnitId to trigger UPDATE
-        const csvContent = `cadTrustUnitId,unitSerialId,unitStartBlock,unitEndBlock,unitCount,unitType,unitVintageYear,unitStatus,cadTrustIssuanceId
-${unit1.cadTrustUnitId},CSV-UPDATE-001,1000,2000,60,Avoidance - nature,2024,Issued,${testIssuanceForAdvanced.cadTrustIssuanceId}
-${unit2.cadTrustUnitId},CSV-UPDATE-002,2000,3000,80,Reduction - technical,2024,Held,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
+        // CSV only updates unitCount — other fields should be merged from DB
+        const csvContent = `cadTrustUnitId,unitCount
+${unit1.cadTrustUnitId},60
+${unit2.cadTrustUnitId},80`;
 
         const csvBuffer = Buffer.from(csvContent, 'utf8');
 
@@ -1641,15 +1644,22 @@ ${unit2.cadTrustUnitId},CSV-UPDATE-002,2000,3000,80,Reduction - technical,2024,H
         expect(response.body.success).to.be.true;
         expect(response.body.message).to.include('CSV processing complete');
 
-        // Verify records were staged as UPDATE
         const stagingRecords = await StagingV2.findAll({
-          where: {
-            table: 'unit',
-            action: 'UPDATE',
-          },
+          where: { table: 'unit', action: 'UPDATE' },
         });
 
         expect(stagingRecords.length).to.be.at.least(2);
+
+        // Verify merge: staged data should contain ALL unit fields
+        const staged1 = stagingRecords.find(r => r.uuid === unit1.cadTrustUnitId);
+        expect(staged1).to.exist;
+        const data1 = JSON.parse(staged1.data)[0];
+        expect(data1.unit_count).to.equal('60');
+        // Fields NOT in CSV should be preserved from the DB
+        expect(data1.unit_serial_id).to.equal('CSV-UPDATE-001');
+        expect(data1.unit_start_block).to.equal('1000');
+        expect(data1.unit_link).to.equal('https://example.com/original-link');
+        expect(data1.org_uid).to.equal(homeOrgId);
       });
 
       it('should return error if no CSV file is provided', async function () {
@@ -1659,6 +1669,206 @@ ${unit2.cadTrustUnitId},CSV-UPDATE-002,2000,3000,80,Reduction - technical,2024,H
 
         expect(response.body.success).to.be.false;
         expect(response.body.message).to.include('Cannot find the required csv file');
+      });
+
+      it('should reject UPDATE for unit belonging to another org', async function () {
+        const otherOrgUnit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'OTHER-ORG-UNIT',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: 'other-org-uid-12345',
+        }));
+
+        const csvContent = `cadTrustUnitId,unitCount
+${otherOrgUnit.cadTrustUnitId},999`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.errors[0].error).to.include('belongs to a different organization');
+      });
+
+      it('should handle duplicate PK in same CSV gracefully (upsert)', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'DUP-UNIT',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+
+        const csvContent = `cadTrustUnitId,unitCount
+${unit.cadTrustUnitId},10
+${unit.cadTrustUnitId},20`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { uuid: unit.cadTrustUnitId } });
+        expect(staged).to.have.lengthOf(1);
+        const data = JSON.parse(staged[0].data)[0];
+        expect(data.unit_count).to.equal('20');
+      });
+
+      it('should strip unknown columns from staged data', async function () {
+        const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId,foobar,unitLabels
+STRIP-UNIT-001,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId},garbage,"[{""id"":""x""}]"`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(staged.length).to.be.at.least(1);
+
+        const data = JSON.parse(staged[0].data)[0];
+        expect(data).to.not.have.property('foobar');
+        expect(data).to.not.have.property('unitLabels');
+        expect(data).to.not.have.property('unit_labels');
+        expect(data).to.have.property('unit_serial_id', 'STRIP-UNIT-001');
+      });
+
+      it('should report error for non-existent cadTrustIssuanceId (FK check)', async function () {
+        const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId
+FK-UNIT-001,100,200,2024,non-existent-issuance-id`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.errors[0].error).to.include('does not exist');
+      });
+
+      it('should succeed with valid cadTrustIssuanceId (FK check)', async function () {
+        const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId
+FK-UNIT-OK,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.errors).to.be.undefined;
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(staged.length).to.be.at.least(1);
+      });
+
+      it('should handle large batch (15+ rows) without race condition', async function () {
+        const rows = [];
+        for (let i = 1; i <= 15; i++) {
+          rows.push(`RACE-UNIT-${String(i).padStart(3, '0')},${i * 100},${i * 100 + 99},2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`);
+        }
+        const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId\n${rows.join('\n')}`;
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(staged.length).to.equal(15);
+      });
+
+      it('should handle mixed INSERT + UPDATE in same CSV', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const existingUnit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'MIX-EXISTING-UNIT',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+
+        const csvContent = `cadTrustUnitId,unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId
+${existingUnit.cadTrustUnitId},MIX-EXISTING-UNIT,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}
+,MIX-NEW-UNIT,300,400,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const updates = await StagingV2.findAll({ where: { table: 'unit', action: 'UPDATE' } });
+        expect(updates.length).to.equal(1);
+
+        const inserts = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(inserts.length).to.equal(1);
+      });
+
+      it('should accept snake_case CSV headers', async function () {
+        const csvContent = `unit_serial_id,unit_start_block,unit_end_block,unit_vintage_year,cad_trust_issuance_id
+SNAKE-UNIT-001,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(staged.length).to.be.at.least(1);
+        const data = JSON.parse(staged[0].data)[0];
+        expect(data.unit_serial_id).to.equal('SNAKE-UNIT-001');
+      });
+
+      it('should derive unitSerialId from start/end blocks in CSV', async function () {
+        const csvContent = `unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId
+5000,6000,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(staged.length).to.be.at.least(1);
+        const data = JSON.parse(staged[0].data)[0];
+        expect(data.unit_serial_id).to.equal('5000-6000');
       });
     });
 

--- a/tests/v2/integration/unit-v2.spec.js
+++ b/tests/v2/integration/unit-v2.spec.js
@@ -1576,7 +1576,7 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
     });
 
     describe('POST /v2/unit/batch', function () {
-      it('should batch upload new units from CSV file (INSERT) with snake_case staging data', async function () {
+      it('should batch upload new units from CSV file (INSERT) with snake_case staging data and counts', async function () {
         const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitCount,unitType,unitVintageYear,unitStatus,cadTrustIssuanceId
 CSV-UNIT-001,1000,2000,50,Avoidance - nature,2024,Issued,${testIssuanceForAdvanced.cadTrustIssuanceId}
 CSV-UNIT-002,2000,3000,75,Reduction - technical,2024,Held,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
@@ -1590,14 +1590,15 @@ CSV-UNIT-002,2000,3000,75,Reduction - technical,2024,Held,${testIssuanceForAdvan
 
         expect(response.body.success).to.be.true;
         expect(response.body.message).to.include('CSV processing complete');
+        expect(response.body.stagedCount).to.equal(2);
+        expect(response.body.errorCount).to.equal(0);
 
         const stagingRecords = await StagingV2.findAll({
           where: { table: 'unit', action: 'INSERT' },
         });
 
-        expect(stagingRecords.length).to.be.at.least(2);
+        expect(stagingRecords.length).to.equal(2);
 
-        // Verify staging data uses snake_case DB field names
         const data = JSON.parse(stagingRecords[0].data)[0];
         expect(data).to.have.property('unit_serial_id');
         expect(data).to.have.property('unit_start_block');
@@ -1671,7 +1672,7 @@ ${unit2.cadTrustUnitId},80`;
         expect(response.body.message).to.include('Cannot find the required csv file');
       });
 
-      it('should reject UPDATE for unit belonging to another org', async function () {
+      it('should reject UPDATE for unit belonging to another org (400 when all rows fail)', async function () {
         const otherOrgUnit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
           unitSerialId: 'OTHER-ORG-UNIT',
           unitStartBlock: '100',
@@ -1689,10 +1690,11 @@ ${otherOrgUnit.cadTrustUnitId},999`;
         const response = await supertest(app)
           .post('/v2/unit/batch')
           .attach('csv', csvBuffer, 'test.csv')
-          .expect(200);
+          .expect(400);
 
-        expect(response.body.success).to.be.true;
-        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
         expect(response.body.errors[0].error).to.include('belongs to a different organization');
       });
 
@@ -1749,7 +1751,7 @@ STRIP-UNIT-001,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId},garbag
         expect(data).to.have.property('unit_serial_id', 'STRIP-UNIT-001');
       });
 
-      it('should report error for non-existent cadTrustIssuanceId (FK check)', async function () {
+      it('should report error for non-existent cadTrustIssuanceId (FK check, 400 when all rows fail)', async function () {
         const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId
 FK-UNIT-001,100,200,2024,non-existent-issuance-id`;
 
@@ -1758,10 +1760,11 @@ FK-UNIT-001,100,200,2024,non-existent-issuance-id`;
         const response = await supertest(app)
           .post('/v2/unit/batch')
           .attach('csv', csvBuffer, 'test.csv')
-          .expect(200);
+          .expect(400);
 
-        expect(response.body.success).to.be.true;
-        expect(response.body.errors).to.be.an('array').with.lengthOf(1);
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
         expect(response.body.errors[0].error).to.include('does not exist');
       });
 
@@ -1850,6 +1853,97 @@ SNAKE-UNIT-001,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
         expect(staged.length).to.be.at.least(1);
         const data = JSON.parse(staged[0].data)[0];
         expect(data.unit_serial_id).to.equal('SNAKE-UNIT-001');
+      });
+
+      it('should return 400 when all rows fail validation (all-rows-invalid)', async function () {
+        const csvContent = `cadTrustUnitId,unitCount
+non-existent-id-1,10
+non-existent-id-2,20`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(400);
+
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(2);
+        expect(response.body.errors).to.have.lengthOf(2);
+        expect(response.body.message).to.include('No rows were staged');
+      });
+
+      it('should reject INSERT rows missing required fields', async function () {
+        // Missing unitStartBlock, unitEndBlock, unitVintageYear (required)
+        const csvContent = `unitSerialId,cadTrustIssuanceId
+MISSING-REQ-001,${testIssuanceForAdvanced.cadTrustIssuanceId}`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(400);
+
+        expect(response.body.success).to.be.false;
+        expect(response.body.stagedCount).to.equal(0);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors[0].error).to.include('Missing required field(s)');
+        expect(response.body.errors[0].error).to.include('unitStartBlock');
+        expect(response.body.errors[0].error).to.include('unitEndBlock');
+        expect(response.body.errors[0].error).to.include('unitVintageYear');
+      });
+
+      it('should accept UPDATE rows that omit required INSERT fields (merged from DB)', async function () {
+        const homeOrgId = await getV2HomeOrgId();
+        const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'UPD-REQ-UNIT',
+          unitStartBlock: '100',
+          unitEndBlock: '200',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: testIssuanceForAdvanced.cadTrustIssuanceId,
+          orgUid: homeOrgId,
+        }));
+
+        // CSV omits all required fields except PK — fine for UPDATE
+        const csvContent = `cadTrustUnitId,unitStatus
+${unit.cadTrustUnitId},Retired`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+        expect(response.body.errorCount).to.equal(0);
+      });
+
+      it('should return partial success with correct counts for mixed valid/invalid rows', async function () {
+        // Row 1: valid INSERT, Row 2: bad FK
+        const csvContent = `unitSerialId,unitStartBlock,unitEndBlock,unitVintageYear,cadTrustIssuanceId
+PARTIAL-UNIT-001,100,200,2024,${testIssuanceForAdvanced.cadTrustIssuanceId}
+PARTIAL-UNIT-002,300,400,2024,non-existent-issuance-id`;
+
+        const csvBuffer = Buffer.from(csvContent, 'utf8');
+
+        const response = await supertest(app)
+          .post('/v2/unit/batch')
+          .attach('csv', csvBuffer, 'test.csv')
+          .expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.stagedCount).to.equal(1);
+        expect(response.body.errorCount).to.equal(1);
+        expect(response.body.errors).to.have.lengthOf(1);
+        expect(response.body.message).to.include('1 row(s) staged');
+        expect(response.body.message).to.include('1 row(s) skipped');
+
+        const staged = await StagingV2.findAll({ where: { table: 'unit', action: 'INSERT' } });
+        expect(staged).to.have.lengthOf(1);
       });
 
       it('should derive unitSerialId from start/end blocks in CSV', async function () {

--- a/tests/v2/integration/v2-xls.spec.js
+++ b/tests/v2/integration/v2-xls.spec.js
@@ -260,6 +260,35 @@ describe('V2 XLS Utility Functions', function () {
       );
     });
 
+    it('should replace multi-digit NEW-X placeholders (NEW-10 through NEW-15)', function () {
+      const rows = [];
+      for (let i = 1; i <= 15; i++) {
+        rows.push([`NEW-${i}`, `Placeholder Project ${i}`]);
+      }
+
+      const buffer = xlsx.build([
+        {
+          name: 'projects',
+          data: [['cadTrustProjectId', 'projectName'], ...rows],
+        },
+      ]);
+
+      const result = parseV2Xlsx(buffer, ProjectV2);
+      expect(result.main).to.have.lengthOf(15);
+
+      const uuids = new Set();
+      result.main.forEach((row) => {
+        expect(row.cadTrustProjectId).to.not.include('NEW-');
+        expect(row.cadTrustProjectId).to.match(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+        uuids.add(row.cadTrustProjectId);
+      });
+
+      // All 15 should have unique UUIDs
+      expect(uuids.size).to.equal(15);
+    });
+
     it('should convert "null" string values to null', function () {
       const projectId = uuidv4();
       const buffer = xlsx.build([

--- a/tests/v2/live-api/csv-batch-upload.live.spec.js
+++ b/tests/v2/live-api/csv-batch-upload.live.spec.js
@@ -1,0 +1,378 @@
+import { expect } from 'chai';
+import {
+  commitStagedRecords,
+  waitForPendingCommits,
+  waitForStagingEmpty,
+} from './helpers/live-api-helpers.js';
+import { getSharedRequest, getSharedHomeOrgId } from './helpers/shared-setup.js';
+import { makePutRequest } from './helpers/api-request-helpers.js';
+import { getFirstCreatedId } from './helpers/shared-state.js';
+
+// Standalone live test for CSV batch upload.
+//
+// This suite intentionally is NOT part of the shared data-short/data-extended
+// orchestration because CSV batch INSERT rows do not expose per-row staging IDs
+// in the API response, which makes it unsafe to commit only this suite's rows
+// on a shared live environment. Run it against a disposable test instance.
+
+const runId = String(Date.now());
+const projectIdsUnderTest = [
+  `TEST-BATCH-LIVE-PRJ-${runId}-001`,
+  `TEST-BATCH-LIVE-PRJ-${runId}-002`,
+];
+const unitSerialsUnderTest = [
+  `TEST-BATCH-LIVE-UNIT-${runId}-001`,
+  `TEST-BATCH-LIVE-UNIT-${runId}-002`,
+];
+
+async function listStagingRows(request) {
+  const response = await request
+    .get('/v2/staging')
+    .query({ page: 1, limit: 1000 })
+    .expect(200);
+  return response.body?.data || response.body || [];
+}
+
+async function listProjects(request, homeOrgId) {
+  const response = await request
+    .get('/v2/project')
+    .query({ page: 1, limit: 1000, orgUid: homeOrgId })
+    .expect(200);
+
+  return response.body?.data || response.body || [];
+}
+
+async function listUnits(request, homeOrgId) {
+  const response = await request
+    .get('/v2/unit')
+    .query({ page: 1, limit: 1000, orgUid: homeOrgId })
+    .expect(200);
+
+  return response.body?.data || response.body || [];
+}
+
+async function resolvePrereqId(request, type, pkField, homeOrgId) {
+  const sharedId = getFirstCreatedId(type);
+  if (sharedId) {
+    const response = await request.get(`/v2/${type}/${sharedId}`);
+    if (response.status === 200) {
+      return sharedId;
+    }
+  }
+
+  const response = await request
+    .get(`/v2/${type}`)
+    .query({ page: 1, limit: 1000 });
+  if (response.status !== 200) {
+    return null;
+  }
+
+  const records = response.body?.data || response.body || [];
+  const homeOrgRecord = records.find((record) => {
+    const recordOrgUid = record.orgUid || record.org_uid;
+    return recordOrgUid && recordOrgUid === homeOrgId;
+  });
+  const selected = homeOrgRecord || records[0];
+  return selected ? selected[pkField] : null;
+}
+
+function buildProjectPutData(record, overrides = {}) {
+  return {
+    projectRegistryName: record.projectRegistryName,
+    projectId: record.projectId,
+    projectName: record.projectName,
+    projectCreditingProgram: record.projectCreditingProgram ?? null,
+    projectLink: record.projectLink ?? null,
+    projectDescription: record.projectDescription ?? null,
+    projectSector: record.projectSector ?? null,
+    projectType: record.projectType ?? null,
+    projectSubtype: record.projectSubtype ?? null,
+    projectStatus: record.projectStatus ?? null,
+    projectStatusDate: record.projectStatusDate ?? null,
+    projectUnitMetric: record.projectUnitMetric ?? null,
+    cadTrustReferenceProjectId: record.cadTrustReferenceProjectId ?? null,
+    cadTrustProgramId: record.cadTrustProgramId ?? null,
+    ...overrides,
+  };
+}
+
+function buildUnitPutData(record, overrides = {}) {
+  return {
+    unitSerialId: record.unitSerialId,
+    unitStartBlock: record.unitStartBlock,
+    unitEndBlock: record.unitEndBlock,
+    unitVintageYear: record.unitVintageYear,
+    cadTrustIssuanceId: record.cadTrustIssuanceId,
+    unitCount: record.unitCount ?? null,
+    unitType: record.unitType ?? null,
+    unitStatus: record.unitStatus ?? null,
+    unitStatusReason: record.unitStatusReason ?? null,
+    unitStatusDate: record.unitStatusDate ?? null,
+    unitRetirementDetail: record.unitRetirementDetail ?? null,
+    unitRetirementBeneficiary: record.unitRetirementBeneficiary ?? null,
+    unitRetirementBeneficiaryId: record.unitRetirementBeneficiaryId ?? null,
+    unitLink: record.unitLink ?? null,
+    unitMetric: record.unitMetric ?? null,
+    unitCurrentOwner: record.unitCurrentOwner ?? null,
+    unitItmosReferenceId: record.unitItmosReferenceId ?? null,
+    marketplace: record.marketplace ?? null,
+    marketplaceLink: record.marketplaceLink ?? null,
+    marketplaceIdentifier: record.marketplaceIdentifier ?? null,
+    ...overrides,
+  };
+}
+
+function stageRowMatches(row, predicate) {
+  try {
+    const parsed = JSON.parse(row.data);
+    const records = Array.isArray(parsed) ? parsed : [parsed];
+    return records.some(predicate);
+  } catch {
+    return false;
+  }
+}
+
+async function getBatchStagingIds(request, table, predicate) {
+  const rows = await listStagingRows(request);
+  return rows
+    .filter((row) => row.table === table)
+    .filter((row) => stageRowMatches(row, predicate))
+    .map((row) => row.uuid);
+}
+
+describe('CSV Batch Upload Live API Tests', function () {
+  this.timeout(1800000);
+
+  let request;
+  let homeOrgId;
+  let programId;
+  let issuanceId;
+  let createdProjectIds = [];
+  let createdUnitIds = [];
+
+  before(async function () {
+    request = getSharedRequest();
+    homeOrgId = getSharedHomeOrgId();
+    programId = await resolvePrereqId(request, 'program', 'cadTrustProgramId', homeOrgId);
+    issuanceId = await resolvePrereqId(request, 'issuance', 'cadTrustIssuanceId', homeOrgId);
+
+    if (!programId) {
+      throw new Error('CSV batch live tests require an existing program record');
+    }
+    if (!issuanceId) {
+      throw new Error('CSV batch live tests require an existing issuance record');
+    }
+  });
+
+  after(async function () {
+    if (!request) {
+      return;
+    }
+
+    try {
+      if (createdUnitIds.length === 0 || createdProjectIds.length === 0) {
+        const [projects, units] = await Promise.all([
+          listProjects(request, homeOrgId),
+          listUnits(request, homeOrgId),
+        ]);
+        if (createdProjectIds.length === 0) {
+          createdProjectIds = projects
+            .filter((project) => projectIdsUnderTest.includes(project.projectId))
+            .map((project) => project.cadTrustProjectId);
+        }
+        if (createdUnitIds.length === 0) {
+          createdUnitIds = units
+            .filter((unit) => unitSerialsUnderTest.includes(unit.unitSerialId))
+            .map((unit) => unit.cadTrustUnitId);
+        }
+      }
+
+      for (const unitId of createdUnitIds) {
+        await request.delete(`/v2/unit/${unitId}`);
+      }
+      for (const projectId of createdProjectIds) {
+        await request.delete(`/v2/project/${projectId}`);
+      }
+
+      if (createdUnitIds.length > 0 || createdProjectIds.length > 0) {
+        const deleteStageIds = [
+          ...(await getBatchStagingIds(request, 'unit', (record) =>
+            createdUnitIds.includes(record.cad_trust_unit_id || record.cadTrustUnitId))),
+          ...(await getBatchStagingIds(request, 'project', (record) =>
+            createdProjectIds.includes(record.cad_trust_project_id || record.cadTrustProjectId))),
+        ];
+        if (deleteStageIds.length > 0) {
+          await commitStagedRecords(request, deleteStageIds, true);
+          await waitForPendingCommits(request);
+          await waitForStagingEmpty(request);
+        }
+      }
+    } catch (error) {
+      console.warn(`CSV batch live test cleanup warning: ${error.message}`);
+    }
+  });
+
+  describe('Step 17: CSV batch insert (projects + units)', function () {
+    it('should stage project and unit CSV batch inserts', async function () {
+      const projectCsv = `projectRegistryName,projectId,projectName,cadTrustProgramId
+Test Registry,${projectIdsUnderTest[0]},CSV Batch Live Project 1,${programId}
+Test Registry,${projectIdsUnderTest[1]},CSV Batch Live Project 2,${programId}`;
+      const unitCsv = `unitSerialId,unitStartBlock,unitEndBlock,unitCount,unitType,unitVintageYear,unitStatus,cadTrustIssuanceId
+${unitSerialsUnderTest[0]},100,200,50,Avoidance - nature,2024,Issued,${issuanceId}
+${unitSerialsUnderTest[1]},300,400,60,Reduction - technical,2024,Held,${issuanceId}`;
+
+      const [projectResponse, unitResponse] = await Promise.all([
+        request.post('/v2/project/batch').attach('csv', Buffer.from(projectCsv, 'utf8'), 'projects.csv'),
+        request.post('/v2/unit/batch').attach('csv', Buffer.from(unitCsv, 'utf8'), 'units.csv'),
+      ]);
+
+      expect(projectResponse.status).to.equal(200);
+      expect(projectResponse.body.success).to.be.true;
+      expect(projectResponse.body.stagedCount).to.equal(2);
+
+      expect(unitResponse.status).to.equal(200);
+      expect(unitResponse.body.success).to.be.true;
+      expect(unitResponse.body.stagedCount).to.equal(2);
+    });
+  });
+
+  describe('Step 17a: Commit inserted CSV rows and verify they appear', function () {
+    it('should commit staged CSV inserts and find the created records', async function () {
+      const stageIds = [
+        ...(await getBatchStagingIds(request, 'project', (record) =>
+          projectIdsUnderTest.includes(record.project_id || record.projectId))),
+        ...(await getBatchStagingIds(request, 'unit', (record) =>
+          unitSerialsUnderTest.includes(record.unit_serial_id || record.unitSerialId))),
+      ];
+      await commitStagedRecords(request, stageIds, true);
+      await waitForPendingCommits(request);
+      await waitForStagingEmpty(request);
+
+      const [projects, units] = await Promise.all([
+        listProjects(request, homeOrgId),
+        listUnits(request, homeOrgId),
+      ]);
+
+      createdProjectIds = projectIdsUnderTest.map((projectId) => {
+        const project = projects.find((candidate) => candidate.projectId === projectId);
+        expect(project, `Project ${projectId} not found after CSV batch commit`).to.exist;
+        return project.cadTrustProjectId;
+      });
+
+      createdUnitIds = unitSerialsUnderTest.map((serialId) => {
+        const unit = units.find((candidate) => candidate.unitSerialId === serialId);
+        expect(unit, `Unit ${serialId} not found after CSV batch commit`).to.exist;
+        return unit.cadTrustUnitId;
+      });
+    });
+  });
+
+  describe('Step 17b: Stage REST updates, then merge CSV updates into them', function () {
+    it('should preserve already-staged REST updates when CSV batch updates the same records', async function () {
+      const [projectResponse, unitResponse] = await Promise.all([
+        request.get(`/v2/project/${createdProjectIds[0]}`).expect(200),
+        request.get(`/v2/unit/${createdUnitIds[0]}`).expect(200),
+      ]);
+      const project = projectResponse.body.data || projectResponse.body;
+      const unit = unitResponse.body.data || unitResponse.body;
+
+      const projectUpdate = buildProjectPutData(project, {
+        projectDescription: 'REST staged project description from live batch test',
+      });
+      const unitUpdate = buildUnitPutData(unit, {
+        unitLink: 'https://example.com/live-batch-staged-unit-link',
+      });
+
+      const [projectPutResponse, unitPutResponse] = await Promise.all([
+        makePutRequest(request, '/v2/project', createdProjectIds[0], projectUpdate),
+        makePutRequest(request, '/v2/unit', createdUnitIds[0], unitUpdate),
+      ]);
+      expect(projectPutResponse.success).to.be.true;
+      expect(unitPutResponse.success).to.be.true;
+
+      const projectCsv = `cadTrustProjectId,projectName
+${createdProjectIds[0]},CSV Batch Live Updated Project Name`;
+      const unitCsv = `cadTrustUnitId,unitSerialId,unitEndBlock
+${createdUnitIds[0]},,250`;
+
+      const [projectBatchResponse, unitBatchResponse] = await Promise.all([
+        request.post('/v2/project/batch').attach('csv', Buffer.from(projectCsv, 'utf8'), 'project-update.csv'),
+        request.post('/v2/unit/batch').attach('csv', Buffer.from(unitCsv, 'utf8'), 'unit-update.csv'),
+      ]);
+
+      expect(projectBatchResponse.status).to.equal(200);
+      expect(projectBatchResponse.body.success).to.be.true;
+      expect(projectBatchResponse.body.stagedCount).to.equal(1);
+
+      expect(unitBatchResponse.status).to.equal(200);
+      expect(unitBatchResponse.body.success).to.be.true;
+      expect(unitBatchResponse.body.stagedCount).to.equal(1);
+    });
+  });
+
+  describe('Step 17c: Commit merged updates and verify final state', function () {
+    it('should commit merged CSV/REST updates and persist the combined result', async function () {
+      const stageIds = [
+        ...(await getBatchStagingIds(request, 'project', (record) =>
+          (record.cad_trust_project_id || record.cadTrustProjectId) === createdProjectIds[0])),
+        ...(await getBatchStagingIds(request, 'unit', (record) =>
+          (record.cad_trust_unit_id || record.cadTrustUnitId) === createdUnitIds[0])),
+      ];
+      await commitStagedRecords(request, stageIds, true);
+      await waitForPendingCommits(request);
+      await waitForStagingEmpty(request);
+
+      const [projectResponse, unitResponse] = await Promise.all([
+        request.get(`/v2/project/${createdProjectIds[0]}`).expect(200),
+        request.get(`/v2/unit/${createdUnitIds[0]}`).expect(200),
+      ]);
+      const project = projectResponse.body.data || projectResponse.body;
+      const unit = unitResponse.body.data || unitResponse.body;
+
+      expect(project.projectName).to.equal('CSV Batch Live Updated Project Name');
+      expect(project.projectDescription).to.equal('REST staged project description from live batch test');
+
+      expect(String(unit.unitEndBlock)).to.equal('250');
+      expect(unit.unitLink).to.equal('https://example.com/live-batch-staged-unit-link');
+      expect(unit.unitSerialId).to.equal('100-250');
+    });
+  });
+
+  describe('Step 17d: Clean up live CSV batch records', function () {
+    it('should delete the batch-created units and projects', async function () {
+      for (const unitId of createdUnitIds) {
+        const response = await request.delete(`/v2/unit/${unitId}`);
+        expect(response.status).to.equal(200);
+        expect(response.body.success).to.be.true;
+      }
+      for (const projectId of createdProjectIds) {
+        const response = await request.delete(`/v2/project/${projectId}`);
+        expect(response.status).to.equal(200);
+        expect(response.body.success).to.be.true;
+      }
+
+      const stageIds = [
+        ...(await getBatchStagingIds(request, 'unit', (record) =>
+          createdUnitIds.includes(record.cad_trust_unit_id || record.cadTrustUnitId))),
+        ...(await getBatchStagingIds(request, 'project', (record) =>
+          createdProjectIds.includes(record.cad_trust_project_id || record.cadTrustProjectId))),
+      ];
+      await commitStagedRecords(request, stageIds, true);
+      await waitForPendingCommits(request);
+      await waitForStagingEmpty(request);
+    });
+  });
+
+  describe('Step 17e: Verify cleanup', function () {
+    it('should no longer find the deleted CSV batch records', async function () {
+      for (const unitId of createdUnitIds) {
+        const response = await request.get(`/v2/unit/${unitId}`);
+        expect(response.status).to.equal(404);
+      }
+      for (const projectId of createdProjectIds) {
+        const response = await request.get(`/v2/project/${projectId}`);
+        expect(response.status).to.equal(404);
+      }
+    });
+  });
+});

--- a/tests/v2/live-api/data-short.js
+++ b/tests/v2/live-api/data-short.js
@@ -134,7 +134,7 @@ function getEndpointPath(type) {
 
 async function commitAndWait(phase) {
   const { getLiveApiRequest, commitStagedRecords, waitForPendingCommits, waitForStagingEmpty, waitForBatchToAppear, validateDataInDatabase } = await import('./helpers/live-api-helpers.js');
-  const { getAllCreatedIds, getBatchVerificationRecords, clearBatchVerificationRecords } = await import('./helpers/shared-state.js');
+  const { getBatchVerificationRecords, clearBatchVerificationRecords } = await import('./helpers/shared-state.js');
 
   // Use V2 API version for health checks since this uses V2 endpoints
   const request = await getLiveApiRequest({ apiVersion: 'v2' });
@@ -154,8 +154,17 @@ async function commitAndWait(phase) {
   await waitForPendingCommits(request);
   await waitForStagingEmpty(request);
 
-  // Wait for all created records to appear after batch commit
-  const recordsToWaitFor = getAllCreatedIds();
+  // Wait for records touched in this phase to appear after batch commit.
+  // DELETE operations are validated separately and must NOT be waited on here.
+  const verificationRecords = getBatchVerificationRecords();
+  const recordsToWaitFor = [];
+  for (const [type, typeRecords] of Object.entries(verificationRecords)) {
+    for (const [id, recordInfo] of Object.entries(typeRecords)) {
+      if (recordInfo.operation === 'POST' || recordInfo.operation === 'PUT') {
+        recordsToWaitFor.push({ type, id });
+      }
+    }
+  }
   if (recordsToWaitFor.length > 0) {
     const waitTimestamp = new Date().toISOString();
     console.log(`[${waitTimestamp}] Waiting for ${recordsToWaitFor.length} record(s) to appear after batch commit...`);
@@ -165,7 +174,6 @@ async function commitAndWait(phase) {
   }
 
   // Verify records
-  const verificationRecords = getBatchVerificationRecords();
   const verifyTimestamp = new Date().toISOString();
   console.log(`[${verifyTimestamp}] Verifying ${phase} operations...`);
 

--- a/tests/v2/live-api/data-short.js
+++ b/tests/v2/live-api/data-short.js
@@ -159,9 +159,10 @@ async function commitAndWait(phase) {
   const verificationRecords = getBatchVerificationRecords();
   const recordsToWaitFor = [];
   for (const [type, typeRecords] of Object.entries(verificationRecords)) {
+    const endpointPath = getEndpointPath(type);
     for (const [id, recordInfo] of Object.entries(typeRecords)) {
       if (recordInfo.operation === 'POST' || recordInfo.operation === 'PUT') {
-        recordsToWaitFor.push({ type, id });
+        recordsToWaitFor.push({ type: endpointPath, id });
       }
     }
   }

--- a/tests/v2/live-api/helpers/shared-state.js
+++ b/tests/v2/live-api/helpers/shared-state.js
@@ -211,7 +211,9 @@ const PRIMARY_KEY_FIELDS = {
  */
 export const getFirstRecordIdFromDatabase = async (request, type) => {
   try {
-    const response = await request.get(`/v2/${type}`);
+    const response = await request
+      .get(`/v2/${type}`)
+      .query({ page: 1, limit: 1 });
     const data = Array.isArray(response.body)
       ? response.body
       : (response.body?.data || []);
@@ -303,8 +305,9 @@ export const getAllCreatedIds = () => {
   ];
 
   for (const type of deleteOrder) {
-    if (createdIds[type] && createdIds[type].length > 0) {
-      for (const id of createdIds[type]) {
+    const ids = getCreatedIds(type);
+    if (ids && ids.length > 0) {
+      for (const id of ids) {
         all.push({ type, id });
       }
     }


### PR DESCRIPTION
## Summary
- reconcile CSV batch updates against the latest pending staged state instead of only the committed DB row, and reject unsafe complex pending unit updates such as splits
- tighten CSV batch docs and regression coverage for staged merge behavior, pending deletes, staged FK parents, ownership errors, and unit serial recomputation
- add a standalone live CSV batch spec plus safer live helper fallbacks without auto-wiring it into the shared live runners

## Test plan
- [x] `eval \"$(fnm env)\" && fnm use && npm run test:v2`
- [x] `eval \"$(fnm env)\" && fnm use && npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js tests/v2/integration/project-v2.spec.js tests/v2/integration/unit-v2.spec.js --reporter spec --exit --timeout 300000`
- [x] `eval \"$(fnm env)\" && fnm use && node --check tests/v2/live-api/csv-batch-upload.live.spec.js`
- [x] `eval \"$(fnm env)\" && fnm use && node --check tests/v2/live-api/helpers/shared-state.js`
- [x] `eval \"$(fnm env)\" && fnm use && node --check tests/v2/live-api/data-short.js`
- [x] `eval \"$(fnm env)\" && fnm use && node --check tests/v2/live-api/data-extended.js`
- [ ] run the standalone live CSV batch spec against a disposable live CADT environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CSV batch upload staging/merge logic for `project` and `unit`, including transactional consolidation of pending rows and new validation/ownership/FK checks; mistakes could cause incorrect staging or rejected uploads. Broad new test coverage reduces risk but the affected path is core data ingestion.
> 
> **Overview**
> **CSV batch upload for `projects` and `units` is made merge-safe and more user-informative.** The `/v2/*/batch` endpoints now return per-request `stagedCount`, `errorCount`, and optional per-row errors, and return HTTP 400 when *all* rows fail validation.
> 
> **Batch CSV processing now reconciles against pending staged edits, not just committed DB state.** The models collect CSV rows, process them sequentially in a transaction, normalize snake_case/camelCase headers, strip unknown/child columns, validate required fields (INSERT-only), enforce home-org ownership on updates, validate FK existence (including staged parents), and consolidate duplicate/pending staging rows so the latest row wins while preserving INSERT vs UPDATE semantics.
> 
> **Staging/XLSX utilities are extended and hardened.** `v2-xls.js` gains reusable helpers for header normalization, required-field validation, pending-staging merge base building, and consolidated staging writes; `transformMetaUid` now correctly handles multi-digit `NEW-10+` placeholders.
> 
> Docs and tests are updated extensively, including new integration coverage for partial success, pending deletes/complex pending updates, staged parent FKs, serial-id recomputation for units, and a standalone live API CSV batch suite plus safer live-test helper pagination/verification behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e02ac84ae2456ddc1bdad3af6a30e81ac3d06e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->