### PR TITLE
fix(API): capture staging commit errors in logs and stream all logs to journalctl

### DIFF
--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -117,11 +117,12 @@ const createVersionLogger = (version) => {
       }),
     );
   } else {
-    // In production, mirror error-level logs to stderr so operators can see
-    // them via journalctl/pm2/docker alongside the on-disk log files.
+    // In production, also stream every log line the logger emits to the
+    // process's stdout/stderr so operators can consume them via journalctl,
+    // pm2, or docker. File transports above continue to hold the same data
+    // on disk. Errors go to stderr, everything else to stdout.
     versionLogger.add(
       new transports.Console({
-        level: 'error',
         stderrLevels: ['error'],
         format: format.combine(format.json()),
       }),

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -117,19 +117,21 @@ const createVersionLogger = (version) => {
       }),
     );
   } else {
-    // In production, also stream every log line the logger emits to the
-    // process's stdout/stderr so operators can consume the full log stream
-    // via journalctl, pm2, or docker. File transports above continue to
-    // hold the same data on disk. Errors go to stderr, everything else to
-    // stdout.
+    // In production, also stream debug-level and above to stdout/stderr so
+    // operators can consume the log stream via journalctl, pm2, or docker
+    // alongside the on-disk log files. Errors go to stderr, everything
+    // else to stdout.
     //
-    // NOTE: in winston 3 a transport's `level` is independent of the
-    // logger's level, so we explicitly use 'silly' (the most permissive
-    // level) to guarantee that anything the app logs reaches journalctl,
-    // regardless of APP.LOG_LEVEL.
+    // The explicit `level: 'debug'` is deliberate: winston 3 transport
+    // levels are independent of the logger's level, and we want journalctl
+    // to receive every "normal" log line (error through debug) regardless
+    // of APP.LOG_LEVEL. The one level we deliberately exclude is `silly`,
+    // which is reserved for extreme debugging (per-query Sequelize output
+    // in src/config/config.js); operators who need that can flip the
+    // transport to 'silly' temporarily.
     versionLogger.add(
       new transports.Console({
-        level: 'silly',
+        level: 'debug',
         stderrLevels: ['error'],
         format: format.combine(format.json()),
       }),

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -118,11 +118,18 @@ const createVersionLogger = (version) => {
     );
   } else {
     // In production, also stream every log line the logger emits to the
-    // process's stdout/stderr so operators can consume them via journalctl,
-    // pm2, or docker. File transports above continue to hold the same data
-    // on disk. Errors go to stderr, everything else to stdout.
+    // process's stdout/stderr so operators can consume the full log stream
+    // via journalctl, pm2, or docker. File transports above continue to
+    // hold the same data on disk. Errors go to stderr, everything else to
+    // stdout.
+    //
+    // NOTE: in winston 3 a transport's `level` is independent of the
+    // logger's level, so we explicitly use 'silly' (the most permissive
+    // level) to guarantee that anything the app logs reaches journalctl,
+    // regardless of APP.LOG_LEVEL.
     versionLogger.add(
       new transports.Console({
+        level: 'silly',
         stderrLevels: ['error'],
         format: format.combine(format.json()),
       }),

--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -116,6 +116,16 @@ const createVersionLogger = (version) => {
         ),
       }),
     );
+  } else {
+    // In production, mirror error-level logs to stderr so operators can see
+    // them via journalctl/pm2/docker alongside the on-disk log files.
+    versionLogger.add(
+      new transports.Console({
+        level: 'error',
+        stderrLevels: ['error'],
+        format: format.combine(format.json()),
+      }),
+    );
   }
 
   return versionLogger;

--- a/src/controllers/staging.controller.js
+++ b/src/controllers/staging.controller.js
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import { Sequelize } from 'sequelize';
 import { Staging } from '../models';
 
