### PR TITLE
fix: batch v1 staging diff lookups

### DIFF
--- a/src/controllers/staging.controller.js
+++ b/src/controllers/staging.controller.js
@@ -39,6 +39,8 @@ export const findAll = async (req, res) => {
     let { page, limit, type, table } = req.query;
 
     let pagination = paginationParams(page, limit);
+    const isPaginated = page !== undefined;
+    const order = [['id', 'ASC']];
 
     let where = {};
     if (type === 'staged') {
@@ -53,32 +55,37 @@ export const findAll = async (req, res) => {
       where.table = table;
     }
 
-    let stagingData = await Staging.findAndCountAll({
-      distinct: true,
-      where,
-      ...pagination,
+    const stagingData = isPaginated
+      ? await Staging.findAndCountAll({
+          distinct: true,
+          where,
+          order,
+          ...pagination,
+        })
+      : {
+          rows: await Staging.findAll({
+            where,
+            order,
+          }),
+        };
+
+    const diffs = await Staging.getDiffObjects(stagingData.rows);
+    const results = stagingData.rows.map((stagingRecord, index) => {
+      const workingData = _.cloneDeep(stagingRecord.dataValues);
+      workingData.diff = diffs[index];
+
+      delete workingData.data;
+
+      return workingData;
     });
 
-    const results = await Promise.all(
-      stagingData.rows.map(async (stagingRecord) => {
-        const { uuid, table, action, data } = stagingRecord;
-        const workingData = _.cloneDeep(stagingRecord.dataValues);
-        workingData.diff = await Staging.getDiffObject(
-          uuid,
-          table,
-          action,
-          data,
-        );
-
-        delete workingData.data;
-
-        return workingData;
-      }),
-    );
-
-    stagingData.rows = results;
-
-    const response = optionallyPaginatedResponse(stagingData, page, limit);
+    const response = isPaginated
+      ? optionallyPaginatedResponse(
+          { count: stagingData.count, rows: results },
+          page,
+          limit,
+        )
+      : results;
 
     res.json(response);
   } catch (error) {

--- a/src/models/staging/staging.model.js
+++ b/src/models/staging/staging.model.js
@@ -25,6 +25,16 @@ import {
 } from '../../utils/xls';
 import { updateNilVerificationBodyAsEmptyString } from '../../utils/helpers.js';
 
+const buildAssociationIncludes = (ModelClass) =>
+  ModelClass.getAssociatedModels().map((association) => {
+    return {
+      model: association.model,
+      as: formatModelAssociationName(association),
+    };
+  });
+
+const dedupe = (values) => _.uniq(values.filter(Boolean));
+
 class Staging extends Model {
   static changes = new rxjs.Subject();
 
@@ -316,100 +326,141 @@ class Staging extends Model {
   };
 
   static getDiffObject = async (uuid, table, action, data) => {
-    const diff = {};
-    if (action === 'INSERT') {
-      diff.original = {};
-      diff.change = JSON.parse(data);
-    }
-
-    if (action === 'UPDATE') {
-      diff.change = JSON.parse(data);
-
-      let original;
-
-      if (table === 'Projects') {
-        original = await Project.findOne({
-          where: { warehouseProjectId: uuid },
-          include: Project.getAssociatedModels().map((association) => {
-            return {
-              model: association.model,
-              as: formatModelAssociationName(association),
-            };
-          }),
-        });
-
-        // Show the issuance data if its being reused
-        // this is just for view purposes onlys
-        await Promise.all(
-          diff.change.map(async (record) => {
-            if (record.issuanceId) {
-              const issuance = await Issuance.findOne({
-                where: { id: record.issuanceId },
-              });
-
-              record.issuance = issuance.dataValues;
-            }
-          }),
-        );
-      } else if (table === 'Units') {
-        original = await Unit.findOne({
-          where: { warehouseUnitId: uuid },
-          include: Unit.getAssociatedModels().map((association) => {
-            return {
-              model: association.model,
-              as: formatModelAssociationName(association),
-            };
-          }),
-        });
-
-        // Show the issuance data if its being reused,
-        // this is just for view purposes onlys
-        await Promise.all(
-          diff.change.map(async (record) => {
-            if (record.issuanceId) {
-              const issuance = await Issuance.findOne({
-                where: { id: record.issuanceId },
-              });
-
-              record.issuance = issuance.dataValues;
-            }
-          }),
-        );
-      }
-
-      diff.original = original;
-    }
-
-    if (action === 'DELETE') {
-      let original;
-
-      if (table === 'Projects') {
-        original = await Project.findOne({
-          where: { warehouseProjectId: uuid },
-          include: Project.getAssociatedModels().map((association) => {
-            return {
-              model: association.model,
-              as: formatModelAssociationName(association),
-            };
-          }),
-        });
-      } else if (table === 'Units') {
-        original = await Unit.findOne({
-          where: { warehouseUnitId: uuid },
-          include: Unit.getAssociatedModels().map((association) => {
-            return {
-              model: association.model,
-              as: formatModelAssociationName(association),
-            };
-          }),
-        });
-      }
-
-      diff.original = original;
-      diff.change = {};
-    }
-
+    const [diff] = await Staging.getDiffObjects([{ uuid, table, action, data }]);
     return diff;
+  };
+
+  static getDiffObjects = async (stagingRecords) => {
+    const normalizedRecords = stagingRecords.map((record) => {
+      if (!record) {
+        return record;
+      }
+
+      return record.dataValues ? record.dataValues : record;
+    });
+
+    const parsedChanges = normalizedRecords.map((record) => {
+      if (!record || record.action !== 'UPDATE') {
+        return null;
+      }
+
+      return JSON.parse(record.data);
+    });
+
+    const unitIds = dedupe(
+      normalizedRecords
+        .filter(
+          (record) =>
+            record &&
+            record.table === 'Units' &&
+            ['UPDATE', 'DELETE'].includes(record.action),
+        )
+        .map((record) => record.uuid),
+    );
+    const projectIds = dedupe(
+      normalizedRecords
+        .filter(
+          (record) =>
+            record &&
+            record.table === 'Projects' &&
+            ['UPDATE', 'DELETE'].includes(record.action),
+        )
+        .map((record) => record.uuid),
+    );
+    const issuanceIds = dedupe(
+      normalizedRecords.flatMap((record, index) => {
+        if (
+          !record ||
+          record.action !== 'UPDATE' ||
+          !['Projects', 'Units'].includes(record.table)
+        ) {
+          return [];
+        }
+
+        return (parsedChanges[index] || []).map((changeRecord) => changeRecord.issuanceId);
+      }),
+    );
+
+    const [units, projects, issuances] = await Promise.all([
+      unitIds.length
+        ? Unit.findAll({
+            where: { warehouseUnitId: { [Op.in]: unitIds } },
+            include: buildAssociationIncludes(Unit),
+          })
+        : [],
+      projectIds.length
+        ? Project.findAll({
+            where: { warehouseProjectId: { [Op.in]: projectIds } },
+            include: buildAssociationIncludes(Project),
+          })
+        : [],
+      issuanceIds.length
+        ? Issuance.findAll({
+            where: { id: { [Op.in]: issuanceIds } },
+          })
+        : [],
+    ]);
+
+    const unitsById = new Map(
+      units.map((record) => [record.warehouseUnitId, record]),
+    );
+    const projectsById = new Map(
+      projects.map((record) => [record.warehouseProjectId, record]),
+    );
+    const issuancesById = new Map(
+      issuances.map((record) => [record.id, record.dataValues]),
+    );
+
+    return normalizedRecords.map((record, index) => {
+      const diff = {};
+
+      if (record.action === 'INSERT') {
+        diff.original = {};
+        diff.change = JSON.parse(record.data);
+        return diff;
+      }
+
+      if (record.action === 'UPDATE') {
+        diff.change = parsedChanges[index];
+
+        if (['Projects', 'Units'].includes(record.table)) {
+          diff.change.forEach((changeRecord) => {
+            if (changeRecord.issuanceId) {
+              if (!issuancesById.has(changeRecord.issuanceId)) {
+                logger.warn(
+                  `[v1][staging:getDiffObjects] Missing issuance '${changeRecord.issuanceId}' for staged ${record.table} record '${record.uuid}'`,
+                );
+                throw new Error(
+                  `Could not find issuance '${changeRecord.issuanceId}' for staged ${record.table} record '${record.uuid}'`,
+                );
+              }
+
+              changeRecord.issuance = issuancesById.get(changeRecord.issuanceId);
+            }
+          });
+        }
+
+        diff.original =
+          record.table === 'Projects'
+            ? projectsById.get(record.uuid) ?? null
+            : record.table === 'Units'
+              ? unitsById.get(record.uuid) ?? null
+              : undefined;
+        return diff;
+      }
+
+      if (record.action === 'DELETE') {
+        diff.original =
+          record.table === 'Projects'
+            ? projectsById.get(record.uuid) ?? null
+            : record.table === 'Units'
+              ? unitsById.get(record.uuid) ?? null
+              : undefined;
+        diff.change = {};
+      }
+
+      return diff;
+    });
   };
 
   static seperateStagingDataIntoActionGroups = (stagedData, table) => {

--- a/src/models/v2/offer-v2.model.js
+++ b/src/models/v2/offer-v2.model.js
@@ -431,12 +431,16 @@ class OfferV2 {
       const tradeId = tradeIdRecord.meta_value;
       await datalayerPersistance.cancelOffer(tradeId);
 
-      // Remove trade ID from MetaV2
-      await MetaV2.destroy({
-        where: {
-          meta_key: 'activeOfferTradeId',
-        },
-      });
+      // Clear the active offer trade ID and the transfer-staging marker in
+      // parallel, mirroring the v1 offer.controller.cancelActiveOffer flow.
+      // The transfer-staging row (committed: true, is_transfer: true) is
+      // preserved by the periodic sync-registries-v2 truncate on purpose so
+      // that GET /v2/offer can read it between transfer-stage and offer
+      // consumption; it must be cleaned up here when the offer is cancelled.
+      await Promise.all([
+        MetaV2.destroy({ where: { meta_key: 'activeOfferTradeId' } }),
+        StagingV2.destroy({ where: { is_transfer: true } }),
+      ]);
     } catch (error) {
       loggerV2.error('[v2]: Error canceling active offer:', error);
       throw new Error(error.message);

--- a/src/tasks/sync-registries-v2.js
+++ b/src/tasks/sync-registries-v2.js
@@ -97,11 +97,17 @@ const truncateStagingV2 = async () => {
 
   while (!success && attempts < maxAttempts) {
     try {
-      // Only delete records that have been marked as committed
-      // This prevents deleting newly staged records that haven't been committed yet
+      // Only delete records that have been marked as committed.
+      // This prevents deleting newly staged records that haven't been committed yet.
+      // Exclude is_transfer records: project transfers are staged with
+      // committed: true + is_transfer: true and must persist until the offer
+      // flow consumes them (see staging-v2.model generateOfferFile and the
+      // offer controller). They are cleaned up explicitly by the offer flow,
+      // not by this periodic task.
       await StagingV2.destroy({
         where: {
           committed: true,
+          is_transfer: false,
         },
       });
       success = true; // If destroy succeeds, set success to true to exit the loop

--- a/src/tasks/sync-registries.js
+++ b/src/tasks/sync-registries.js
@@ -215,7 +215,20 @@ const truncateStaging = async () => {
   while (!success && attempts < maxAttempts) {
     try {
       if (CONFIG.USE_SIMULATOR) {
-        await Staging.destroy({ where: { commited: true } });
+        // Simulator-mode cleanup: delete only committed non-transfer
+        // records. Project transfers are staged with commited: true +
+        // isTransfer: true and must persist until the offer flow consumes
+        // them (see Staging.generateOfferFile and
+        // offer.controller.cancelActiveOffer, which destroys the
+        // isTransfer row on cancel). Excluding them here matches the
+        // existing v1 cancelActiveOffer contract.
+        //
+        // The non-simulator branch below still calls truncate()
+        // unconditionally; that pre-existing race on the v1 transfer
+        // flow is out of scope for this change.
+        await Staging.destroy({
+          where: { commited: true, isTransfer: false },
+        });
       } else {
         await Staging.truncate();
       }

--- a/tests/resources/staging.spec.js
+++ b/tests/resources/staging.spec.js
@@ -3,8 +3,10 @@ import supertest from 'supertest';
 import newProject from '../test-data/new-project.js';
 import { pullPickListValues } from '../../src/utils/data-loaders';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { prepareDb } from '../../src/database';
 import datalayer from '../../src/datalayer';
+import { Issuance, Project, Staging, Unit } from '../../src/models';
 const TEST_WAIT_TIME = datalayer.POLLING_INTERVAL * 2;
 
 describe('Staging Resource CRUD', function () {
@@ -15,6 +17,10 @@ describe('Staging Resource CRUD', function () {
 
   beforeEach(async function () {
     await supertest(app).delete(`/v1/staging/clean`);
+  });
+
+  afterEach(function () {
+    sinon.restore();
   });
 
   describe('GET - Find all Staging Records', function () {
@@ -39,6 +45,337 @@ describe('Staging Resource CRUD', function () {
         'Biodiversity through planting a variety of trees that are home to many native Singaporean species',
       );
     }).timeout(TEST_WAIT_TIME * 10);
+
+    it('uses findAll instead of findAndCountAll for unpaginated reads', async function () {
+      const stagedRows = [
+        {
+          id: 1,
+          uuid: 'unit-1',
+          table: 'Units',
+          action: 'DELETE',
+          data: '{}',
+          dataValues: {
+            id: 1,
+            uuid: 'unit-1',
+            table: 'Units',
+            action: 'DELETE',
+            data: '{}',
+          },
+        },
+        {
+          id: 2,
+          uuid: 'unit-2',
+          table: 'Units',
+          action: 'DELETE',
+          data: '{}',
+          dataValues: {
+            id: 2,
+            uuid: 'unit-2',
+            table: 'Units',
+            action: 'DELETE',
+            data: '{}',
+          },
+        },
+      ];
+      const findAllStub = sinon.stub(Staging, 'findAll').resolves(stagedRows);
+      const findAndCountAllStub = sinon.stub(Staging, 'findAndCountAll');
+      const getDiffObjectsStub = sinon.stub(Staging, 'getDiffObjects').resolves([
+        { original: { warehouseUnitId: 'unit-1' }, change: {} },
+        { original: { warehouseUnitId: 'unit-2' }, change: {} },
+      ]);
+
+      const response = await supertest(app).get('/v1/staging').expect(200);
+
+      expect(findAllStub.calledOnce).to.be.true;
+      expect(findAndCountAllStub.called).to.be.false;
+      expect(getDiffObjectsStub.calledOnce).to.be.true;
+      expect(getDiffObjectsStub.firstCall.args[0]).to.deep.equal(stagedRows);
+      expect(findAllStub.firstCall.args[0]).to.deep.equal({
+        where: {},
+        order: [['id', 'ASC']],
+      });
+      expect(response.body).to.have.length(2);
+      expect(response.body[0].diff.original.warehouseUnitId).to.equal('unit-1');
+      expect(response.body[1].diff.original.warehouseUnitId).to.equal('unit-2');
+    });
+
+    it('uses findAndCountAll for paginated reads', async function () {
+      const stagedRows = [
+        {
+          id: 3,
+          uuid: 'unit-3',
+          table: 'Units',
+          action: 'DELETE',
+          data: '{}',
+          dataValues: {
+            id: 3,
+            uuid: 'unit-3',
+            table: 'Units',
+            action: 'DELETE',
+            data: '{}',
+          },
+        },
+        {
+          id: 4,
+          uuid: 'unit-4',
+          table: 'Units',
+          action: 'DELETE',
+          data: '{}',
+          dataValues: {
+            id: 4,
+            uuid: 'unit-4',
+            table: 'Units',
+            action: 'DELETE',
+            data: '{}',
+          },
+        },
+      ];
+      const findAllStub = sinon.stub(Staging, 'findAll');
+      const findAndCountAllStub = sinon.stub(Staging, 'findAndCountAll').resolves({
+        count: 2,
+        rows: stagedRows,
+      });
+      const getDiffObjectsStub = sinon.stub(Staging, 'getDiffObjects').resolves([
+        { original: { warehouseUnitId: 'unit-3' }, change: {} },
+        { original: { warehouseUnitId: 'unit-4' }, change: {} },
+      ]);
+
+      const response = await supertest(app)
+        .get('/v1/staging')
+        .query({ page: 1, limit: 10 })
+        .expect(200);
+
+      expect(findAndCountAllStub.calledOnce).to.be.true;
+      expect(findAllStub.called).to.be.false;
+      expect(getDiffObjectsStub.calledOnce).to.be.true;
+      expect(getDiffObjectsStub.firstCall.args[0]).to.deep.equal(stagedRows);
+      expect(findAndCountAllStub.firstCall.args[0]).to.deep.equal({
+        distinct: true,
+        where: {},
+        order: [['id', 'ASC']],
+        limit: 10,
+        offset: 0,
+      });
+      expect(response.body.page).to.equal(1);
+      expect(response.body.pageCount).to.equal(1);
+      expect(response.body.data).to.have.length(2);
+      expect(response.body.data[0].diff.original.warehouseUnitId).to.equal('unit-3');
+      expect(response.body.data[1].diff.original.warehouseUnitId).to.equal('unit-4');
+    });
+
+    it('treats limit-only reads as unpaginated', async function () {
+      const stagedRow = {
+        id: 1,
+        uuid: 'unit-1',
+        table: 'Units',
+        action: 'DELETE',
+        data: '{}',
+        dataValues: {
+          id: 1,
+          uuid: 'unit-1',
+          table: 'Units',
+          action: 'DELETE',
+          data: '{}',
+        },
+      };
+      const findAllStub = sinon.stub(Staging, 'findAll').resolves([stagedRow]);
+      const findAndCountAllStub = sinon.stub(Staging, 'findAndCountAll');
+      const getDiffObjectsStub = sinon
+        .stub(Staging, 'getDiffObjects')
+        .resolves([{ original: { warehouseUnitId: 'unit-1' }, change: {} }]);
+
+      const response = await supertest(app).get('/v1/staging').expect(200);
+
+      expect(findAllStub.calledOnce).to.be.true;
+      expect(findAndCountAllStub.called).to.be.false;
+      expect(findAllStub.firstCall.args[0]).to.deep.equal({
+        where: {},
+        order: [['id', 'ASC']],
+      });
+      expect(response.body).to.have.length(1);
+      expect(response.body[0].diff.original.warehouseUnitId).to.equal('unit-1');
+    });
+  });
+
+  describe('Diff batching', function () {
+    it('batches unit original lookups for delete diffs', async function () {
+      const unitFindOneStub = sinon.stub(Unit, 'findOne');
+      const unitFindAllStub = sinon.stub(Unit, 'findAll').resolves([
+        { warehouseUnitId: 'unit-2', issuance: { id: 'iss-2' } },
+        { warehouseUnitId: 'unit-1', issuance: { id: 'iss-1' } },
+      ]);
+
+      const diffs = await Staging.getDiffObjects([
+        { uuid: 'unit-1', table: 'Units', action: 'DELETE', data: '{}' },
+        { uuid: 'unit-2', table: 'Units', action: 'DELETE', data: '{}' },
+      ]);
+
+      expect(unitFindAllStub.calledOnce).to.be.true;
+      expect(unitFindOneStub.called).to.be.false;
+      expect(unitFindAllStub.firstCall.args[0].include).to.be.an('array').that.is
+        .not.empty;
+      expect(diffs[0].original.warehouseUnitId).to.equal('unit-1');
+      expect(diffs[1].original.warehouseUnitId).to.equal('unit-2');
+      expect(diffs[0].original.issuance.id).to.equal('iss-1');
+      expect(diffs[1].original.issuance.id).to.equal('iss-2');
+      expect(diffs[0].change).to.deep.equal({});
+      expect(diffs[1].change).to.deep.equal({});
+    });
+
+    it('batches project original lookups for delete diffs', async function () {
+      const projectFindOneStub = sinon.stub(Project, 'findOne');
+      const projectFindAllStub = sinon.stub(Project, 'findAll').resolves([
+        { warehouseProjectId: 'project-2', issuances: [{ id: 'iss-2' }] },
+        { warehouseProjectId: 'project-1', issuances: [{ id: 'iss-1' }] },
+      ]);
+
+      const diffs = await Staging.getDiffObjects([
+        { uuid: 'project-1', table: 'Projects', action: 'DELETE', data: '{}' },
+        { uuid: 'project-2', table: 'Projects', action: 'DELETE', data: '{}' },
+      ]);
+
+      expect(projectFindAllStub.calledOnce).to.be.true;
+      expect(projectFindOneStub.called).to.be.false;
+      expect(projectFindAllStub.firstCall.args[0].include).to.be.an('array').that
+        .is.not.empty;
+      expect(diffs[0].original.warehouseProjectId).to.equal('project-1');
+      expect(diffs[1].original.warehouseProjectId).to.equal('project-2');
+      expect(diffs[0].original.issuances[0].id).to.equal('iss-1');
+      expect(diffs[1].original.issuances[0].id).to.equal('iss-2');
+      expect(diffs[0].change).to.deep.equal({});
+      expect(diffs[1].change).to.deep.equal({});
+    });
+
+    it('batches issuance lookups when update changes reuse issuances', async function () {
+      const unitFindAllStub = sinon.stub(Unit, 'findAll').resolves([
+        { warehouseUnitId: 'unit-1' },
+        { warehouseUnitId: 'unit-2' },
+      ]);
+      const issuanceFindAllStub = sinon.stub(Issuance, 'findAll').resolves([
+        { id: 'iss-1', dataValues: { id: 'iss-1', verificationBody: 'Verifier' } },
+      ]);
+
+      const diffs = await Staging.getDiffObjects([
+        {
+          uuid: 'unit-1',
+          table: 'Units',
+          action: 'UPDATE',
+          data: JSON.stringify([{ issuanceId: 'iss-1', unitCount: 1 }]),
+        },
+        {
+          uuid: 'unit-2',
+          table: 'Units',
+          action: 'UPDATE',
+          data: JSON.stringify([{ issuanceId: 'iss-1', unitCount: 2 }]),
+        },
+      ]);
+
+      expect(unitFindAllStub.calledOnce).to.be.true;
+      expect(issuanceFindAllStub.calledOnce).to.be.true;
+      expect(diffs[0].change[0].issuance.id).to.equal('iss-1');
+      expect(diffs[1].change[0].issuance.verificationBody).to.equal('Verifier');
+    });
+
+    it('batches issuance lookups for project updates too', async function () {
+      const projectFindAllStub = sinon.stub(Project, 'findAll').resolves([
+        { warehouseProjectId: 'project-2' },
+        { warehouseProjectId: 'project-1' },
+      ]);
+      const issuanceFindAllStub = sinon.stub(Issuance, 'findAll').resolves([
+        { id: 'iss-2', dataValues: { id: 'iss-2', verificationBody: 'Project Verifier' } },
+      ]);
+
+      const diffs = await Staging.getDiffObjects([
+        {
+          uuid: 'project-1',
+          table: 'Projects',
+          action: 'UPDATE',
+          data: JSON.stringify([{ issuanceId: 'iss-2', projectName: 'Updated Project' }]),
+        },
+        {
+          uuid: 'project-2',
+          table: 'Projects',
+          action: 'UPDATE',
+          data: JSON.stringify([{ issuanceId: 'iss-2', projectName: 'Updated Project 2' }]),
+        },
+      ]);
+
+      expect(projectFindAllStub.calledOnce).to.be.true;
+      expect(issuanceFindAllStub.calledOnce).to.be.true;
+      expect(diffs[0].change[0].issuance.id).to.equal('iss-2');
+      expect(diffs[0].change[0].issuance.verificationBody).to.equal(
+        'Project Verifier',
+      );
+      expect(diffs[1].change[0].issuance.id).to.equal('iss-2');
+    });
+
+    it('throws when an update references a missing issuance', async function () {
+      sinon.stub(Unit, 'findAll').resolves([{ warehouseUnitId: 'unit-1' }]);
+      sinon.stub(Issuance, 'findAll').resolves([]);
+
+      try {
+        await Staging.getDiffObjects([
+          {
+            uuid: 'unit-1',
+            table: 'Units',
+            action: 'UPDATE',
+            data: JSON.stringify([{ issuanceId: 'missing-issuance', unitCount: 1 }]),
+          },
+        ]);
+        expect.fail('Expected missing issuance lookup to throw');
+      } catch (error) {
+        expect(error.message).to.include(
+          "Could not find issuance 'missing-issuance'",
+        );
+      }
+    });
+
+    it('preserves generic update payloads for non-project staging tables', async function () {
+      const diffs = await Staging.getDiffObjects([
+        {
+          uuid: 'label-1',
+          table: 'Labels',
+          action: 'UPDATE',
+          data: JSON.stringify([{ label: 'updated-label' }]),
+        },
+      ]);
+
+      expect(diffs[0].change).to.deep.equal([{ label: 'updated-label' }]);
+      expect(diffs[0].original).to.equal(undefined);
+    });
+
+    it('returns null when a batched original record is missing', async function () {
+      sinon.stub(Unit, 'findAll').resolves([]);
+
+      const diffs = await Staging.getDiffObjects([
+        { uuid: 'missing-unit', table: 'Units', action: 'DELETE', data: '{}' },
+      ]);
+
+      expect(diffs[0].original).to.equal(null);
+      expect(diffs[0].change).to.deep.equal({});
+    });
+
+    it('preserves the single-record getDiffObject adapter', async function () {
+      const getDiffObjectsStub = sinon.stub(Staging, 'getDiffObjects').resolves([
+        { original: { warehouseUnitId: 'unit-99' }, change: {} },
+      ]);
+
+      const diff = await Staging.getDiffObject(
+        'unit-99',
+        'Units',
+        'DELETE',
+        '{}',
+      );
+
+      expect(getDiffObjectsStub.calledOnce).to.be.true;
+      expect(getDiffObjectsStub.firstCall.args[0]).to.deep.equal([
+        { uuid: 'unit-99', table: 'Units', action: 'DELETE', data: '{}' },
+      ]);
+      expect(diff).to.deep.equal({
+        original: { warehouseUnitId: 'unit-99' },
+        change: {},
+      });
+    });
   });
 
   describe('POST - Commit Records to datalayer', function () {

--- a/tests/resources/staging.spec.js
+++ b/tests/resources/staging.spec.js
@@ -184,10 +184,14 @@ describe('Staging Resource CRUD', function () {
         .stub(Staging, 'getDiffObjects')
         .resolves([{ original: { warehouseUnitId: 'unit-1' }, change: {} }]);
 
-      const response = await supertest(app).get('/v1/staging').expect(200);
+      const response = await supertest(app)
+        .get('/v1/staging')
+        .query({ limit: 10 })
+        .expect(200);
 
       expect(findAllStub.calledOnce).to.be.true;
       expect(findAndCountAllStub.called).to.be.false;
+      expect(getDiffObjectsStub.calledOnce).to.be.true;
       expect(findAllStub.firstCall.args[0]).to.deep.equal({
         where: {},
         order: [['id', 'ASC']],

--- a/tests/v2/integration/offer-v2.spec.js
+++ b/tests/v2/integration/offer-v2.spec.js
@@ -380,6 +380,44 @@ describe('Phase 18.4: OfferV2 Integration Tests', function () {
           }
         });
     });
+
+    it('should remove activeOfferTradeId meta and is_transfer staging row on successful cancel', async function () {
+      // Regression guard: cancelActiveOffer must clear both MetaV2.activeOfferTradeId
+      // and the is_transfer staging marker, since the periodic truncateStagingV2
+      // task deliberately preserves is_transfer rows (see src/tasks/sync-registries-v2.js).
+      await MetaV2.destroy({ where: {} });
+      await resetV2StagingTable();
+
+      await MetaV2.create({
+        meta_key: 'activeOfferTradeId',
+        meta_value: 'test-trade-id-cleanup',
+      });
+
+      await StagingV2.create({
+        uuid: testProject.cadTrustProjectId,
+        table: 'project',
+        action: 'UPDATE',
+        data: JSON.stringify([
+          { cad_trust_project_id: testProject.cadTrustProjectId },
+        ]),
+        committed: true,
+        failed_commit: false,
+        is_transfer: true,
+      });
+
+      const response = await supertest(app).delete('/v2/offer').expect(200);
+      expect(response.body).to.have.property('success', true);
+
+      const remainingTradeIdMeta = await MetaV2.findOne({
+        where: { meta_key: 'activeOfferTradeId' },
+      });
+      expect(remainingTradeIdMeta, 'activeOfferTradeId meta should be cleared').to.be.null;
+
+      const remainingTransferRows = await StagingV2.count({
+        where: { is_transfer: true },
+      });
+      expect(remainingTransferRows, 'is_transfer staging row should be cleared').to.equal(0);
+    });
   });
 
   describe('POST /v2/offer/accept/commit - Commit imported offer', function () {


### PR DESCRIPTION
## Summary
- batch v1 staging diff hydration so project, unit, and issuance records are fetched in bulk instead of one query per row
- skip the extra count query for unpaginated `GET /v1/staging` reads while preserving existing response shapes
- add focused regression coverage for controller branch selection, batched diff loading, missing issuance handling, and null normalization

## Test plan
- [x] `eval "$(fnm env)" && fnm use && bash tests/run-tests.sh ./node_modules/.bin/cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31310 ./node_modules/.bin/mocha --loader node_modules/extensionless/src/register.js "tests/resources/staging.spec.js" --grep "uses findAll instead of findAndCountAll for unpaginated reads|uses findAndCountAll for paginated reads|treats limit-only reads as unpaginated|batches unit original lookups for delete diffs|batches project original lookups for delete diffs|batches issuance lookups when update changes reuse issuances|batches issuance lookups for project updates too|throws when an update references a missing issuance|preserves generic update payloads for non-project staging tables|returns null when a batched original record is missing|preserves the single-record getDiffObject adapter" --reporter spec --exit --timeout 300000`
- [ ] capture before/after benchmark data for the large real staging payload noted in the ticket

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `GET /v1/staging` loads data and computes diffs (including new error behavior for missing issuances) and adjusts staging cleanup rules around transfer records, which could affect operational workflows if assumptions differ.
> 
> **Overview**
> Improves `GET /v1/staging` performance by skipping the extra count query when the request is **not paginated** (uses `findAll` + stable `order`), while preserving the existing paginated response shape when `page` is provided.
> 
> Refactors v1 staging diff hydration to batch-fetch `Project`, `Unit`, and `Issuance` data via new `Staging.getDiffObjects`, replacing per-row lookups; `getDiffObject` becomes a thin adapter. Missing issuances referenced by staged updates now **warn + throw**, and missing originals normalize to `null`.
> 
> Adjusts staging cleanup around transfers: v2 periodic truncation now preserves `is_transfer` rows, and v2 offer cancel explicitly clears both `MetaV2.activeOfferTradeId` and transfer staging rows; v1 simulator-mode staging cleanup similarly excludes `isTransfer` rows. Adds focused regression tests covering controller pagination branching, batched diff loading, and offer-cancel transfer cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b951fe614010adb7211ade06dc7e9c2d63a77fbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->