### PR TITLE
perf(V2): cut live API CI time ~11 min by splitting cascade-delete into parallel job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -624,6 +624,540 @@ jobs:
           chia stop all -d || true
           echo "Chia services stopped"
 
+  test-v2-live-cascade-delete:
+    name: v2 live api cascade delete tests
+    runs-on: ubuntu-latest
+    container:
+      image: node:24
+
+    steps:
+      - uses: Chia-Network/actions/clean-workspace@main
+
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Ignore Husky
+        run: npm pkg delete scripts.prepare
+
+      - name: Install Mocha
+        run: npm install --save-dev mocha
+
+      - name: npm install
+        run: npm install
+
+      - name: install global packages
+        run: npm i -g @babel/cli sequelize-cli cross-env pm2@latest
+      - name: Show home directory
+        run: ls -lah ~
+
+      - name: Install system packages and Chia tools
+        shell: bash
+        run: |
+          curl -sL https://repo.chia.net/FD39E6D3.pubkey.asc | gpg --dearmor -o /usr/share/keyrings/chia.gpg
+
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/chia.gpg] https://repo.chia.net/debian/ stable main" | tee /etc/apt/sources.list.d/chia.list > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/chia.gpg] https://repo.chia.net/chia-tools/debian/ stable main" | tee /etc/apt/sources.list.d/chia-tools.list > /dev/null
+
+          apt-get update
+          apt-get install -y yq jq bc iproute2 default-mysql-server default-mysql-client chia-blockchain-cli chia-tools
+
+      - name: Configure MySQL for mirror database testing
+        shell: bash
+        run: |
+          echo "Starting MariaDB service..."
+          service mariadb start
+
+          # Wait for MariaDB to be ready
+          echo "Waiting for MariaDB to be ready..."
+          for i in {1..30}; do
+            if mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "MariaDB is ready!"
+              break
+            fi
+            echo "Waiting for MariaDB... ($i/30)"
+            sleep 1
+          done
+
+          echo "Creating test database and user..."
+          mysql -u root <<EOF
+          CREATE DATABASE IF NOT EXISTS cadt_mirror_test;
+          CREATE DATABASE IF NOT EXISTS cadt_mirror_test_v2;
+          CREATE USER IF NOT EXISTS 'cadt_test'@'localhost' IDENTIFIED BY 'cadt_test_password';
+          GRANT ALL PRIVILEGES ON cadt_mirror_test.* TO 'cadt_test'@'localhost';
+          GRANT ALL PRIVILEGES ON cadt_mirror_test_v2.* TO 'cadt_test'@'localhost';
+          FLUSH PRIVILEGES;
+          EOF
+
+          echo "Verifying MariaDB setup..."
+          mysql -u cadt_test -pcadt_test_password -e "SELECT 1 as test;" || {
+            echo "Failed to connect as test user"
+            exit 1
+          }
+          echo "✓ MariaDB (MySQL-compatible) mirror database is ready for testing"
+
+          # Stop MariaDB so CADT starts against a DOWN mirror. This exercises
+          # the startup race that k8s observers hit: CADT up before MySQL is
+          # reachable. The subsequent "Delay-start MariaDB (exercise mirror
+          # reconnect recovery)" step will restart MariaDB ~30s after CADT,
+          # and the V2 mirror reconnect path must transparently run
+          # migrations + backfill and catch up without losing any writes.
+          # If the test fails, either the init race fix or the
+          # reconnect-backfill logic has regressed.
+          #
+          # The race test is load-bearing on MariaDB actually being down
+          # when CADT starts - fail the job if mysqladmin can still ping it
+          # after 10 seconds of retries rather than letting the test
+          # silently degrade into a no-op.
+          echo "Stopping MariaDB so CADT starts against a down mirror..."
+          service mariadb stop
+          for STOP_ATTEMPT in $(seq 1 10); do
+            if ! mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "✓ MariaDB stopped after ${STOP_ATTEMPT}s - CADT startup will race against delayed restart"
+              break
+            fi
+            if [ "$STOP_ATTEMPT" -eq 10 ]; then
+              echo "ERROR: MariaDB still responding 10s after 'service mariadb stop'."
+              echo "The race test's precondition (MariaDB down when CADT starts) cannot be met."
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Configure Chia
+        shell: bash
+        run: |
+          chia init
+          chia keys generate -l "functional_tests"
+          chia-tools network switch testneta
+          chia-tools config add-trusted-peer -y testneta-node-msp.chia.net 58444
+          chia-tools config edit --set wallet.connect_to_unknown_peers=false --set 'wallet.trusted_cidrs=["207.228.216.0/22"]'
+          chia configure -log-level INFO
+
+      - name: Configure CADT
+        shell: bash
+        run: |
+          # Run cadt momentarily to create config file. Note: MariaDB is
+          # intentionally stopped at this point to exercise the mirror
+          # init race on first boot - CADT must log the setup failure
+          # non-fatally and continue, then recover automatically once
+          # MariaDB restarts.
+          pm2 start npm --no-autorestart --name "cadt" -- start
+          sleep 10
+          pm2 logs cadt --nostream
+          pm2 stop cadt
+
+          # Remove cadt databases to reset system
+          echo "Removing cadt databases to reset system..."
+          rm -f ~/.chia/mainnet/cadt/v1/data.sqlite3*
+          rm -f ~/.chia/mainnet/cadt/v2/data.sqlite3*
+
+          # Configure CADT to most verbose logs
+          echo "Configuring CADT config.yaml..."
+          yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Set network to testnet to match the Chia network configuration
+          # Value must be lowercase - the check uses case-sensitive .includes()
+          yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
+          # Use 127.0.0.1 instead of localhost for more reliable binding in containers
+          yq -yi '.APP.BIND_ADDRESS = "127.0.0.1"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V1.GOVERNANCE.GOVERNANCE_BODY_ID = "22a0331b3b789fde950511f1c13d4d96cda127d7f5ecf8eaab64e5cc8e8dfc48"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DATALAYER_HOST = "https://127.0.0.1:8562"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.WALLET_HOST = "https://127.0.0.1:9256"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DATALAYER_FILE_SERVER_URL = "https://127.0.0.1:8575"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.AUTO_MIRROR_EXTERNAL_STORES = false' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V2.GOVERNANCE.GOVERNANCE_BODY_ID = ""' ~/.chia/mainnet/cadt/config.yaml
+          # Enable V2 for V2 live API tests
+          yq -yi '.V2.ENABLE = true' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V1.ENABLE = false' ~/.chia/mainnet/cadt/config.yaml
+
+          # Configure MySQL mirror database for V2 testing
+          # MIRROR_DB must be under V2 section for V2 API
+          echo "Configuring MySQL mirror database for V2..."
+          yq -yi '.V2.MIRROR_DB.DB_HOST = "localhost"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V2.MIRROR_DB.DB_USERNAME = "cadt_test"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V2.MIRROR_DB.DB_PASSWORD = "cadt_test_password"' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.V2.MIRROR_DB.DB_NAME = "cadt_mirror_test"' ~/.chia/mainnet/cadt/config.yaml
+
+          # Show the config file
+          echo "Showing the config file after configuration ... (this is the final config file)"
+          cat ~/.chia/mainnet/cadt/config.yaml
+
+          # Clean up any existing PM2 processes with the same name
+          pm2 delete cadt 2>/dev/null || true
+
+      - name: Start Chia
+        shell: bash
+        run: |
+          chia start wallet data data_layer_http
+          sleep 10
+          tail ~/.chia/mainnet/log/debug.log
+          chia wallet show
+
+      - name: Faucet
+        shell: bash
+        run: |
+          CHIA_WALLET_ADDRESS=$(chia wallet get_address)
+          echo "Requesting funds from faucet for address: $CHIA_WALLET_ADDRESS"
+          FAUCET_SUCCESS=false
+          for FAUCET_ATTEMPT in 1 2 3 4 5; do
+            echo "Faucet request attempt $FAUCET_ATTEMPT/5..."
+            FAUCET_RESPONSE=$(curl -s -w "\n%{http_code}" --max-time 30 -X POST \
+              -H "Content-Type: application/json" \
+              -d '{"address":"'"$CHIA_WALLET_ADDRESS"'","amount":0.0001}' \
+              "${{ secrets.TESTNETA_FAUCET }}" 2>&1) || true
+            FAUCET_HTTP_CODE=$(echo "$FAUCET_RESPONSE" | tail -1)
+            FAUCET_BODY=$(echo "$FAUCET_RESPONSE" | head -n -1)
+            echo "  Response (HTTP $FAUCET_HTTP_CODE): $FAUCET_BODY"
+            if [ -n "$FAUCET_HTTP_CODE" ] && [ "$FAUCET_HTTP_CODE" -ge 200 ] 2>/dev/null && [ "$FAUCET_HTTP_CODE" -lt 300 ] 2>/dev/null; then
+              echo "Faucet request succeeded on attempt $FAUCET_ATTEMPT"
+              FAUCET_SUCCESS=true
+              break
+            fi
+            if [ "$FAUCET_ATTEMPT" -lt 5 ]; then
+              echo "  Faucet request failed, retrying in 15 seconds..."
+              sleep 15
+            fi
+          done
+          if [ "$FAUCET_SUCCESS" = "false" ]; then
+            echo "WARNING: All 5 faucet attempts failed or returned empty response. Proceeding to balance polling in case a request was queued."
+          fi
+
+          echo "Waiting for wallet to receive funds..."
+          MAX_ATTEMPTS=60  # 60 attempts * 10 seconds = 10 minutes
+          ATTEMPT=0
+          while true; do
+            BALANCE=$(chia rpc wallet get_wallet_balance '{"wallet_id": 1}' | jq -r '.wallet_balance.confirmed_wallet_balance')
+            echo "Current balance: $BALANCE (attempt $((ATTEMPT + 1))/$MAX_ATTEMPTS)"
+            if [ "$BALANCE" != "0" ] && [ "$BALANCE" != "null" ] && [ -n "$BALANCE" ]; then
+              XCH_BALANCE=$(echo "scale=12; $BALANCE / 1000000000000" | bc)
+              echo "Wallet funded! Balance: $BALANCE mojos ($XCH_BALANCE XCH)"
+              break
+            fi
+            ATTEMPT=$((ATTEMPT + 1))
+            if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+              echo "ERROR: Timeout waiting for wallet to be funded after 10 minutes"
+              exit 1
+            fi
+            echo "Balance still zero, waiting 10 seconds..."
+            sleep 10
+          done
+
+      - name: Show wallet balance after funding from faucet
+        shell: bash
+        run: |
+          chia wallet show
+
+      - name: Start CADT
+        shell: bash
+        run: |
+          # MariaDB is still stopped at this point (see "Configure MySQL").
+          # CADT must start successfully, log the mirror setup failure as
+          # non-fatal, and expose its health endpoint. This exercises the
+          # mirror init race that broke production observers on k8s.
+          pm2 start npm --no-autorestart --name "cadt" -- start
+          echo "Waiting for CADT health endpoint..."
+          MAX_CADT_HEALTH_ATTEMPTS=30
+          for CADT_ATTEMPT in $(seq 1 "$MAX_CADT_HEALTH_ATTEMPTS"); do
+            if curl -fsS --max-time 5 http://127.0.0.1:31310/health >/dev/null 2>&1; then
+              echo "CADT health endpoint is ready"
+              break
+            fi
+            if [ "$CADT_ATTEMPT" -eq "$MAX_CADT_HEALTH_ATTEMPTS" ]; then
+              echo "ERROR: CADT health endpoint did not become ready in time"
+              pm2 logs cadt --lines 200 --nostream || true
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Delay-start MariaDB (exercise mirror reconnect recovery)
+        shell: bash
+        run: |
+          # Restart MariaDB now that CADT has been running without it for a
+          # while. The next V2 mirror operation should:
+          #   1. Detect authenticate success following previous failures.
+          #   2. Retry CREATE DATABASE + migrations via prepareMysqlMirrorV2
+          #      (they never ran at startup because MariaDB was down).
+          #   3. Run backfillMirrorV2 to catch up any writes + deletes that
+          #      happened while MariaDB was unavailable.
+          # The live-api tests' verifyMirrorRecordsBatch assertions will
+          # fail if any step regresses.
+          echo "Waiting a few seconds so CADT logs multiple mirror-down messages..."
+          sleep 10
+          echo "Starting MariaDB (CADT should reconnect and recover)..."
+          service mariadb start
+          for i in {1..30}; do
+            if mysqladmin ping -h localhost --silent 2>/dev/null; then
+              echo "MariaDB is back up"
+              break
+            fi
+            sleep 1
+          done
+          # Re-verify the DB and test user persist - they were created
+          # before the stop, and the data directory is unchanged.
+          mysql -u cadt_test -pcadt_test_password -e "SELECT 1 as test;" || {
+            echo "Failed to reconnect to MariaDB after restart"
+            exit 1
+          }
+          echo "✓ MariaDB back online - CADT mirror recovery path will engage"
+
+      - name: Wait for wallet sync and datalayer readiness
+        shell: bash
+        run: |
+          echo "Waiting for wallet to finish syncing..."
+          MAX_WAIT_MINUTES=10
+          WAIT_SECONDS=$((MAX_WAIT_MINUTES * 60))
+          START_TIME=$(date +%s)
+
+          while true; do
+            CURRENT_TIME=$(date +%s)
+            ELAPSED=$((CURRENT_TIME - START_TIME))
+            REMAINING=$((WAIT_SECONDS - ELAPSED))
+
+            if [ "$REMAINING" -le 0 ]; then
+              echo "Reached maximum wait time of $MAX_WAIT_MINUTES minutes"
+              break
+            fi
+
+            # Check wallet sync status
+            WALLET_STATUS=$(chia rpc wallet get_sync_status 2>/dev/null || echo '{"synced": false}')
+            WALLET_SYNCED=$(echo "$WALLET_STATUS" | jq -r '.synced // false')
+            WALLET_SYNCING=$(echo "$WALLET_STATUS" | jq -r '.syncing // true')
+
+            echo "Wallet status: synced=$WALLET_SYNCED, syncing=$WALLET_SYNCING (elapsed: ${ELAPSED}s, remaining: ${REMAINING}s)"
+
+            if [ "$WALLET_SYNCED" = "true" ]; then
+              echo "Wallet is synced!"
+              echo "Verifying CADT health stays ready after wallet sync..."
+              MAX_HEALTH_CHECKS=12
+              HEALTH_OK=false
+              for HEALTH_ATTEMPT in $(seq 1 "$MAX_HEALTH_CHECKS"); do
+                if curl -fsS --max-time 5 http://127.0.0.1:31310/health >/dev/null 2>&1; then
+                  HEALTH_OK=true
+                  echo "CADT health confirmed"
+                  break
+                fi
+                sleep 5
+              done
+              if [ "$HEALTH_OK" != "true" ]; then
+                echo "ERROR: CADT health endpoint not ready after wallet sync"
+                exit 1
+              fi
+              break
+            fi
+
+            echo "Wallet still syncing, waiting 30 seconds..."
+            sleep 30
+          done
+
+          echo ""
+          echo "=========================================="
+          echo "Final Status Check"
+          echo "=========================================="
+
+          echo ""
+          echo "Wallet sync status:"
+          chia rpc wallet get_sync_status || echo "Failed to get wallet sync status"
+
+          echo ""
+          echo "Wallet balance:"
+          chia wallet show || echo "Failed to show wallet"
+
+          echo ""
+          echo "Datalayer subscriptions:"
+          chia rpc data_layer subscriptions || echo "Failed to get datalayer subscriptions"
+
+          echo ""
+          echo "Datalayer root for governance store (22a0331b3b789fde950511f1c13d4d96cda127d7f5ecf8eaab64e5cc8e8dfc48):"
+          chia rpc data_layer get_root '{"id": "22a0331b3b789fde950511f1c13d4d96cda127d7f5ecf8eaab64e5cc8e8dfc48"}' || echo "Failed to get root"
+
+      - name: Show CADT logs before tests
+        shell: bash
+        run: |
+          echo "Last 100 lines of CADT logs:"
+          pm2 logs cadt --lines 100 --nostream
+
+      - name: Pre-flight check
+        shell: bash
+        run: |
+          echo "########################################################"
+          echo "Running pre-flight checks before V2 live API tests"
+          echo "########################################################"
+          # Run pre-flight check - requires V2 for this job
+          npm run preflight-check:v2 || {
+            echo ""
+            echo "########################################################"
+            echo "PRE-FLIGHT CHECK FAILED - Showing additional debug info:"
+            echo "########################################################"
+            echo ""
+            echo "PM2 status:"
+            pm2 list || true
+            echo ""
+            echo "CADT pm2 logs (last 100 lines):"
+            pm2 logs cadt --lines 100 --nostream || true
+            echo ""
+            echo "Config file contents:"
+            cat ~/.chia/mainnet/cadt/config.yaml || true
+            echo ""
+            echo "Node processes:"
+            ps aux | grep -E "node|cadt" | grep -v grep || true
+            exit 1
+          }
+
+      - name: npm live api tests
+        env:
+          TEST_API_HOST: 127.0.0.1
+        run: |
+          echo "########################################################"
+          echo "Running organization creation tests"
+          echo "########################################################"
+          npm run test:v2:live:organization:create
+          echo "########################################################"
+          echo "Running wallet health sanity check"
+          echo "########################################################"
+          npm run test:v2:live:wallet-health
+          echo "########################################################"
+          echo "Running cascade delete tests"
+          echo "########################################################"
+          npm run test:v2:live:cascade-delete
+          echo "########################################################"
+          echo "Running organization deletion tests"
+          echo "########################################################"
+          npm run test:v2:live:organization:delete
+
+      - name: Show MySQL mirror database status
+        if: always()
+        shell: bash
+        run: |
+          echo "=========================================="
+          echo "MySQL/MariaDB Mirror Database Status"
+          echo "=========================================="
+          echo ""
+          echo "Checking MariaDB service status..."
+          service mariadb status || echo "MariaDB service status check failed"
+          echo ""
+          echo "Checking mirror database tables..."
+          mysql -u cadt_test -pcadt_test_password -e "USE cadt_mirror_test_v2; SHOW TABLES;" 2>/dev/null || echo "Could not list tables (DB may not have been created yet)"
+          echo ""
+          echo "Record counts in mirror tables:"
+          mysql -u cadt_test -pcadt_test_password cadt_mirror_test_v2 -e "
+            SELECT 'project_mirror' as table_name, COUNT(*) as count FROM project_mirror UNION ALL
+            SELECT 'methodology_mirror', COUNT(*) FROM methodology_mirror UNION ALL
+            SELECT 'program_mirror', COUNT(*) FROM program_mirror UNION ALL
+            SELECT 'unit_mirror', COUNT(*) FROM unit_mirror UNION ALL
+            SELECT 'issuance_mirror', COUNT(*) FROM issuance_mirror UNION ALL
+            SELECT 'verification_mirror', COUNT(*) FROM verification_mirror UNION ALL
+            SELECT 'validation_mirror', COUNT(*) FROM validation_mirror UNION ALL
+            SELECT 'location_mirror', COUNT(*) FROM location_mirror UNION ALL
+            SELECT 'estimation_mirror', COUNT(*) FROM estimation_mirror UNION ALL
+            SELECT 'rating_mirror', COUNT(*) FROM rating_mirror UNION ALL
+            SELECT 'label_mirror', COUNT(*) FROM label_mirror UNION ALL
+            SELECT 'stakeholder_mirror', COUNT(*) FROM stakeholder_mirror;
+          " 2>/dev/null || echo "Could not count records (tables may not exist)"
+
+      - name: Show CADT logs after tests
+        if: always()
+        shell: bash
+        run: |
+          for LOGFILE in ~/.pm2/logs/cadt-out.log ~/.pm2/logs/cadt-error.log; do
+            LOGNAME=$(basename "$LOGFILE")
+            echo "=========================================="
+            echo "CADT $LOGNAME:"
+            echo "=========================================="
+            if [ -f "$LOGFILE" ]; then
+              LOGSIZE=$(wc -c < "$LOGFILE")
+              LOGLINES=$(wc -l < "$LOGFILE")
+              echo "File size: $LOGSIZE bytes, $LOGLINES lines"
+              if [ "$LOGLINES" -le 2500 ]; then
+                cat "$LOGFILE"
+              else
+                echo "--- first 50 lines (startup) ---"
+                head -50 "$LOGFILE"
+                echo ""
+                echo "--- last 2000 lines (most recent) ---"
+                tail -2000 "$LOGFILE"
+              fi
+            else
+              echo "No $LOGNAME found"
+            fi
+            echo ""
+          done
+
+      - name: Upload CADT logs as artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cadt-logs-${{ github.job }}
+          path: |
+            ~/.pm2/logs/cadt-out.log
+            ~/.pm2/logs/cadt-error.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Show Chia debug log after tests (filtered)
+        if: always()
+        shell: bash
+        run: |
+          echo "=========================================="
+          echo "Chia debug log (filtered, last 5000 lines):"
+          echo "=========================================="
+          echo "Filtering out noisy messages..."
+          echo ""
+          tail -n 5000 ~/.chia/mainnet/log/debug.log 2>/dev/null | grep -v \
+            -e "Connecting: wss://127.0.0.1" \
+            -e "respond_block_headers from" \
+            -e "Time for request request_block_headers" \
+            -e "get_timestamp_for_height_from_peer add to cache" \
+            -e "request_puzzle_solution to peer" \
+            -e "acquired on.*keyring.yaml.lock" \
+            -e "released on.*keyring.yaml.lock" \
+            -e "request_header_blocks" \
+            -e "coin_state_update" \
+            -e "new_signage_point_or_end_of_sub_slot" \
+            -e "request_removal_proof" \
+            -e "RespondToCoinUpdates" \
+            -e "register_interest_in_coin" \
+            -e "request_children to peer" \
+            -e "respond_to_coin_update" \
+            -e "_coin_subscriptions" \
+            -e "Getting generator for" \
+            -e "SubscriptionConfig" \
+            -e "sub epoch.*start weight is" \
+            -e "Puzzle at index" \
+            -e "Attempting to acquire lock" \
+            -e "watchdog.observers.inotify_buffer" \
+            -e "filelock" \
+            -e "Adding derivation record" \
+            -e "Received message: WSMessage" \
+            -e "DataLayer subscription update pool" \
+            -e "register_service" \
+            -e "Cannot connect to host 127.0.0.1" \
+            -e "Failed to connect to PeerInfo" \
+            || echo "No Chia debug log found or all lines filtered"
+
+      - name: Stop CADT
+        if: always()
+        shell: bash
+        run: |
+          echo "Stopping CADT pm2 process..."
+          pm2 stop cadt || true
+          pm2 delete cadt || true
+          echo "CADT stopped"
+
+      - name: Show wallet balance (v2)
+        if: always()
+        shell: bash
+        run: |
+          echo "Wallet balance at end of job:"
+          chia wallet show || echo "Failed to show wallet"
+
+      - name: Stop Chia services (v2)
+        if: always()
+        shell: bash
+        run: |
+          echo "Stopping all Chia services..."
+          chia stop all -d || true
+          echo "Chia services stopped"
+
   test-v1-live-api:
     name: v1 live api tests
     runs-on: ubuntu-latest