+import { logger } from '../config/logger.js';
+
 import {
   optionallyPaginatedResponse,
   paginationParams,
@@ -110,7 +112,9 @@ export const commit = async (req, res) => {
       success: true,
     });
   } catch (error) {
-    console.trace(error);
+    logger.error(`POST /v1/staging/commit failed: ${error.message}`, {
+      stack: error.stack,
+    });
     res.status(400).json({
       message: 'Error commiting staging table',
       error: error.message,


### PR DESCRIPTION
## Summary

Close two observability gaps:

1. `POST /v1/staging/commit` 400 responses had no entry in the Winston JSON logs because the catch block used `console.trace`.
2. In production, the logger had no Console transport at all, so `logger.*(...)` calls only hit on-disk log files — operators consuming logs via `journalctl` / pm2 / docker saw nothing from the application.

After this PR, error/warn/info/verbose/debug all go to both on-disk files and the process's stdout/stderr.

## Changes

### 1. `src/controllers/staging.controller.js` — log commit failures via Winston

```js
- } catch (error) {
-   console.trace(error);
+ } catch (error) {
+   logger.error(`POST /v1/staging/commit failed: ${error.message}`, {
+     stack: error.stack,
+   });
    res.status(400).json({ ... });
  }
```

Error message and stack now land in `error.log` / `combined.log` / `application-*.log`, and (because of change 2 below) also in journalctl.

### 2. `src/config/logger.js` — production Console transport at debug level

Previously no Console transport was added in production. Now:

```js
versionLogger.add(
  new transports.Console({
    level: 'debug',
    stderrLevels: ['error'],
    format: format.combine(format.json()),
  }),
);
```

Behavior in production:

- `level: 'debug'` — accepts error, warn, info, verbose, debug. Deliberately excludes `silly`, which is used in `src/config/config.js` for per-query Sequelize output and would flood journalctl on a busy instance.
- In winston 3 a transport's level is independent of the logger's, so this guarantees debug-level coverage in journalctl regardless of `APP.LOG_LEVEL`.
- Errors → `process.stderr`; warn/info/verbose/debug → `process.stdout`.
- All existing File / DailyRotateFile transports are unchanged.

File-transport cleanup (consolidating to 3 rotated files and removing legacy unbounded files) is handled in #1597.

## Verification

Smoke test against `winston@3.19.0` Console transport with `level: 'debug'`, `stderrLevels: ['error']`, with logger level `info`:

```
STDOUT: warn, info, verbose, debug
STDERR: error
FILTERED: silly
```

Correct routing: all normal levels reach journalctl, silly SQL query output is excluded.

## Impact on existing deployments

- Disk logs: unchanged.
- journalctl / pm2 / docker: operators now see error/warn/info/verbose/debug where they previously saw nothing from the application.
- Log volume: bounded to ~the same set of messages that already hit `debug-%DATE%.log`; no per-query Sequelize spam.

## Scope

Intentionally narrow:
- Controller change only touches the `commit` handler. Other `console.trace(error)` sites in `organization`, `project`, `units`, `offer` controllers and `sync-registries*` tasks remain for a follow-up sweep.
- File-transport cleanup is #1597.

## Test plan

- [ ] `npm run test` passes locally
- [ ] With `NODE_ENV=production`, trigger a 400 from `POST /v1/staging/commit` (e.g. empty staging table) and verify:
  - `error.log` / `combined.log` under `~/.chia/mainnet/cadt/v1/logs/` contain a structured entry with `level: error`, `message: POST /v1/staging/commit failed: ...`, and the stack
  - `journalctl -u cadt` shows the same error on stderr
- [ ] With `NODE_ENV=production`, confirm info/warn/verbose/debug lines appear in `journalctl` on stdout; silly-level Sequelize queries do NOT
- [ ] With `NODE_ENV!=production`, confirm the pretty-printed colorized dev console output still works (no regression)
- [ ] HTTP response body of the 400 is unchanged

## Notes on the failing CI run

The v2 integration test failure (`V2 Issuance API - Basic CRUD Tests > DELETE /v2/issuance/:id > should stage issuance deletion with no children`) is unrelated to this PR:

- Tests run with `NODE_ENV=test`, not `production`, so this PR's Console transport change is not active during test runs.
- The test uses a fixed 500 ms `waitForV2DataLayerSync()` followed by an issuance create + delete; the 400 is coming from one of the preconditions in `v2 issuance-v2.controller.js` `destroy` (`assertV2IfReadOnlyMode` / `assertV2HomeOrgExists` / `assertNoPendingCommitsExcludingTransfers`) — likely stale staging state from a preceding test.
- The earlier commits of this PR passed the v2 integration tests, and the `src/controllers/staging.controller.js` change only touches the v1 commit handler.