### PR TITLE
fix(V2): remove sync generation wait

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY src /app/src/
 COPY tests /app/tests/
 WORKDIR /app
 
-RUN npm install && npm rebuild sqlite3 --build-from-source
+RUN npm install
 
 RUN mkdir -p /root/.chia/mainnet/config/ssl && mkdir -p /root/.chia/mainnet/cadt/v1
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,24 @@ You'll need:
 ​
 - Git
 - [nvm](https://github.com/nvm-sh/nvm) - This app uses `nvm` to align node versions across development, CI and production. If you're working on Windows, you should consider [nvm-windows](https://github.com/coreybutler/nvm-windows)
+- C/C++ build tools for compiling the SQLite native module (see below)
 - A working [Chia installation](https://docs.chia.net/installation/#using-the-cli) running wallet and datalayer (full node recommended)
+
+##### Build Prerequisites
+
+The `sqlite3` npm package is compiled from source during `npm install` to ensure compatibility across platforms. This requires a C/C++ toolchain and Python 3:
+
+**Debian / Ubuntu:**
+
+```
+sudo apt-get install -y build-essential python3
+```
+
+**macOS:**
+
+```
+xcode-select --install
+```
 
 To install from source:
 
@@ -137,6 +154,7 @@ git clone git@github.com:Chia-Network/cadt.git
 cd cadt
 nvm install
 nvm use
+npm install
 npm run start
 ```
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:v2:live:all": "npm run test:v2:live:organization:create && npm run test:v2:live:data && npm run test:v2:live:organization:delete",
     "resetTestDb": "rm -rf ./tests/test-dbs && mkdir -p ./tests/test-dbs",
     "resetMirrorDb": "npx sequelize-cli db:drop --env mirror",
+    "postinstall": "cd node_modules/sqlite3 && node-gyp rebuild --napi_build_version=6",
     "prepare": "husky",
     "build": "babel src --keep-file-extension --out-dir build --copy-files && cp package.json ./build && node change-build-package-type-commonjs.cjs",
     "build-migrations": "babel migrations --keep-file-extension --out-dir dist/migrations --copy-files",

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -51,7 +51,9 @@ const getHomeOrg = async () => {
   }
 
   // Neither V1 nor V2 is enabled or orgs don't exist
-  logger.debug('[persistance]: No home org found - V1 and V2 both disabled or no orgs exist');
+  logger.debug(
+    '[persistance]: No home org found - V1 and V2 both disabled or no orgs exist',
+  );
   return null;
 };
 
@@ -107,7 +109,9 @@ const getMirrors = async (storeId) => {
 
   // In simulator mode, return empty array (no mirrors in simulator)
   if (CONFIG.USE_SIMULATOR || CONFIG.USE_DEVELOPMENT_MODE) {
-    logger.debug(`[MIRROR_DEBUG] Simulator mode - returning empty mirrors array`);
+    logger.debug(
+      `[MIRROR_DEBUG] Simulator mode - returning empty mirrors array`,
+    );
     return [];
   }
 
@@ -210,8 +214,8 @@ const checkWalletBalanceForMirror = async (coinAmount, fee) => {
       if (isSplitInProgress()) {
         logger.warn(
           `Wallet balance temporarily reduced by coin split in progress ` +
-          `(have ${balanceMojos} mojos, need ${coinAmount} mojos). ` +
-          `Skipping mirror creation - will retry after split confirms.`,
+            `(have ${balanceMojos} mojos, need ${coinAmount} mojos). ` +
+            `Skipping mirror creation - will retry after split confirms.`,
         );
       } else {
         logger.error(
@@ -318,7 +322,9 @@ const addMirrorInner = async (storeId, url, forceAddMirror) => {
 
   // In simulator mode, return success without making RPC call
   if (CONFIG.USE_SIMULATOR || CONFIG.USE_DEVELOPMENT_MODE) {
-    logger.debug(`[MIRROR_DEBUG] Simulator mode - returning success for addMirror`);
+    logger.debug(
+      `[MIRROR_DEBUG] Simulator mode - returning success for addMirror`,
+    );
     return true;
   }
 
@@ -448,10 +454,15 @@ const getRootDiff = async (storeId, root1, root2) => {
       return _.get(data, 'diff', []);
     }
 
-    return [];
+    throw new Error(
+      data.error ||
+        `DataLayer get_kv_diff failed for store ${storeId} between roots ${root1} and ${root2}`,
+    );
   } catch (error) {
-    logger.error(error);
-    return [];
+    logger.error(
+      `DataLayer get_kv_diff failed for store ${storeId} between roots ${root1} and ${root2}: ${error.message}`,
+    );
+    throw error;
   }
 };
 
@@ -692,7 +703,11 @@ const getRoots = async (storeIds) => {
   }
 };
 
-const pushChangeListToDataLayer = async (storeId, changelist, { skipTransactionWait = false } = {}) => {
+const pushChangeListToDataLayer = async (
+  storeId,
+  changelist,
+  { skipTransactionWait = false } = {},
+) => {
   let attempts = 0;
   const maxAttempts = 5;
 
@@ -706,30 +721,33 @@ const pushChangeListToDataLayer = async (storeId, changelist, { skipTransactionW
       }
 
       // Log the changelist being sent (with decoded keys/values for readability)
-      logger.debug(`[DATALAYER_RPC] Sending changelist to storeId: ${storeId}`, {
-        storeId,
-        changelistSize: changelist.length,
-        changelist: changelist.map((change) => {
-          const decoded = {
-            action: change.action,
-            key: change.key ? decodeHex(change.key) : change.key,
-          };
-          if (change.value) {
-            try {
-              decoded.value = decodeHex(change.value);
-              // Try to parse as JSON for better readability
+      logger.debug(
+        `[DATALAYER_RPC] Sending changelist to storeId: ${storeId}`,
+        {
+          storeId,
+          changelistSize: changelist.length,
+          changelist: changelist.map((change) => {
+            const decoded = {
+              action: change.action,
+              key: change.key ? decodeHex(change.key) : change.key,
+            };
+            if (change.value) {
               try {
-                decoded.valueParsed = JSON.parse(decoded.value);
-              } catch {
-                // Not JSON, that's fine
+                decoded.value = decodeHex(change.value);
+                // Try to parse as JSON for better readability
+                try {
+                  decoded.valueParsed = JSON.parse(decoded.value);
+                } catch {
+                  // Not JSON, that's fine
+                }
+              } catch (e) {
+                decoded.value = change.value; // Keep hex if decode fails
               }
-            } catch (e) {
-              decoded.value = change.value; // Keep hex if decode fails
             }
-          }
-          return decoded;
-        }),
-      });
+            return decoded;
+          }),
+        },
+      );
 
       const url = `${CONFIG.DATALAYER_URL}/batch_update`;
       const { cert, key, timeout } = getBaseOptions();
@@ -766,7 +784,9 @@ const pushChangeListToDataLayer = async (storeId, changelist, { skipTransactionW
       // Wait for confirmation then retry the push instead of failing to writeService.
       if (
         data.error &&
-        data.error.includes('Already have a pending root waiting for confirmation')
+        data.error.includes(
+          'Already have a pending root waiting for confirmation',
+        )
       ) {
         logger.info(
           `Pending root for store ${storeId}; waiting for confirmation then retrying (attempt ${attempts + 1}/${maxAttempts})`,
@@ -831,21 +851,26 @@ const pushChangeListToDataLayer = async (storeId, changelist, { skipTransactionW
       // All data in CADT must come from datalayer, so DELETE operations should always find the keys
       // If keys are not found, it indicates a key format mismatch that needs to be fixed
       if (data.error && data.error.includes('unknown key')) {
-        const isDeleteOnlyChangelist = changelist.every(change => change.action === 'delete');
+        const isDeleteOnlyChangelist = changelist.every(
+          (change) => change.action === 'delete',
+        );
 
         // Log detailed information about the keys we're trying to delete
-        const deleteKeys = changelist.map(change => ({
+        const deleteKeys = changelist.map((change) => ({
           hex: change.key,
           decoded: decodeHex(change.key),
         }));
 
-        logger.error(`[DELETE KEY MISMATCH ERROR] Unknown key error for ${isDeleteOnlyChangelist ? 'DELETE-only' : ''} changelist`, {
-          storeId,
-          deleteKeysCount: deleteKeys.length,
-          deleteKeys,
-          error: data.error,
-          traceback: data.traceback,
-        });
+        logger.error(
+          `[DELETE KEY MISMATCH ERROR] Unknown key error for ${isDeleteOnlyChangelist ? 'DELETE-only' : ''} changelist`,
+          {
+            storeId,
+            deleteKeysCount: deleteKeys.length,
+            deleteKeys,
+            error: data.error,
+            traceback: data.traceback,
+          },
+        );
 
         if (isDeleteOnlyChangelist) {
           logger.error(
@@ -1208,7 +1233,8 @@ const getDataLayerStoreSyncStatus = async (storeId) => {
       sync_status: {
         generation: 10000,
         target_generation: 10000,
-        target_root_hash: '0000000000000000000000000000000000000000000000000000000000000000',
+        target_root_hash:
+          '0000000000000000000000000000000000000000000000000000000000000000',
       },
     };
   }

--- a/src/tasks/sync-registries-v2.js
+++ b/src/tasks/sync-registries-v2.js
@@ -29,6 +29,9 @@ const CONFIG = getConfig().APP;
 
 const mismatchBackoff = new SyncMismatchBackoff(loggerV2, '[v2]');
 
+const hasUsableSyncStatus = (syncStatus) =>
+  syncStatus?.generation != null && syncStatus?.target_generation != null;
+
 const task = new Task('sync-registries-v2', async () => {
   loggerV2.debug('[v2]: sync registries v2 task invoked');
   if (!syncRegistriesTaskMutexV2.isLocked()) {
@@ -134,7 +137,7 @@ const syncOrganizationAuditV2 = async (organization) => {
 
     loggerV2.debug('querying organization model for home org');
     const homeOrg = await OrganizationsV2.getHomeOrg();
-    
+
     // Check if registry_id is set
     if (!organization.registry_id) {
       loggerV2.warn(
@@ -142,7 +145,7 @@ const syncOrganizationAuditV2 = async (organization) => {
       );
       return;
     }
-    
+
     loggerV2.debug(`querying datalayer for ${organization.name} root history`);
     const rootHistory = await datalayer.getRootHistory(
       organization.registry_id,
@@ -152,13 +155,13 @@ const syncOrganizationAuditV2 = async (organization) => {
       organization.registry_id,
     );
     const sync_status = syncResult?.sync_status;
-    
+
     // Log diagnostic info for debugging
     loggerV2.debug(
       `[v2]: [SYNC_DIAG] ${organization.name}: registry_id=${organization.registry_id}, ` +
-      `rootHistory.length=${rootHistory?.length || 0}, ` +
-      `sync_status.generation=${sync_status?.generation}, ` +
-      `sync_status.target_generation=${sync_status?.target_generation}`,
+        `rootHistory.length=${rootHistory?.length || 0}, ` +
+        `sync_status.generation=${sync_status?.generation}, ` +
+        `sync_status.target_generation=${sync_status?.target_generation}`,
     );
 
     if (!rootHistory?.length) {
@@ -171,7 +174,7 @@ const syncOrganizationAuditV2 = async (organization) => {
     // For home org, skip the sync_status check - our own data is already local
     // The sync_status might lag behind because datalayer is still processing our own updates
     const isHomeOrg = homeOrg && organization.org_uid === homeOrg.org_uid;
-    
+
     if (
       process.env.NODE_ENV !== 'test' &&
       !isHomeOrg &&
@@ -298,9 +301,9 @@ const syncOrganizationAuditV2 = async (organization) => {
 
     loggerV2.debug(
       `[SYNC DEBUG] ${organization.name}: rootHistory.length=${rootHistory.length}, ` +
-      `auditGeneration=${auditTableHighestProcessedGenerationIndex}, ` +
-      `rootHistoryHighestIndex=${rootHistoryHighestGenerationIndex}, ` +
-      `syncRemaining=${syncRemaining}, isSynced=${isSynced}`,
+        `auditGeneration=${auditTableHighestProcessedGenerationIndex}, ` +
+        `rootHistoryHighestIndex=${rootHistoryHighestGenerationIndex}, ` +
+        `syncRemaining=${syncRemaining}, isSynced=${isSynced}`,
     );
 
     loggerV2.debug(
@@ -345,20 +348,36 @@ const syncOrganizationAuditV2 = async (organization) => {
       `${organization.name} is ${syncRemaining} DataLayer generations away from being fully synced (orgUid ${organization.org_uid}, registryId ${organization.registry_id}).`,
     );
 
-    if (!CONFIG.USE_SIMULATOR) {
-      await new Promise((resolve) => setTimeout(resolve, 30000));
+    loggerV2.debug(
+      `5 Last processed index of ${organization.name}: ${auditTableHighestProcessedGenerationIndex}`,
+    );
+    const lastProcessedRoot = _.get(
+      rootHistory,
+      `[${auditTableHighestProcessedGenerationIndex}]`,
+    );
+    loggerV2.debug(
+      `6 To be processed index of ${organization.name}: ${toBeProcessedDatalayerGenerationIndex}`,
+    );
+    const rootToBeProcessed = _.get(
+      rootHistory,
+      `[${toBeProcessedDatalayerGenerationIndex}]`,
+    );
 
+    loggerV2.debug(
+      `last processed root of ${organization.name}: ${JSON.stringify(lastProcessedRoot)}`,
+    );
+    loggerV2.debug(
+      `root to be processed of ${organization.name}: ${JSON.stringify(rootToBeProcessed)}`,
+    );
+
+    if (!CONFIG.USE_SIMULATOR) {
       // For home org, we can skip sync_status validation since we created the data locally
       // DataLayer may not have processed our own updates yet, which is fine
       if (isHomeOrg) {
         loggerV2.debug(
           `[v2]: Home org sync_status check skipped - data is local (generation=${sync_status?.generation}, target_generation=${sync_status?.target_generation})`,
         );
-      } else if (
-        sync_status &&
-        sync_status?.generation &&
-        sync_status?.target_generation
-      ) {
+      } else if (hasUsableSyncStatus(sync_status)) {
         loggerV2.debug(
           `store ${organization.registry_id} (${organization.name}) is currently at generation ${sync_status.generation} with a target generation of ${sync_status.target_generation}`,
         );
@@ -389,10 +408,13 @@ const syncOrganizationAuditV2 = async (organization) => {
       }
 
       // For home org, we don't need to check if DataLayer has caught up - we created the data
-      if (!isHomeOrg && toBeProcessedDatalayerGenerationIndex > sync_status.generation) {
+      if (
+        !isHomeOrg &&
+        toBeProcessedDatalayerGenerationIndex > sync_status.generation
+      ) {
         const warningMsg = [
-          `Generation ${toBeProcessedDatalayerGenerationIndex + 1} does not exist in ${organization.name} (registry store ${organization.registry_id}) root history`,
-          `DataLayer not yet caught up to generation ${auditTableHighestProcessedGenerationIndex + 1}. The the highest generation datalayer has synced is ${sync_status.generation}.`,
+          `DataLayer has not locally synced generation index ${toBeProcessedDatalayerGenerationIndex} for ${organization.name} (registry store ${organization.registry_id}).`,
+          `The highest generation DataLayer has synced is ${sync_status.generation}.`,
           `This issue is often temporary and could be due to a lag in data propagation.`,
           'Syncing for this organization will be paused until this is resolved.',
           'For ongoing issues, please contact the organization.',
@@ -403,27 +425,12 @@ const syncOrganizationAuditV2 = async (organization) => {
       }
     }
 
-    loggerV2.debug(
-      `5 Last processed index of ${organization.name}: ${auditTableHighestProcessedGenerationIndex}`,
-    );
-    const lastProcessedRoot = _.get(
-      rootHistory,
-      `[${auditTableHighestProcessedGenerationIndex}]`,
-    );
-    loggerV2.debug(
-      `6 To be processed index of ${organization.name}: ${toBeProcessedDatalayerGenerationIndex}`,
-    );
-    const rootToBeProcessed = _.get(
-      rootHistory,
-      `[${toBeProcessedDatalayerGenerationIndex}]`,
-    );
-
-    loggerV2.debug(
-      `last processed root of ${organization.name}: ${JSON.stringify(lastProcessedRoot)}`,
-    );
-    loggerV2.debug(
-      `root to be processed of ${organization.name}: ${JSON.stringify(rootToBeProcessed)}`,
-    );
+    if (!rootToBeProcessed) {
+      loggerV2.warn(
+        `Generation index ${toBeProcessedDatalayerGenerationIndex} does not exist in ${organization.name} (registry store ${organization.registry_id}) root history. Syncing will retry on the next run.`,
+      );
+      return;
+    }
 
     if (!_.get(rootToBeProcessed, 'confirmed')) {
       loggerV2.info(
@@ -439,11 +446,19 @@ const syncOrganizationAuditV2 = async (organization) => {
       `8 To be processed index of ${organization.name}: ${toBeProcessedDatalayerGenerationIndex}`,
     );
 
-    const kvDiff = await datalayer.getRootDiff(
-      organization.registry_id,
-      lastProcessedRoot.root_hash,
-      rootToBeProcessed.root_hash,
-    );
+    let kvDiff;
+    try {
+      kvDiff = await datalayer.getRootDiff(
+        organization.registry_id,
+        lastProcessedRoot.root_hash,
+        rootToBeProcessed.root_hash,
+      );
+    } catch (error) {
+      loggerV2.warn(
+        `DataLayer diff for ${organization.name} generation index ${toBeProcessedDatalayerGenerationIndex} is not ready. Syncing will retry on the next run. Error: ${error.message}`,
+      );
+      return;
+    }
 
     const comment = kvDiff.filter(
       (diff) =>
@@ -473,7 +488,7 @@ const syncOrganizationAuditV2 = async (organization) => {
         orgName: organization.name,
         diffCount: optimizedKvDiff.length,
         isEmpty: _.isEmpty(optimizedKvDiff),
-        sampleDiffs: optimizedKvDiff.slice(0, 3).map(d => ({
+        sampleDiffs: optimizedKvDiff.slice(0, 3).map((d) => ({
           type: d.type,
           key: d.key?.substring(0, 30),
         })),
@@ -487,7 +502,9 @@ const syncOrganizationAuditV2 = async (organization) => {
           type: 'NO CHANGE',
           table: null,
           change: null,
-          onchain_confirmation_time_stamp: rootToBeProcessed.timestamp?.toString() || Math.floor(Date.now() / 1000).toString(),
+          onchain_confirmation_time_stamp:
+            rootToBeProcessed.timestamp?.toString() ||
+            Math.floor(Date.now() / 1000).toString(),
           generation: toBeProcessedDatalayerGenerationIndex,
           comment: '',
           author: '',
@@ -520,7 +537,9 @@ const syncOrganizationAuditV2 = async (organization) => {
             type: diff.type,
             table: modelKey,
             change: diff.value ? decodeHex(diff.value) : null, // DELETE operations don't have a value field
-            onchain_confirmation_time_stamp: rootToBeProcessed.timestamp?.toString() || Math.floor(Date.now() / 1000).toString(),
+            onchain_confirmation_time_stamp:
+              rootToBeProcessed.timestamp?.toString() ||
+              Math.floor(Date.now() / 1000).toString(),
             generation: toBeProcessedDatalayerGenerationIndex,
             comment: _.get(
               tryParseJSON(
@@ -550,9 +569,13 @@ const syncOrganizationAuditV2 = async (organization) => {
                 // Convert snake_case to camelCase
                 return _.camelCase(key);
               });
-              const primaryKeyValue = camelCaseRecord[primaryKeyFieldCamelCase] || record[primaryKeyField];
+              const primaryKeyValue =
+                camelCaseRecord[primaryKeyFieldCamelCase] ||
+                record[primaryKeyField];
 
-              loggerV2.verbose(`UPSERTING (${diff.type}): ${modelKey} - ${primaryKeyValue}`);
+              loggerV2.verbose(
+                `UPSERTING (${diff.type}): ${modelKey} - ${primaryKeyValue}`,
+              );
 
               // Remove updatedAt/updated_at fields if they exist
               // This is because the db will update this field automatically and its not allowed to be null
@@ -600,20 +623,25 @@ const syncOrganizationAuditV2 = async (organization) => {
               // Key format is: "project|{uuid}" or "co_benefit|{uuid}" or "project_methodology|{uuid}"
               const keyParts = key.split('|');
               if (keyParts.length < 2) {
-                loggerV2.error(`Invalid DELETE key format: ${key}. Expected format: "table|id"`);
+                loggerV2.error(
+                  `Invalid DELETE key format: ${key}. Expected format: "table|id"`,
+                );
                 continue;
               }
               const primaryKeyValue = keyParts.slice(1).join('|'); // Handle cases where UUID might contain '|'
 
-              loggerV2.debug(`[v2]: [DELETE SYNC DEBUG] Processing DELETE operation from datalayer`, {
-                modelKey,
-                decodedKey: key,
-                hexKey: diff.key,
-                primaryKeyValue,
-                keyParts,
-                organization: organization.name,
-                generationIndex: toBeProcessedDatalayerGenerationIndex,
-              });
+              loggerV2.debug(
+                `[v2]: [DELETE SYNC DEBUG] Processing DELETE operation from datalayer`,
+                {
+                  modelKey,
+                  decodedKey: key,
+                  hexKey: diff.key,
+                  primaryKeyValue,
+                  keyParts,
+                  organization: organization.name,
+                  generationIndex: toBeProcessedDatalayerGenerationIndex,
+                },
+              );
 
               loggerV2.verbose(`DELETING: ${modelKey} - ${primaryKeyValue}`);
 
@@ -766,4 +794,3 @@ const orgGenerationMismatchCheckV2 = async (
 };
 
 export default job;
-

--- a/src/tasks/sync-registries.js
+++ b/src/tasks/sync-registries.js
@@ -33,6 +33,9 @@ const CONFIG = getConfig().APP;
 
 const mismatchBackoff = new SyncMismatchBackoff(logger, '[v1]');
 
+const hasUsableSyncStatus = (syncStatus) =>
+  syncStatus?.generation != null && syncStatus?.target_generation != null;
+
 const task = new Task('sync-registries', async () => {
   logger.debug('[v1]: sync registries task invoked');
   if (!syncRegistriesTaskMutex.isLocked()) {
@@ -154,7 +157,9 @@ async function createAndProcessTransaction(callback, afterCommitCallbacks) {
   let transaction;
   let mirrorTransaction;
 
-  logger.info('[v1]: Starting sequelize transaction and acquiring transaction mutex');
+  logger.info(
+    '[v1]: Starting sequelize transaction and acquiring transaction mutex',
+  );
   const releaseTransactionMutex =
     await processingSyncRegistriesTransactionMutex.acquire();
 
@@ -243,7 +248,9 @@ const truncateStaging = async () => {
         logger.info('[v1]: WAITING 1 SECOND BEFORE RETRYING...');
         await new Promise((resolve) => setTimeout(resolve, 1000));
       } else {
-        logger.error('[v1]: MAXIMUM STAGING CLEANUP ATTEMPTS REACHED, GIVING UP');
+        logger.error(
+          '[v1]: MAXIMUM STAGING CLEANUP ATTEMPTS REACHED, GIVING UP',
+        );
       }
     }
   }
@@ -256,9 +263,13 @@ const syncOrganizationAudit = async (organization) => {
 
     logger.debug(`[v1]: querying organization model for home org`);
     const homeOrg = await Organization.getHomeOrg();
-    logger.debug(`[v1]: querying datalayer for ${organization.name} root history`);
+    logger.debug(
+      `[v1]: querying datalayer for ${organization.name} root history`,
+    );
     const rootHistory = await datalayer.getRootHistory(organization.registryId);
-    logger.debug(`[v1]: querying datalayer for ${organization.name} sync status`);
+    logger.debug(
+      `[v1]: querying datalayer for ${organization.name} sync status`,
+    );
     const { sync_status } = await datalayer.getDataLayerStoreSyncStatus(
       organization.registryId,
     );
@@ -430,20 +441,36 @@ const syncOrganizationAudit = async (organization) => {
       `${organization.name} is ${syncRemaining} DataLayer generations away from being fully synced (orgUid ${organization.orgUid}, registryId ${organization.registryId}).`,
     );
 
-    if (!CONFIG.USE_SIMULATOR) {
-      await new Promise((resolve) => setTimeout(resolve, 30000));
+    logger.debug(
+      `5 Last processed index of ${organization.name}: ${auditTableHighestProcessedGenerationIndex}`,
+    );
+    const lastProcessedRoot = _.get(
+      rootHistory,
+      `[${auditTableHighestProcessedGenerationIndex}]`,
+    );
+    logger.debug(
+      `6 To be processed index of ${organization.name}: ${toBeProcessedDatalayerGenerationIndex}`,
+    );
+    const rootToBeProcessed = _.get(
+      rootHistory,
+      `[${toBeProcessedDatalayerGenerationIndex}]`,
+    );
 
+    logger.debug(
+      `last processed root of ${organization.name}: ${JSON.stringify(lastProcessedRoot)}`,
+    );
+    logger.debug(
+      `root to be processed of ${organization.name}: ${JSON.stringify(rootToBeProcessed)}`,
+    );
+
+    if (!CONFIG.USE_SIMULATOR) {
       // For home org, we can skip sync_status validation since we created the data locally
       // DataLayer may not have processed our own updates yet, which is fine
       if (isHomeOrg) {
         logger.debug(
           `[v1]: Home org sync_status check skipped - data is local (generation=${sync_status?.generation}, target_generation=${sync_status?.target_generation})`,
         );
-      } else if (
-        sync_status &&
-        sync_status?.generation &&
-        sync_status?.target_generation
-      ) {
+      } else if (hasUsableSyncStatus(sync_status)) {
         logger.debug(
           `store ${organization.registryId} (${organization.name}) is currently at generation ${sync_status.generation} with a target generation of ${sync_status.target_generation}`,
         );
@@ -474,10 +501,13 @@ const syncOrganizationAudit = async (organization) => {
       }
 
       // For home org, we don't need to check if DataLayer has caught up - we created the data
-      if (!isHomeOrg && toBeProcessedDatalayerGenerationIndex > sync_status.generation) {
+      if (
+        !isHomeOrg &&
+        toBeProcessedDatalayerGenerationIndex > sync_status.generation
+      ) {
         const warningMsg = [
-          `Generation ${toBeProcessedDatalayerGenerationIndex + 1} does not exist in ${organization.name} (registry store ${organization.registryId}) root history`,
-          `DataLayer not yet caught up to generation ${auditTableHighestProcessedGenerationIndex + 1}. The the highest generation datalayer has synced is ${sync_status.generation}.`,
+          `DataLayer has not locally synced generation index ${toBeProcessedDatalayerGenerationIndex} for ${organization.name} (registry store ${organization.registryId}).`,
+          `The highest generation DataLayer has synced is ${sync_status.generation}.`,
           `This issue is often temporary and could be due to a lag in data propagation.`,
           'Syncing for this organization will be paused until this is resolved.',
           'For ongoing issues, please contact the organization.',
@@ -488,27 +518,12 @@ const syncOrganizationAudit = async (organization) => {
       }
     }
 
-    logger.debug(
-      `5 Last processed index of ${organization.name}: ${auditTableHighestProcessedGenerationIndex}`,
-    );
-    const lastProcessedRoot = _.get(
-      rootHistory,
-      `[${auditTableHighestProcessedGenerationIndex}]`,
-    );
-    logger.debug(
-      `6 To be processed index of ${organization.name}: ${toBeProcessedDatalayerGenerationIndex}`,
-    );
-    const rootToBeProcessed = _.get(
-      rootHistory,
-      `[${toBeProcessedDatalayerGenerationIndex}]`,
-    );
-
-    logger.debug(
-      `last processed root of ${organization.name}: ${JSON.stringify(lastProcessedRoot)}`,
-    );
-    logger.debug(
-      `root to be processed of ${organization.name}: ${JSON.stringify(rootToBeProcessed)}`,
-    );
+    if (!rootToBeProcessed) {
+      logger.warn(
+        `Generation index ${toBeProcessedDatalayerGenerationIndex} does not exist in ${organization.name} (registry store ${organization.registryId}) root history. Syncing will retry on the next run.`,
+      );
+      return;
+    }
 
     if (!_.get(rootToBeProcessed, 'confirmed')) {
       logger.info(
@@ -524,11 +539,19 @@ const syncOrganizationAudit = async (organization) => {
       `8 To be processed index of ${organization.name}: ${toBeProcessedDatalayerGenerationIndex}`,
     );
 
-    const kvDiff = await datalayer.getRootDiff(
-      organization.registryId,
-      lastProcessedRoot.root_hash,
-      rootToBeProcessed.root_hash,
-    );
+    let kvDiff;
+    try {
+      kvDiff = await datalayer.getRootDiff(
+        organization.registryId,
+        lastProcessedRoot.root_hash,
+        rootToBeProcessed.root_hash,
+      );
+    } catch (error) {
+      logger.warn(
+        `DataLayer diff for ${organization.name} generation index ${toBeProcessedDatalayerGenerationIndex} is not ready. Syncing will retry on the next run. Error: ${error.message}`,
+      );
+      return;
+    }
 
     const comment = kvDiff.filter(
       (diff) =>
@@ -613,7 +636,9 @@ const syncOrganizationAudit = async (organization) => {
               record[ModelKeys[modelKey].primaryKeyAttributes[0]];
 
             if (diff.type === 'INSERT') {
-              logger.verbose(`[v1]: UPSERTING: ${modelKey} - ${primaryKeyValue}`);
+              logger.verbose(
+                `[v1]: UPSERTING: ${modelKey} - ${primaryKeyValue}`,
+              );
 
               // Remove updatedAt fields if they exist
               // This is because the db will update this field automatically and its not allowed to be null
@@ -631,7 +656,9 @@ const syncOrganizationAudit = async (organization) => {
                 mirrorTransaction,
               });
             } else if (diff.type === 'DELETE') {
-              logger.verbose(`[v1]: DELETING: ${modelKey} - ${primaryKeyValue}`);
+              logger.verbose(
+                `[v1]: DELETING: ${modelKey} - ${primaryKeyValue}`,
+              );
               await ModelKeys[modelKey].destroy({
                 where: {
                   [ModelKeys[modelKey].primaryKeyAttributes[0]]:


### PR DESCRIPTION
## Summary
- Remove fixed 30-second waits from v1 and v2 registry sync generation processing.
- Gate sync work on confirmed roots and DataLayer local generation readiness, then retry on the next tick when roots or diffs are not ready.
- Stop treating failed DataLayer root diffs as empty diffs to avoid writing incorrect NO CHANGE audit entries.

## Test plan
- `npx prettier --check src/datalayer/persistance.js src/tasks/sync-registries.js src/tasks/sync-registries-v2.js`
- `node --check src/datalayer/persistance.js && node --check src/tasks/sync-registries.js && node --check src/tasks/sync-registries-v2.js`
- `npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js 'tests/v2/integration/sync-registries-v2-comprehensive.spec.js' --reporter spec --exit --timeout 300000 --grep 'V1/V2 Isolation' --invert`

## Notes
- Full `sync-registries-v2-comprehensive.spec.js` still has an unrelated targeted-run failure in the V1/V2 isolation case because the v1 `organizations` table is not prepared in that invocation.
- Pre-push diff review ran clean after fixing the reviewer-reported missing-root reset regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the V1/V2 registry sync control flow and error handling around DataLayer sync status and kv diffs, which can affect when audit rows and model updates are applied. Also alters sqlite3 native build behavior during installs, which may break builds on some environments if toolchains are missing.
> 
> **Overview**
> Removes the fixed 30s sleep from both `sync-registries` tasks and instead gates per-generation processing on **DataLayer local generation readiness**, **root existence/confirmation**, and **presence of usable `sync_status`**, retrying on the next scheduler tick when prerequisites aren’t met.
> 
> Tightens DataLayer error semantics by making `getRootDiff` throw on RPC failure (instead of returning an empty diff), and updates both v1/v2 sync to catch this and *skip* generation processing to avoid writing incorrect **`NO CHANGE`** audit entries when the diff isn’t ready.
> 
> Updates packaging/build: moves sqlite3 rebuild into an npm `postinstall`, simplifies the Docker build to `npm install`, and documents native build prerequisites for source installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7917dc96e55458593447d6da052f445a309fc26b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->