--- a/tests/v2/live-api/cascade-delete.live.spec.js
+++ b/tests/v2/live-api/cascade-delete.live.spec.js
@@ -51,6 +51,11 @@ describe('Cascade Delete Live API Tests', function () {
     return parsed.some((p) => p?.[key] === value);
   });
 
+  // Graphs A and B are intentionally combined into one it() to share a single
+  // on-chain commit cycle.  Trade-off: a Graph A assertion failure will abort
+  // the test before Graph B executes.  Accepted because the two graphs share
+  // the same commit, and duplicating the commit cycle for isolation would cost
+  // ~2 min per CI run.
   it('should cascade delete project and sub-entity children through commit', async function () {
     // === Graph A: full project cascade (project + 11 children) ===
     const programAId = await postAndGetId('/v2/program', generateProgram(), 'cadTrustProgramId');

--- a/tests/v2/live-api/cascade-delete.live.spec.js
+++ b/tests/v2/live-api/cascade-delete.live.spec.js
@@ -51,165 +51,154 @@ describe('Cascade Delete Live API Tests', function () {
     return parsed[0]?.[key] === value;
   });
 
-  it('should cascade delete project children through commit', async function () {
-    const programId = await postAndGetId('/v2/program', generateProgram(), 'cadTrustProgramId');
-    const projectId = await postAndGetId('/v2/project', generateProject(programId), 'cadTrustProjectId');
-    const methodologyId = await postAndGetId('/v2/methodology', generateMethodology(), 'cadTrustMethodologyId');
-    const validationId = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
-    const verificationId = await postAndGetId('/v2/verification', generateVerification(projectId, validationId), 'cadTrustVerificationId');
-    const projectMethodologyId = await postAndGetId('/v2/project-methodology', generateProjectMethodology(projectId, methodologyId), 'cadTrustProjectMethodologyId');
-    const issuanceId = await postAndGetId('/v2/issuance', generateIssuance(verificationId, projectMethodologyId), 'cadTrustIssuanceId');
-    const unitId = await postAndGetId('/v2/unit', generateUnit(issuanceId), 'cadTrustUnitId');
-    const labelId = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
-    const unitLabelId = await postAndGetId('/v2/unit-label', generateUnitLabel(labelId, unitId), 'cadTrustUnitLabelId');
-    const locationId = await postAndGetId('/v2/location', generateLocation(projectId), 'cadTrustLocationId');
-    const estimationId = await postAndGetId('/v2/estimation', generateEstimation(projectId), 'cadTrustEstimationId');
-    const ratingId = await postAndGetId('/v2/rating', generateRating(projectId), 'cadTrustRatingId');
-    const coBenefitId = await postAndGetId('/v2/co-benefit', generateCoBenefit(projectId), 'cadTrustCoBenefitId');
-    const stakeholderId = await postAndGetId('/v2/stakeholder', generateStakeholder(), 'cadTrustStakeholderId');
-    const stakeholderProjectId = await postAndGetId('/v2/stakeholder-projects', generateStakeholderProjects(stakeholderId, projectId), 'cadTrustStakeholderProjectId');
+  it('should cascade delete project and sub-entity children through commit', async function () {
+    // === Graph A: full project cascade (project + 11 children) ===
+    const programAId = await postAndGetId('/v2/program', generateProgram(), 'cadTrustProgramId');
+    const projectAId = await postAndGetId('/v2/project', generateProject(programAId), 'cadTrustProjectId');
+    const methodologyAId = await postAndGetId('/v2/methodology', generateMethodology(), 'cadTrustMethodologyId');
+    const validationAId = await postAndGetId('/v2/validation', generateValidation(projectAId), 'cadTrustValidationId');
+    const verificationAId = await postAndGetId('/v2/verification', generateVerification(projectAId, validationAId), 'cadTrustVerificationId');
+    const projectMethodologyAId = await postAndGetId('/v2/project-methodology', generateProjectMethodology(projectAId, methodologyAId), 'cadTrustProjectMethodologyId');
+    const issuanceAId = await postAndGetId('/v2/issuance', generateIssuance(verificationAId, projectMethodologyAId), 'cadTrustIssuanceId');
+    const unitAId = await postAndGetId('/v2/unit', generateUnit(issuanceAId), 'cadTrustUnitId');
+    const labelAId = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
+    const unitLabelAId = await postAndGetId('/v2/unit-label', generateUnitLabel(labelAId, unitAId), 'cadTrustUnitLabelId');
+    const locationAId = await postAndGetId('/v2/location', generateLocation(projectAId), 'cadTrustLocationId');
+    const estimationAId = await postAndGetId('/v2/estimation', generateEstimation(projectAId), 'cadTrustEstimationId');
+    const ratingAId = await postAndGetId('/v2/rating', generateRating(projectAId), 'cadTrustRatingId');
+    const coBenefitAId = await postAndGetId('/v2/co-benefit', generateCoBenefit(projectAId), 'cadTrustCoBenefitId');
+    const stakeholderAId = await postAndGetId('/v2/stakeholder', generateStakeholder(), 'cadTrustStakeholderId');
+    const stakeholderProjectAId = await postAndGetId('/v2/stakeholder-projects', generateStakeholderProjects(stakeholderAId, projectAId), 'cadTrustStakeholderProjectId');
 
-    await commitStagedRecords(request, [], true);
-    await waitForPendingCommits(request);
-    await waitForStagingEmpty(request);
+    // === Graph B: three independent sub-entity cascade scenarios ===
+    const programBId = await postAndGetId('/v2/program', generateProgram(), 'cadTrustProgramId');
+    const projectBId = await postAndGetId('/v2/project', generateProject(programBId), 'cadTrustProjectId');
+    const methodologyBId = await postAndGetId('/v2/methodology', generateMethodology(), 'cadTrustMethodologyId');
 
-    await waitForDataToAppear(request, 'project', projectId);
-    await waitForDataToAppear(request, 'unit-label', unitLabelId);
-
-    const deleteResponse = await request.delete(`/v2/project/${projectId}`).expect(200);
-    expect(deleteResponse.body.success).to.equal(true);
-    expect(deleteResponse.body.stagedChildDeletes).to.equal(11);
-
-    const stagingResponse = await request.get('/v2/staging').query({ page: 1, limit: 500 }).expect(200);
-    const stagedRows = stagingResponse.body?.data || [];
-
-    const expectedDeleteRows = [
-      ['location', 'cad_trust_location_id', locationId],
-      ['estimation', 'cad_trust_estimation_id', estimationId],
-      ['rating', 'cad_trust_rating_id', ratingId],
-      ['co_benefit', 'cad_trust_co_benefit_id', coBenefitId],
-      ['validation', 'cad_trust_validation_id', validationId],
-      ['verification', 'cad_trust_verification_id', verificationId],
-      ['project_methodology', 'cad_trust_project_methodology_id', projectMethodologyId],
-      ['stakeholder_projects', 'cad_trust_stakeholder_project_id', stakeholderProjectId],
-      ['issuance', 'cad_trust_issuance_id', issuanceId],
-      ['unit', 'cad_trust_unit_id', unitId],
-      ['unit_label', 'cad_trust_unit_label_id', unitLabelId],
-      ['project', 'cad_trust_project_id', projectId],
-    ];
-
-    for (const [table, key, value] of expectedDeleteRows) {
-      expect(hasStagedDelete(stagedRows, table, key, value), `missing staged delete ${table}:${value}`).to.equal(true);
-    }
-
-    await commitStagedRecords(request, [], true);
-    await waitForPendingCommits(request);
-    await waitForStagingEmpty(request);
-
-    const childrenToVerifyMissing = [
-      ['/v2/location', locationId],
-      ['/v2/estimation', estimationId],
-      ['/v2/rating', ratingId],
-      ['/v2/co-benefit', coBenefitId],
-      ['/v2/validation', validationId],
-      ['/v2/verification', verificationId],
-      ['/v2/project-methodology', projectMethodologyId],
-      ['/v2/stakeholder-projects', stakeholderProjectId],
-      ['/v2/issuance', issuanceId],
-      ['/v2/unit', unitId],
-      ['/v2/unit-label', unitLabelId],
-      ['/v2/project', projectId],
-    ];
-
-    for (const [endpoint, id] of childrenToVerifyMissing) {
-      const response = await request.get(`${endpoint}/${id}`);
-      expect([400, 404]).to.include(response.status);
-    }
-  });
-
-  it('should cascade delete unit_label, issuance children, and verification children through commit', async function () {
-    // Build a shared entity graph once for three cascade-delete scenarios.
-    // This avoids three separate commit cycles that would each add ~2 minutes.
-    const programId = await postAndGetId('/v2/program', generateProgram(), 'cadTrustProgramId');
-    const projectId = await postAndGetId('/v2/project', generateProject(programId), 'cadTrustProjectId');
-    const methodologyId = await postAndGetId('/v2/methodology', generateMethodology(), 'cadTrustMethodologyId');
-
-    // Verification 1 — will be deleted as a mid-chain cascade test
-    const val1Id = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
-    const ver1Id = await postAndGetId('/v2/verification', generateVerification(projectId, val1Id), 'cadTrustVerificationId');
-    const pm1Id = await postAndGetId('/v2/project-methodology', generateProjectMethodology(projectId, methodologyId), 'cadTrustProjectMethodologyId');
+    // Verification 1 — will be deleted to cascade issuance1, unit1, unit_label1
+    const val1Id = await postAndGetId('/v2/validation', generateValidation(projectBId), 'cadTrustValidationId');
+    const ver1Id = await postAndGetId('/v2/verification', generateVerification(projectBId, val1Id), 'cadTrustVerificationId');
+    const pm1Id = await postAndGetId('/v2/project-methodology', generateProjectMethodology(projectBId, methodologyBId), 'cadTrustProjectMethodologyId');
     const iss1Id = await postAndGetId('/v2/issuance', generateIssuance(ver1Id, pm1Id), 'cadTrustIssuanceId');
     const unit1Id = await postAndGetId('/v2/unit', generateUnit(iss1Id), 'cadTrustUnitId');
     const label1Id = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
     const ul1Id = await postAndGetId('/v2/unit-label', generateUnitLabel(label1Id, unit1Id), 'cadTrustUnitLabelId');
 
-    // Issuance 2 — will be deleted standalone
-    const val2Id = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
-    const ver2Id = await postAndGetId('/v2/verification', generateVerification(projectId, val2Id), 'cadTrustVerificationId');
+    // Issuance 2 — will be deleted to cascade unit2 + unit_label2
+    const val2Id = await postAndGetId('/v2/validation', generateValidation(projectBId), 'cadTrustValidationId');
+    const ver2Id = await postAndGetId('/v2/verification', generateVerification(projectBId, val2Id), 'cadTrustVerificationId');
     const iss2Id = await postAndGetId('/v2/issuance', generateIssuance(ver2Id, pm1Id), 'cadTrustIssuanceId');
     const unit2Id = await postAndGetId('/v2/unit', generateUnit(iss2Id), 'cadTrustUnitId');
     const label2Id = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
     const ul2Id = await postAndGetId('/v2/unit-label', generateUnitLabel(label2Id, unit2Id), 'cadTrustUnitLabelId');
 
-    // Unit 3 — will test bare unit → unit_label cascade
-    const val3Id = await postAndGetId('/v2/validation', generateValidation(projectId), 'cadTrustValidationId');
-    const ver3Id = await postAndGetId('/v2/verification', generateVerification(projectId, val3Id), 'cadTrustVerificationId');
+    // Unit 3 — will be deleted to cascade unit_label3
+    const val3Id = await postAndGetId('/v2/validation', generateValidation(projectBId), 'cadTrustValidationId');
+    const ver3Id = await postAndGetId('/v2/verification', generateVerification(projectBId, val3Id), 'cadTrustVerificationId');
     const iss3Id = await postAndGetId('/v2/issuance', generateIssuance(ver3Id, pm1Id), 'cadTrustIssuanceId');
     const unit3Id = await postAndGetId('/v2/unit', generateUnit(iss3Id), 'cadTrustUnitId');
     const label3Id = await postAndGetId('/v2/label', generateLabel(), 'cadTrustLabelId');
     const ul3Id = await postAndGetId('/v2/unit-label', generateUnitLabel(label3Id, unit3Id), 'cadTrustUnitLabelId');
 
-    // Commit the full graph in one cycle
+    // --- Commit cycle 1: commit both graphs in one pass ---
     await commitStagedRecords(request, [], true);
     await waitForPendingCommits(request);
     await waitForStagingEmpty(request);
+
+    await waitForDataToAppear(request, 'project', projectAId);
+    await waitForDataToAppear(request, 'unit-label', unitLabelAId);
     await waitForDataToAppear(request, 'unit-label', ul3Id);
 
-    // --- Scenario A: Delete unit3 → should cascade unit_label ---
+    // --- Graph A deletes: delete projectA → cascades 11 children ---
+    const deleteResponse = await request.delete(`/v2/project/${projectAId}`).expect(200);
+    expect(deleteResponse.body.success).to.equal(true);
+    expect(deleteResponse.body.stagedChildDeletes).to.equal(11);
+
+    const stagingResponseA = await request.get('/v2/staging').query({ page: 1, limit: 500 }).expect(200);
+    const stagedRowsA = stagingResponseA.body?.data || [];
+
+    const expectedDeleteRowsA = [
+      ['location', 'cad_trust_location_id', locationAId],
+      ['estimation', 'cad_trust_estimation_id', estimationAId],
+      ['rating', 'cad_trust_rating_id', ratingAId],
+      ['co_benefit', 'cad_trust_co_benefit_id', coBenefitAId],
+      ['validation', 'cad_trust_validation_id', validationAId],
+      ['verification', 'cad_trust_verification_id', verificationAId],
+      ['project_methodology', 'cad_trust_project_methodology_id', projectMethodologyAId],
+      ['stakeholder_projects', 'cad_trust_stakeholder_project_id', stakeholderProjectAId],
+      ['issuance', 'cad_trust_issuance_id', issuanceAId],
+      ['unit', 'cad_trust_unit_id', unitAId],
+      ['unit_label', 'cad_trust_unit_label_id', unitLabelAId],
+      ['project', 'cad_trust_project_id', projectAId],
+    ];
+
+    for (const [table, key, value] of expectedDeleteRowsA) {
+      expect(hasStagedDelete(stagedRowsA, table, key, value), `missing staged delete ${table}:${value}`).to.equal(true);
+    }
+
+    // --- Graph B deletes: unit3, issuance2, verification1 ---
     const unitDelResp = await request.delete(`/v2/unit/${unit3Id}`).expect(200);
     expect(unitDelResp.body.success).to.equal(true);
     expect(unitDelResp.body.stagedChildDeletes).to.equal(1);
 
-    // --- Scenario B: Delete issuance2 → should cascade unit2 + unit_label2 ---
     const issDelResp = await request.delete(`/v2/issuance/${iss2Id}`).expect(200);
     expect(issDelResp.body.success).to.equal(true);
     expect(issDelResp.body.stagedChildDeletes).to.equal(2);
 
-    // --- Scenario C: Delete verification1 → should cascade issuance1, unit1, unit_label1 ---
     const verDelResp = await request.delete(`/v2/verification/${ver1Id}`).expect(200);
     expect(verDelResp.body.success).to.equal(true);
     expect(verDelResp.body.stagedChildDeletes).to.equal(3);
 
-    // Verify all expected staging rows
-    const stagingResponse = await request.get('/v2/staging').query({ page: 1, limit: 500 }).expect(200);
-    const stagedRows = stagingResponse.body?.data || [];
+    const stagingResponseB = await request.get('/v2/staging').query({ page: 1, limit: 500 }).expect(200);
+    const stagedRowsB = stagingResponseB.body?.data || [];
 
-    const expectedStagedDeletes = [
-      // Scenario A
+    const expectedStagedDeletesB = [
+      // unit3 cascade
       ['unit', 'cad_trust_unit_id', unit3Id],
       ['unit_label', 'cad_trust_unit_label_id', ul3Id],
-      // Scenario B
+      // issuance2 cascade
       ['issuance', 'cad_trust_issuance_id', iss2Id],
       ['unit', 'cad_trust_unit_id', unit2Id],
       ['unit_label', 'cad_trust_unit_label_id', ul2Id],
-      // Scenario C
+      // verification1 cascade
       ['verification', 'cad_trust_verification_id', ver1Id],
       ['issuance', 'cad_trust_issuance_id', iss1Id],
       ['unit', 'cad_trust_unit_id', unit1Id],
       ['unit_label', 'cad_trust_unit_label_id', ul1Id],
     ];
 
-    for (const [table, key, value] of expectedStagedDeletes) {
-      expect(hasStagedDelete(stagedRows, table, key, value), `missing staged delete ${table}:${value}`).to.equal(true);
+    for (const [table, key, value] of expectedStagedDeletesB) {
+      expect(hasStagedDelete(stagedRowsB, table, key, value), `missing staged delete ${table}:${value}`).to.equal(true);
     }
 
-    // Commit all deletes in one cycle
+    // --- Commit cycle 2: commit all deletes (both graphs) in one pass ---
     await commitStagedRecords(request, [], true);
     await waitForPendingCommits(request);
     await waitForStagingEmpty(request);
 
-    // Verify everything is gone
-    const toVerifyMissing = [
+    // Verify Graph A entities are gone
+    const childrenToVerifyMissingA = [
+      ['/v2/location', locationAId],
+      ['/v2/estimation', estimationAId],
+      ['/v2/rating', ratingAId],
+      ['/v2/co-benefit', coBenefitAId],
+      ['/v2/validation', validationAId],
+      ['/v2/verification', verificationAId],
+      ['/v2/project-methodology', projectMethodologyAId],
+      ['/v2/stakeholder-projects', stakeholderProjectAId],
+      ['/v2/issuance', issuanceAId],
+      ['/v2/unit', unitAId],
+      ['/v2/unit-label', unitLabelAId],
+      ['/v2/project', projectAId],
+    ];
+
+    for (const [endpoint, id] of childrenToVerifyMissingA) {
+      const response = await request.get(`${endpoint}/${id}`);
+      expect([400, 404]).to.include(response.status);
+    }
+
+    // Verify Graph B entities are gone
+    const toVerifyMissingB = [
       ['/v2/unit', unit3Id],
       ['/v2/unit-label', ul3Id],
       ['/v2/issuance', iss2Id],
@@ -221,7 +210,7 @@ describe('Cascade Delete Live API Tests', function () {
       ['/v2/unit-label', ul1Id],
     ];
 
-    for (const [endpoint, id] of toVerifyMissing) {
+    for (const [endpoint, id] of toVerifyMissingB) {
       const resp = await request.get(`${endpoint}/${id}`);
       expect([400, 404]).to.include(resp.status);
     }

--- a/tests/v2/live-api/cascade-delete.live.spec.js
+++ b/tests/v2/live-api/cascade-delete.live.spec.js
@@ -48,7 +48,7 @@ describe('Cascade Delete Live API Tests', function () {
     }
     const data = row.diff?.change;
     const parsed = Array.isArray(data) ? data : [data];
-    return parsed[0]?.[key] === value;
+    return parsed.some((p) => p?.[key] === value);
   });
 
   it('should cascade delete project and sub-entity children through commit', async function () {
@@ -213,6 +213,21 @@ describe('Cascade Delete Live API Tests', function () {
     for (const [endpoint, id] of toVerifyMissingB) {
       const resp = await request.get(`${endpoint}/${id}`);
       expect([400, 404]).to.include(resp.status);
+    }
+
+    // Verify non-deleted Graph B siblings are still present (guards against
+    // overly-aggressive cascades that silently delete sibling entities)
+    const survivingGraphB = [
+      ['/v2/project', projectBId],
+      ['/v2/project-methodology', pm1Id],
+      ['/v2/verification', ver2Id],
+      ['/v2/verification', ver3Id],
+      ['/v2/issuance', iss3Id],
+    ];
+
+    for (const [endpoint, id] of survivingGraphB) {
+      const resp = await request.get(`${endpoint}/${id}`);
+      expect(resp.status, `expected ${endpoint}/${id} to still exist after cascade`).to.equal(200);
     }
   });
 });

--- a/tests/v2/live-api/cascade-delete.live.spec.js
+++ b/tests/v2/live-api/cascade-delete.live.spec.js
@@ -136,6 +136,10 @@ describe('Cascade Delete Live API Tests', function () {
       expect(hasStagedDelete(stagedRowsA, table, key, value), `missing staged delete ${table}:${value}`).to.equal(true);
     }
 
+    // Exact row count guards against spurious over-staging (12 = 11 children + project itself)
+    const deleteRowsA = stagedRowsA.filter((r) => r.action === 'DELETE');
+    expect(deleteRowsA.length, 'unexpected extra staged deletes in Graph A').to.equal(12);
+
     // --- Graph B deletes: unit3, issuance2, verification1 ---
     const unitDelResp = await request.delete(`/v2/unit/${unit3Id}`).expect(200);
     expect(unitDelResp.body.success).to.equal(true);
@@ -170,6 +174,10 @@ describe('Cascade Delete Live API Tests', function () {
     for (const [table, key, value] of expectedStagedDeletesB) {
       expect(hasStagedDelete(stagedRowsB, table, key, value), `missing staged delete ${table}:${value}`).to.equal(true);
     }
+
+    // Exact row count: 12 from Graph A + 9 from Graph B = 21 DELETE rows total
+    const deleteRowsB = stagedRowsB.filter((r) => r.action === 'DELETE');
+    expect(deleteRowsB.length, 'unexpected extra staged deletes after Graph B').to.equal(21);
 
     // --- Commit cycle 2: commit all deletes (both graphs) in one pass ---
     await commitStagedRecords(request, [], true);
@@ -216,10 +224,15 @@ describe('Cascade Delete Live API Tests', function () {
     }
 
     // Verify non-deleted Graph B siblings are still present (guards against
-    // overly-aggressive cascades that silently delete sibling entities)
+    // overly-aggressive cascades that silently delete sibling entities).
+    // val1/val2/val3 are parent validations whose child verifications were
+    // deleted — they must NOT be cascade-deleted upward.
     const survivingGraphB = [
       ['/v2/project', projectBId],
       ['/v2/project-methodology', pm1Id],
+      ['/v2/validation', val1Id],
+      ['/v2/validation', val2Id],
+      ['/v2/validation', val3Id],
       ['/v2/verification', ver2Id],
       ['/v2/verification', ver3Id],
       ['/v2/issuance', iss3Id],

--- a/tests/v2/live-api/data-short.js
+++ b/tests/v2/live-api/data-short.js
@@ -394,19 +394,11 @@ async function main() {
     console.log('');
 
     const xlsxTestFiles = ['xlsx-import-export.live.spec.js'];
+    await runMochaTests('Step 1[1-6]a?:', 'XLSX Import/Export', xlsxTestFiles);
 
-    // Pass 1: XLSX imports + verify + export (1 on-chain commit from Step 11)
-    await runMochaTests('Step 11:|Step 11a:|Step 12a:|Step 13:|Step 14:', 'XLSX Import/Export (imports)', xlsxTestFiles);
-
-    // Pass 2: XLSX round-trip staging only (no separate commit — absorbed into PUT commit below)
-    await runMochaTests('Step 15: Round-trip re-import \\(batch\\)', 'XLSX Round-trip Staging', xlsxTestFiles);
-
-    // Phase 4: PUT tests (stages on top of XLSX round-trip; one commit covers both)
+    // Phase 4: PUT tests
     await runMochaTests('Step 7: PUT Request Tests', 'PUT Operations');
     await commitAndWait('PUT');
-
-    // Pass 3: XLSX round-trip verify + filter export (reads now-committed data)
-    await runMochaTests('Step 15a:|Step 16:', 'XLSX Round-trip Verify + Filter Export', xlsxTestFiles);
 
     // Phase 5: DELETE tests
     await runMochaTests('Step 9: DELETE Request Tests', 'DELETE Operations');

--- a/tests/v2/live-api/data-short.js
+++ b/tests/v2/live-api/data-short.js
@@ -394,25 +394,23 @@ async function main() {
     console.log('');
 
     const xlsxTestFiles = ['xlsx-import-export.live.spec.js'];
-    await runMochaTests('Step 1[1-6]a?:', 'XLSX Import/Export', xlsxTestFiles);
 
-    // Phase 4: PUT tests
+    // Pass 1: XLSX imports + verify + export (1 on-chain commit from Step 11)
+    await runMochaTests('Step 11:|Step 11a:|Step 12a:|Step 13:|Step 14:', 'XLSX Import/Export (imports)', xlsxTestFiles);
+
+    // Pass 2: XLSX round-trip staging only (no separate commit — absorbed into PUT commit below)
+    await runMochaTests('Step 15: Round-trip re-import \\(batch\\)', 'XLSX Round-trip Staging', xlsxTestFiles);
+
+    // Phase 4: PUT tests (stages on top of XLSX round-trip; one commit covers both)
     await runMochaTests('Step 7: PUT Request Tests', 'PUT Operations');
     await commitAndWait('PUT');
+
+    // Pass 3: XLSX round-trip verify + filter export (reads now-committed data)
+    await runMochaTests('Step 15a:|Step 16:', 'XLSX Round-trip Verify + Filter Export', xlsxTestFiles);
 
     // Phase 5: DELETE tests
     await runMochaTests('Step 9: DELETE Request Tests', 'DELETE Operations');
     await commitAndWait('DELETE');
-
-    // Phase 6: Cascade delete e2e tests
-    // Run as a dedicated suite (not step-grep based) because it validates
-    // cascade-specific staging + commit behavior end-to-end.
-    console.log('--- Running cascade delete tests ---');
-    await runMochaTests(
-      'should cascade delete',
-      'Cascade Delete Operations',
-      ['cascade-delete.live.spec.js'],
-    );
 
     console.log('\n=== All phases complete ===\n');
 

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -10,6 +10,10 @@ import {
   createRecoveryStuckTracker,
 } from './wallet-diagnostics.js';
 
+// Reduced from 10 000 ms to cut idle wait time between blockchain commits.
+// Increases API call volume ~3x but stays well within the 30-minute suite timeout.
+const COMMIT_POLL_INTERVAL_MS = 3000;
+
 /**
  * Format current timestamp as YYYY-MM-DD HH:mm:ss
  * @returns {string} - Formatted timestamp
@@ -595,7 +599,7 @@ export const checkOrganizationSynced = async (request) => {
  */
 export const waitForPendingCommits = async (request, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  const interval = 3000;
+  const interval = COMMIT_POLL_INTERVAL_MS;
   const timestamp = new Date().toISOString();
   const recoveryTracker = createRecoveryStuckTracker();
 
@@ -633,7 +637,7 @@ export const waitForPendingCommits = async (request, maxWaitTime = 600000) => {
  */
 export const waitForStagingEmpty = async (request, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  const interval = 3000;
+  const interval = COMMIT_POLL_INTERVAL_MS;
   const recoveryTracker = createRecoveryStuckTracker();
 
   console.log('Waiting for staging table to be empty...');

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -10,11 +10,10 @@ import {
   createRecoveryStuckTracker,
 } from './wallet-diagnostics.js';
 
-// Reduced from 10 000 ms to cut idle wait time between blockchain commits.
 // Each iteration calls two HTTP endpoints (org-synced + wallet-diagnostics),
-// so the total request rate increase across all live jobs is ~6.7× vs the old
-// 10 s interval.  Both jobs (test-v2-live-api, test-v2-live-cascade-delete)
-// use this helper; the 30-minute suite timeout is not at risk.
+// so the per-loop request rate is ~6.7× the org-creation polling interval.
+// Both live jobs (test-v2-live-api, test-v2-live-cascade-delete) share this
+// helper; the 30-minute suite timeout is not at risk.
 const COMMIT_POLL_INTERVAL_MS = 3000;
 
 /**

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -595,7 +595,7 @@ export const checkOrganizationSynced = async (request) => {
  */
 export const waitForPendingCommits = async (request, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  const interval = 10000;
+  const interval = 3000;
   const timestamp = new Date().toISOString();
   const recoveryTracker = createRecoveryStuckTracker();
 
@@ -633,7 +633,7 @@ export const waitForPendingCommits = async (request, maxWaitTime = 600000) => {
  */
 export const waitForStagingEmpty = async (request, maxWaitTime = 600000) => {
   const startTime = Date.now();
-  const interval = 10000;
+  const interval = 3000;
   const recoveryTracker = createRecoveryStuckTracker();
 
   console.log('Waiting for staging table to be empty...');

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -11,7 +11,10 @@ import {
 } from './wallet-diagnostics.js';
 
 // Reduced from 10 000 ms to cut idle wait time between blockchain commits.
-// Increases API call volume ~3x but stays well within the 30-minute suite timeout.
+// Each iteration calls two HTTP endpoints (org-synced + wallet-diagnostics),
+// so the total request rate increase across all live jobs is ~6.7× vs the old
+// 10 s interval.  Both jobs (test-v2-live-api, test-v2-live-cascade-delete)
+// use this helper; the 30-minute suite timeout is not at risk.
 const COMMIT_POLL_INTERVAL_MS = 3000;
 
 /**
@@ -1199,7 +1202,7 @@ export const getLiveApiRequest = async (options = {}) => {
 export const waitForV2OrganizationReady = async (request, orgName = null, maxWaitTime = 900000, options = {}) => {
   const { isUpgrade = false } = options;
   const startTime = Date.now();
-  const interval = 10000;
+  const interval = 10000; // org-creation poller, not a commit poller — intentionally not COMMIT_POLL_INTERVAL_MS
   const timestamp = getTimestamp();
   const recoveryTracker = createRecoveryStuckTracker();
   let lastDiagAt = 0;
@@ -1496,7 +1499,7 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
  */
 export const waitForV1OrganizationReady = async (request, orgName = null, maxWaitTime = 900000) => {
   const startTime = Date.now();
-  const interval = 10000;
+  const interval = 10000; // org-creation poller, not a commit poller — intentionally not COMMIT_POLL_INTERVAL_MS
   const timestamp = getTimestamp();
   const recoveryTracker = createRecoveryStuckTracker();
   let lastDiagAt = 0;

--- a/tests/v2/live-api/xlsx-import-export.live.spec.js
+++ b/tests/v2/live-api/xlsx-import-export.live.spec.js
@@ -515,6 +515,11 @@ describe('XLSX Import/Export Live API Tests', function () {
       expect(importResponse.body.success).to.be.true;
     });
 
+    it('should commit all round-trip staged records', async function () {
+      await commitStagedRecords(request, [], true);
+      await waitForPendingCommits(request);
+      await waitForStagingEmpty(request);
+    });
   });
 
   describe('Step 15a: Verify round-trip fidelity', function () {

--- a/tests/v2/live-api/xlsx-import-export.live.spec.js
+++ b/tests/v2/live-api/xlsx-import-export.live.spec.js
@@ -515,11 +515,6 @@ describe('XLSX Import/Export Live API Tests', function () {
       expect(importResponse.body.success).to.be.true;
     });
 
-    it('should commit all round-trip staged records', async function () {
-      await commitStagedRecords(request, [], true);
-      await waitForPendingCommits(request);
-      await waitForStagingEmpty(request);
-    });
   });
 
   describe('Step 15a: Verify round-trip fidelity', function () {


### PR DESCRIPTION
## Summary

- **Opt 1 — Parallel cascade-delete job**: Adds `test-v2-live-cascade-delete` CI job that runs the organization-create → wallet-health → cascade-delete → organization-delete sequence in a fully independent runner in parallel with `test-v2-live-api`. Removes the cascade-delete phase from `data-short.js` (it was the last phase, making it the critical-path bottleneck). Estimated savings: **~7–8 min** off the critical path.

- **Opt 2 — Merged cascade-delete `it()` blocks**: The two original `it` blocks (full-project cascade + three sub-entity cascades) shared a commit cycle by building their entity graphs in the same `describe` but running two on-chain commits. Merged into a single `it` with one shared commit cycle (Graph A + Graph B staged together, committed once). Reduces on-chain commit cycles from 4 to 2. Estimated savings: **~3–4 min**.

- **Opt 3 — 3 s commit-poll interval**: `waitForPendingCommits` and `waitForStagingEmpty` were polling every 10 s. Reduced to a module-level constant `COMMIT_POLL_INTERVAL_MS = 3000` (applies to both live jobs). Cuts idle wait at each commit boundary. Org-creation pollers intentionally retain their own 10 s interval and are annotated to explain why.

**Dropped**: The originally-planned XLSX round-trip commit-folding (Opt 4) was dropped after review: module-level `beforeProjects`/`beforeUnits` variables are reset between Mocha subprocess invocations, and the PUT changes committed in the same cycle would break the Step 15a fidelity assertions. The single-pass XLSX invocation and its standalone commit are restored.

## Review

Ran the multi-persona code review pipeline (10 parallel subagents). Findings addressed:
- **Critical fixed**: Cross-process state loss in XLSX 3-pass split — reverted to single-pass invocation.
- **Warning fixed (cascade spec)**: `hasStagedDelete` now iterates all `diff.change` array elements instead of only `[0]`, guarding against before/after payloads.
- **Warning fixed (cascade spec)**: Added survival assertions for non-deleted Graph B siblings to guard against overly-aggressive cascades.
- **Warning addressed (helpers comment)**: Updated `COMMIT_POLL_INTERVAL_MS` comment to reflect true scope (both live jobs, ~6.7× per-iteration HTTP call increase) and annotated org-creation pollers.
- **Warning dismissed (CI job copy)**: New job follows the existing copy-paste pattern (three similar jobs already in the file). Extracting to a reusable workflow is a separate refactor.
- **Warning dismissed (merged `it()` blocks)**: Deliberate tradeoff per plan. The two scenarios share a commit graph; separate `it()` blocks would require duplicating the full commit cycle. Noted in spec comments.

## Test plan

- [ ] Confirm `test-v2-live-cascade-delete` job appears in GitHub Actions and runs independently from `test-v2-live-api`
- [ ] Confirm `test-v2-live-api` still passes without cascade-delete phase in `data-short.js`
- [ ] Confirm cascade-delete spec runs cleanly in the new job (org-create → cascade-delete → org-delete)
- [ ] Compare wall-clock time of the new `test-v2-live-api` job vs the previous ~34 min baseline
- [ ] Verify both jobs upload their CADT logs as artifacts on failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/live-test behavior changes substantially (new parallel job, altered polling cadence, and merged cascade-delete assertions), which could introduce new flakiness or mask regressions despite being non-production code.
> 
> **Overview**
> Cuts the v2 live API CI critical path by **splitting cascade-delete coverage into a new parallel workflow job** (`test-v2-live-cascade-delete`) and removing cascade-delete execution from the main v2 data-short runner.
> 
> Optimizes the cascade-delete live spec by **combining two scenarios into a single `it()` with shared commit cycles**, tightening staged-delete validation (scan all `diff.change` entries), adding row-count guards, and asserting certain sibling entities survive.
> 
> Speeds up live-test synchronization waits by reducing `waitForPendingCommits`/`waitForStagingEmpty` polling from 10s to a shared 3s interval (`COMMIT_POLL_INTERVAL_MS`), while leaving org-creation poll intervals unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76be7111f3899138ac99ed6b435a343f52c328fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->