### PR TITLE
perf: defer FTS triggers, bulk-write audit, index audit on sync

### DIFF
--- a/src/database/index.js
+++ b/src/database/index.js
@@ -21,13 +21,20 @@ const dbConfigKey = nodeEnv;
 // Safety check: In test mode, ensure we're using test database configuration
 if (nodeEnv === 'test') {
   const testConfig = config[dbConfigKey];
-  if (!testConfig || !testConfig.storage || !testConfig.storage.includes('test')) {
+  if (
+    !testConfig ||
+    !testConfig.storage ||
+    !testConfig.storage.includes('test')
+  ) {
     const errorMsg = `SAFETY CHECK FAILED: Test mode detected but database config '${dbConfigKey}' does not appear to be a test database. Storage: ${testConfig?.storage || 'undefined'}. This prevents accidental production database access.`;
     console.error(errorMsg);
     throw new Error(errorMsg);
   }
   // Additional check: test database should be under tests/test-dbs/, not in home directory
-  if (testConfig.storage.includes('~') || testConfig.storage.includes(os.homedir())) {
+  if (
+    testConfig.storage.includes('~') ||
+    testConfig.storage.includes(os.homedir())
+  ) {
     const errorMsg = `SAFETY CHECK FAILED: Test database path appears to be in home directory: ${testConfig.storage}. Test databases must be under tests/test-dbs/.`;
     console.error(errorMsg);
     throw new Error(errorMsg);
@@ -206,9 +213,7 @@ export const prepareMysqlMirror = async () => {
       mirrorSetupSucceeded = true;
       return true;
     } catch (error) {
-      logger.error(
-        `Error setting up MySQL mirror database: ${error.message}`,
-      );
+      logger.error(`Error setting up MySQL mirror database: ${error.message}`);
       return false;
     }
   })().finally(() => {
@@ -318,10 +323,7 @@ export const safeMirrorDbHandler = (callback) => {
           // below. Skip quietly - the next authenticate success will
           // re-enter startReconnectBackfill and retry setup. Symmetric
           // with safeMirrorDbHandlerV2.
-          if (
-            isMysqlMirrorConfiguredForReconnect() &&
-            !mirrorSetupSucceeded
-          ) {
+          if (isMysqlMirrorConfiguredForReconnect() && !mirrorSetupSucceeded) {
             return;
           }
 
@@ -523,13 +525,25 @@ export const backfillMirror = async () => {
     const mirrorPairs = [
       { source: models.Project, mirror: ProjectMirror, name: 'project' },
       { source: models.CoBenefit, mirror: CoBenefitMirror, name: 'co_benefit' },
-      { source: models.ProjectLocation, mirror: ProjectLocationMirror, name: 'location' },
+      {
+        source: models.ProjectLocation,
+        mirror: ProjectLocationMirror,
+        name: 'location',
+      },
       { source: models.Label, mirror: LabelMirror, name: 'label' },
       { source: models.Rating, mirror: RatingMirror, name: 'rating' },
-      { source: models.RelatedProject, mirror: RelatedProjectMirror, name: 'related_project' },
+      {
+        source: models.RelatedProject,
+        mirror: RelatedProjectMirror,
+        name: 'related_project',
+      },
       { source: models.Unit, mirror: UnitMirror, name: 'unit' },
       { source: models.Issuance, mirror: IssuanceMirror, name: 'issuance' },
-      { source: models.Estimation, mirror: EstimationMirror, name: 'estimation' },
+      {
+        source: models.Estimation,
+        mirror: EstimationMirror,
+        name: 'estimation',
+      },
       { source: models.LabelUnit, mirror: LabelUnitMirror, name: 'label_unit' },
       { source: models.Audit, mirror: AuditMirror, name: 'audit' },
     ];
@@ -539,8 +553,13 @@ export const backfillMirror = async () => {
 
     for (const { source, mirror, name } of mirrorPairs) {
       try {
-        if (!mirror.rawAttributes || Object.keys(mirror.rawAttributes).length === 0) {
-          logger.warn(`Mirror backfill: ${name} - mirror model not initialized, skipping`);
+        if (
+          !mirror.rawAttributes ||
+          Object.keys(mirror.rawAttributes).length === 0
+        ) {
+          logger.warn(
+            `Mirror backfill: ${name} - mirror model not initialized, skipping`,
+          );
           continue;
         }
 
@@ -581,7 +600,9 @@ export const backfillMirror = async () => {
           // eslint-disable-next-line no-constant-condition
           while (true) {
             const where =
-              lastPk === null ? undefined : { [pk]: { [Sequelize.Op.gt]: lastPk } };
+              lastPk === null
+                ? undefined
+                : { [pk]: { [Sequelize.Op.gt]: lastPk } };
             // NOTE: Do NOT pass `raw: true` to findAll. With raw:true
             // Sequelize returns SQLite values as-stored (strings),
             // including DATE columns as "YYYY-MM-DD HH:mm:ss.SSS +00:00".
@@ -745,6 +766,31 @@ export const prepareDb = async () => {
   }
 
   await checkForMigrations(sequelize);
+
+  // FTS5 deferral crash-recovery (SQLite only). If the previous run
+  // crashed mid-catch-up while the project/unit FTS triggers were
+  // dropped, the deferral flag in `meta` is still set and the FTS tables
+  // are stale. Restore the triggers + rebuild FTS content from
+  // projects/units before any reads can observe stale data.
+  //
+  // Failure here is logged and swallowed: stale FTS reads are vastly
+  // preferable to a dead app on boot, and the next sync tick re-tries the
+  // restore via the same helper once all subscribed orgs are caught up.
+  //
+  // Lazy import so this file doesn't pull in src/models/index.js (which
+  // imports from this file) at module load.
+  if (sequelize.getDialect() === 'sqlite') {
+    try {
+      const { restoreV1FtsTriggersAndRebuildIfDeferred } =
+        // eslint-disable-next-line no-restricted-syntax -- circular dep guard
+        await import('../utils/fts5-deferral.js');
+      await restoreV1FtsTriggersAndRebuildIfDeferred();
+    } catch (error) {
+      logger.error(
+        `[v1]: FTS5 deferral recovery on boot failed; FTS reads may be stale until the next caught-up sync tick re-runs the restore: ${error?.message || error}`,
+      );
+    }
+  }
 
   // Run the mirror backfill after main migrations so all source and
   // mirror tables exist. This catches up rows that were inserted/

--- a/src/database/migrations/20260301120000-add-audit-sync-indexes.js
+++ b/src/database/migrations/20260301120000-add-audit-sync-indexes.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Composite indexes on the V1 audit table to make the per-tick "find last
+// processed generation for this org" query usable by the SQLite planner.
+//
+// Hot-path query in src/tasks/sync-registries.js:
+//
+//   Audit.findOne({
+//     where: { registryId: organization.registryId },
+//     order: [['generation', 'DESC']],
+//   })
+//
+// The legacy schema has only the implicit `id` PK, so this query degrades to
+// a full table scan + sort once the audit table is large. The same pattern
+// applies to orgUid lookups elsewhere in the codebase. Indexes are
+// idempotent (IF NOT EXISTS via Sequelize's migration meta) so this is safe
+// to re-run.
+
+const INDEXES = [
+  {
+    fields: ['registryId', 'generation'],
+    name: 'audit_registry_id_generation',
+  },
+  { fields: ['orgUid', 'generation'], name: 'audit_org_uid_generation' },
+];
+
+const isDuplicateIndexError = (error) => {
+  const message = error?.message || '';
+  return /already exists/i.test(message) || /duplicate key name/i.test(message);
+};
+
+export default {
+  async up(queryInterface) {
+    for (const { fields, name } of INDEXES) {
+      try {
+        await queryInterface.addIndex('audit', fields, { name });
+      } catch (error) {
+        // Idempotent: ignore "already exists" so re-running the migration
+        // (e.g. after a partial run) doesn't fail.
+        if (!isDuplicateIndexError(error)) {
+          throw error;
+        }
+      }
+    }
+  },
+
+  async down(queryInterface) {
+    for (const { name } of INDEXES) {
+      try {
+        await queryInterface.removeIndex('audit', name);
+      } catch {
+        // Best-effort drop on rollback.
+      }
+    }
+  },
+};

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -34,6 +34,7 @@ import OrgSyncStatus from './20231020201652-OrgSyncStatus';
 import OrgSyncRemaining from './20231020214357-OrgSyncRemainingCount';
 import AddGenerationIndexToAudit from './20231207142225-AddGenerationIndexToAudit';
 import AddDataModelVersionStoreToOrganizationTable from './20241211153456-add-data-model-version-store-to-organization-table.js';
+import AddAuditSyncIndexes from './20260301120000-add-audit-sync-indexes.js';
 
 export const migrations = [
   {
@@ -183,5 +184,9 @@ export const migrations = [
   {
     migration: AddDataModelVersionStoreToOrganizationTable,
     name: '20241211153456-add-data-model-version-store-to-organization-table',
+  },
+  {
+    migration: AddAuditSyncIndexes,
+    name: '20260301120000-add-audit-sync-indexes',
   },
 ];

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -15,18 +15,27 @@ dotenv.config({ quiet: true });
 
 // possible values: local, test
 const nodeEnv = process.env.NODE_ENV;
-const dbConfigKey = nodeEnv ? `v2${nodeEnv.charAt(0).toUpperCase() + nodeEnv.slice(1)}` : 'v2Local';
+const dbConfigKey = nodeEnv
+  ? `v2${nodeEnv.charAt(0).toUpperCase() + nodeEnv.slice(1)}`
+  : 'v2Local';
 
 // Safety check: In test mode, ensure we're using test database configuration
 if (nodeEnv === 'test') {
   const testConfig = config[dbConfigKey];
-  if (!testConfig || !testConfig.storage || !testConfig.storage.includes('test')) {
+  if (
+    !testConfig ||
+    !testConfig.storage ||
+    !testConfig.storage.includes('test')
+  ) {
     const errorMsg = `SAFETY CHECK FAILED: Test mode detected but V2 database config '${dbConfigKey}' does not appear to be a test database. Storage: ${testConfig?.storage || 'undefined'}. This prevents accidental production database access.`;
     console.error(errorMsg);
     throw new Error(errorMsg);
   }
   // Additional check: test database should be under tests/test-dbs/, not in home directory
-  if (testConfig.storage.includes('~') || testConfig.storage.includes(os.homedir())) {
+  if (
+    testConfig.storage.includes('~') ||
+    testConfig.storage.includes(os.homedir())
+  ) {
     const errorMsg = `SAFETY CHECK FAILED: V2 test database path appears to be in home directory: ${testConfig.storage}. Test databases must be under tests/test-dbs/.`;
     console.error(errorMsg);
     throw new Error(errorMsg);
@@ -53,7 +62,9 @@ const mysqlMirrorConfigured =
 // Use MySQL config (v2Mirror) if configured, otherwise fall back to SQLite test config
 const mirrorConfig = mysqlMirrorConfigured ? 'v2Mirror' : 'v2MirrorTest';
 
-loggerV2.info(`[v2]: Mirror DB config selected: ${mirrorConfig} (MySQL configured: ${!!mysqlMirrorConfigured})`);
+loggerV2.info(
+  `[v2]: Mirror DB config selected: ${mirrorConfig} (MySQL configured: ${!!mysqlMirrorConfigured})`,
+);
 
 // Test-only override for isMysqlMirrorConfiguredForReconnectV2(). Tests set
 // this to simulate "MySQL is configured" (or not) independently of the actual
@@ -188,8 +199,8 @@ export const validateMirrorDbNames = (v1Config, v2Config) => {
   if (v1DbName && v2DbName && v1DbName === v2DbName) {
     throw new Error(
       `V1 and V2 mirror databases must use different database names, ` +
-      `but both are set to '${v1DbName}'. ` +
-      `Update MIRROR_DB.DB_NAME in your config.yaml so V1 and V2 have distinct values.`,
+        `but both are set to '${v1DbName}'. ` +
+        `Update MIRROR_DB.DB_NAME in your config.yaml so V1 and V2 have distinct values.`,
     );
   }
 };
@@ -210,10 +221,7 @@ const startV2ReconnectBackfill = () => {
       // configurations - the SQLite test fallback never needs setup retries
       // and would otherwise log a spurious "still failing" error on every
       // call when tests force the mirror enabled via the test override.
-      if (
-        !v2MirrorSetupSucceeded &&
-        isMysqlMirrorConfiguredForReconnectV2()
-      ) {
+      if (!v2MirrorSetupSucceeded && isMysqlMirrorConfiguredForReconnectV2()) {
         const ok = await prepareMysqlMirrorV2();
         if (!ok) {
           loggerV2.error(
@@ -331,9 +339,7 @@ export const initMirrorModelV2 = (initFn) => {
   try {
     initFn();
   } catch (error) {
-    loggerV2.error(
-      `[v2]: Failed to initialize mirror model: ${error.message}`,
-    );
+    loggerV2.error(`[v2]: Failed to initialize mirror model: ${error.message}`);
   }
 };
 
@@ -373,9 +379,13 @@ export const checkForV2Migrations = async (db) => {
     });
 
     // Special handling for FTS triggers migration - verify triggers exist even if marked complete
-    const ftsTriggersMigration = migrations.find(m => m.name === '20250110120032-create-fts5-triggers-v2');
+    const ftsTriggersMigration = migrations.find(
+      (m) => m.name === '20250110120032-create-fts5-triggers-v2',
+    );
     if (ftsTriggersMigration && db.getDialect() === 'sqlite') {
-      const isCompleted = completedMigrations.some(m => m.name === ftsTriggersMigration.name);
+      const isCompleted = completedMigrations.some(
+        (m) => m.name === ftsTriggersMigration.name,
+      );
       if (isCompleted) {
         // Verify triggers actually exist
         const triggerCheck = await db.query(
@@ -383,7 +393,9 @@ export const checkForV2Migrations = async (db) => {
           { type: Sequelize.QueryTypes.SELECT },
         );
         if (triggerCheck.length !== 6) {
-          loggerV2.warn(`FTS triggers missing (found ${triggerCheck.length}, expected 6), re-running migration`);
+          loggerV2.warn(
+            `FTS triggers missing (found ${triggerCheck.length}, expected 6), re-running migration`,
+          );
           // Remove from completed migrations so it runs again
           await db.query('DELETE FROM `SequelizeMetaV2` WHERE name = :name', {
             replacements: { name: ftsTriggersMigration.name },
@@ -410,23 +422,32 @@ export const checkForV2Migrations = async (db) => {
         const isAlreadyExistsError =
           errorMessage.includes('already exists') ||
           errorMessage.includes('duplicate column name') ||
-          (e.parent && (
+          (e.parent &&
             e.parent.code === 'SQLITE_ERROR' &&
-            (e.parent.message?.includes('already exists') || e.parent.message?.includes('duplicate')
-          )));
+            (e.parent.message?.includes('already exists') ||
+              e.parent.message?.includes('duplicate')));
 
         if (isAlreadyExistsError) {
-          loggerV2.warn(`V2 Migration ${notCompleted.name} encountered "already exists" error, marking as complete:`, errorMessage);
+          loggerV2.warn(
+            `V2 Migration ${notCompleted.name} encountered "already exists" error, marking as complete:`,
+            errorMessage,
+          );
           // Mark migration as complete even if some parts already exist
           try {
-            await db.query('INSERT INTO `SequelizeMetaV2` (name) VALUES(:name)', {
-              type: Sequelize.QueryTypes.INSERT,
-              replacements: { name: notCompleted.name },
-            });
+            await db.query(
+              'INSERT INTO `SequelizeMetaV2` (name) VALUES(:name)',
+              {
+                type: Sequelize.QueryTypes.INSERT,
+                replacements: { name: notCompleted.name },
+              },
+            );
           } catch (insertError) {
             // Ignore if already in meta table
             if (!insertError.message?.includes('UNIQUE constraint')) {
-              loggerV2.error('Error marking migration as complete', insertError);
+              loggerV2.error(
+                'Error marking migration as complete',
+                insertError,
+              );
             }
           }
         } else {
@@ -471,32 +492,113 @@ export const backfillMirrorV2 = async () => {
   try {
     // Dynamic import to avoid circular dependency
     // (model files import sequelizeV2/safeMirrorDbHandlerV2 from this file)
+    // eslint-disable-next-line no-restricted-syntax -- circular dep guard
     const models = await import('../../models/v2/index.js');
 
     // All 23 source/mirror pairs - covers every model that has a mirror
     const mirrorPairs = [
-      { source: models.OrganizationsV2, mirror: models.OrganizationsV2Mirror, name: 'organizations' },
-      { source: models.ProgramV2, mirror: models.ProgramV2Mirror, name: 'program' },
-      { source: models.MethodologyV2, mirror: models.MethodologyV2Mirror, name: 'methodology' },
-      { source: models.ProjectV2, mirror: models.ProjectV2Mirror, name: 'project' },
-      { source: models.ValidationV2, mirror: models.ValidationV2Mirror, name: 'validation' },
-      { source: models.VerificationV2, mirror: models.VerificationV2Mirror, name: 'verification' },
-      { source: models.IssuanceV2, mirror: models.IssuanceV2Mirror, name: 'issuance' },
+      {
+        source: models.OrganizationsV2,
+        mirror: models.OrganizationsV2Mirror,
+        name: 'organizations',
+      },
+      {
+        source: models.ProgramV2,
+        mirror: models.ProgramV2Mirror,
+        name: 'program',
+      },
+      {
+        source: models.MethodologyV2,
+        mirror: models.MethodologyV2Mirror,
+        name: 'methodology',
+      },
+      {
+        source: models.ProjectV2,
+        mirror: models.ProjectV2Mirror,
+        name: 'project',
+      },
+      {
+        source: models.ValidationV2,
+        mirror: models.ValidationV2Mirror,
+        name: 'validation',
+      },
+      {
+        source: models.VerificationV2,
+        mirror: models.VerificationV2Mirror,
+        name: 'verification',
+      },
+      {
+        source: models.IssuanceV2,
+        mirror: models.IssuanceV2Mirror,
+        name: 'issuance',
+      },
       { source: models.UnitV2, mirror: models.UnitV2Mirror, name: 'unit' },
-      { source: models.LocationV2, mirror: models.LocationV2Mirror, name: 'location' },
-      { source: models.EstimationV2, mirror: models.EstimationV2Mirror, name: 'estimation' },
-      { source: models.RatingV2, mirror: models.RatingV2Mirror, name: 'rating' },
-      { source: models.CoBenefitV2, mirror: models.CoBenefitV2Mirror, name: 'co_benefit' },
-      { source: models.ProjectMethodologyV2, mirror: models.ProjectMethodologyV2Mirror, name: 'project_methodology' },
-      { source: models.StakeholderV2, mirror: models.StakeholderV2Mirror, name: 'stakeholder' },
-      { source: models.StakeholderProjectV2, mirror: models.StakeholderProjectV2Mirror, name: 'stakeholder_projects' },
+      {
+        source: models.LocationV2,
+        mirror: models.LocationV2Mirror,
+        name: 'location',
+      },
+      {
+        source: models.EstimationV2,
+        mirror: models.EstimationV2Mirror,
+        name: 'estimation',
+      },
+      {
+        source: models.RatingV2,
+        mirror: models.RatingV2Mirror,
+        name: 'rating',
+      },
+      {
+        source: models.CoBenefitV2,
+        mirror: models.CoBenefitV2Mirror,
+        name: 'co_benefit',
+      },
+      {
+        source: models.ProjectMethodologyV2,
+        mirror: models.ProjectMethodologyV2Mirror,
+        name: 'project_methodology',
+      },
+      {
+        source: models.StakeholderV2,
+        mirror: models.StakeholderV2Mirror,
+        name: 'stakeholder',
+      },
+      {
+        source: models.StakeholderProjectV2,
+        mirror: models.StakeholderProjectV2Mirror,
+        name: 'stakeholder_projects',
+      },
       { source: models.LabelV2, mirror: models.LabelV2Mirror, name: 'label' },
-      { source: models.UnitLabelV2, mirror: models.UnitLabelV2Mirror, name: 'unit_label' },
-      { source: models.AefT1SubmissionV2, mirror: models.AefT1SubmissionV2Mirror, name: 'aef_t1_submission' },
-      { source: models.AefT5AuthorizedEntitiesV2, mirror: models.AefT5AuthorizedEntitiesV2Mirror, name: 'aef_t5_authorized_entities' },
-      { source: models.AefT2AuthorizationsV2, mirror: models.AefT2AuthorizationsV2Mirror, name: 'aef_t2_authorizations' },
-      { source: models.AefT3ActionsV2, mirror: models.AefT3ActionsV2Mirror, name: 'aef_t3_actions' },
-      { source: models.AefT4HoldingsV2, mirror: models.AefT4HoldingsV2Mirror, name: 'aef_t4_holdings' },
+      {
+        source: models.UnitLabelV2,
+        mirror: models.UnitLabelV2Mirror,
+        name: 'unit_label',
+      },
+      {
+        source: models.AefT1SubmissionV2,
+        mirror: models.AefT1SubmissionV2Mirror,
+        name: 'aef_t1_submission',
+      },
+      {
+        source: models.AefT5AuthorizedEntitiesV2,
+        mirror: models.AefT5AuthorizedEntitiesV2Mirror,
+        name: 'aef_t5_authorized_entities',
+      },
+      {
+        source: models.AefT2AuthorizationsV2,
+        mirror: models.AefT2AuthorizationsV2Mirror,
+        name: 'aef_t2_authorizations',
+      },
+      {
+        source: models.AefT3ActionsV2,
+        mirror: models.AefT3ActionsV2Mirror,
+        name: 'aef_t3_actions',
+      },
+      {
+        source: models.AefT4HoldingsV2,
+        mirror: models.AefT4HoldingsV2Mirror,
+        name: 'aef_t4_holdings',
+      },
       { source: models.AuditV2, mirror: models.AuditV2Mirror, name: 'audit' },
     ];
 
@@ -506,8 +608,13 @@ export const backfillMirrorV2 = async () => {
     for (const { source, mirror, name } of mirrorPairs) {
       try {
         // Verify mirror model is initialized (init may not have completed if mirror was just configured)
-        if (!mirror.rawAttributes || Object.keys(mirror.rawAttributes).length === 0) {
-          loggerV2.warn(`[v2]: Mirror backfill: ${name} - mirror model not initialized, skipping`);
+        if (
+          !mirror.rawAttributes ||
+          Object.keys(mirror.rawAttributes).length === 0
+        ) {
+          loggerV2.warn(
+            `[v2]: Mirror backfill: ${name} - mirror model not initialized, skipping`,
+          );
           continue;
         }
 
@@ -553,7 +660,9 @@ export const backfillMirrorV2 = async () => {
           // eslint-disable-next-line no-constant-condition
           while (true) {
             const where =
-              lastPk === null ? undefined : { [pk]: { [Sequelize.Op.gt]: lastPk } };
+              lastPk === null
+                ? undefined
+                : { [pk]: { [Sequelize.Op.gt]: lastPk } };
             // NOTE: Do NOT pass `raw: true` to findAll. With raw:true
             // Sequelize returns SQLite values as-stored (strings),
             // including DATE columns as "YYYY-MM-DD HH:mm:ss.SSS +00:00".
@@ -613,11 +722,15 @@ export const backfillMirrorV2 = async () => {
         if (synced === 0) {
           loggerV2.debug(`[v2]: Mirror backfill: ${name} - no records to sync`);
         } else {
-          loggerV2.info(`[v2]: Mirror backfill: ${name} - synced ${synced} records`);
+          loggerV2.info(
+            `[v2]: Mirror backfill: ${name} - synced ${synced} records`,
+          );
         }
         totalSynced += synced;
       } catch (error) {
-        loggerV2.error(`[v2]: Mirror backfill error for ${name}: ${error.message}`);
+        loggerV2.error(
+          `[v2]: Mirror backfill error for ${name}: ${error.message}`,
+        );
         // Continue with next table - don't let one failure stop the entire backfill
       }
     }
@@ -783,9 +896,7 @@ export const prepareMysqlMirrorV2 = async () => {
 
       try {
         const dbName = mirrorDbConfig.DB_NAME;
-        await connection.query(
-          `CREATE DATABASE IF NOT EXISTS \`${dbName}\`;`,
-        );
+        await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbName}\`;`);
         loggerV2.info(
           `[v2]: MySQL mirror database '${dbName}' created/verified`,
         );
@@ -823,7 +934,7 @@ export const prepareV2Db = async () => {
     try {
       const tables = await sequelizeV2.query(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='governance'",
-        { type: sequelizeV2.QueryTypes.SELECT }
+        { type: sequelizeV2.QueryTypes.SELECT },
       );
       if (tables && tables.length > 0) {
         // Tables exist, safe to return
@@ -835,7 +946,10 @@ export const prepareV2Db = async () => {
       prepareV2DbPromise = null;
     } catch (error) {
       // Database not accessible, reset and re-run
-      loggerV2.warn('[v2]: Database check failed, re-running prepareV2Db():', error.message);
+      loggerV2.warn(
+        '[v2]: Database check failed, re-running prepareV2Db():',
+        error.message,
+      );
       prepareV2DbCompleted = false;
       prepareV2DbPromise = null;
     }
@@ -871,12 +985,34 @@ export const prepareV2Db = async () => {
       await prepareMysqlMirrorV2();
     } else {
       // No MySQL mirror configured - mirror operations will be no-ops
-      loggerV2.info('[v2]: No MySQL mirror configured, mirror operations disabled');
+      loggerV2.info(
+        '[v2]: No MySQL mirror configured, mirror operations disabled',
+      );
     }
 
-    loggerV2.info('[v2]: About to run main database migrations (sequelizeV2)...');
+    loggerV2.info(
+      '[v2]: About to run main database migrations (sequelizeV2)...',
+    );
     await checkForV2Migrations(sequelizeV2);
     loggerV2.info('[v2]: Main database migrations completed');
+
+    // FTS5 deferral crash-recovery (SQLite only). See V1 prepareDb for
+    // the full rationale. Failure here is logged and swallowed - stale
+    // FTS reads are preferable to a dead app on boot, and the next sync
+    // tick will re-try the restore once all subscribed orgs are caught
+    // up.
+    if (sequelizeV2.getDialect() === 'sqlite') {
+      try {
+        const { restoreV2FtsTriggersAndRebuildIfDeferred } =
+          // eslint-disable-next-line no-restricted-syntax -- circular dep guard
+          await import('../../utils/fts5-deferral-v2.js');
+        await restoreV2FtsTriggersAndRebuildIfDeferred();
+      } catch (error) {
+        loggerV2.error(
+          `[v2]: FTS5 deferral recovery on boot failed; FTS reads may be stale until the next caught-up sync tick re-runs the restore: ${error?.message || error}`,
+        );
+      }
+    }
 
     // Backfill mirror database from SQLite source data (idempotent upsert).
     // Runs after both mirror and main migrations are complete so all tables exist.
@@ -902,10 +1038,14 @@ export const prepareV2Db = async () => {
 async function setV2WALMode() {
   try {
     await sequelizeV2.authenticate();
-    await sequelizeV2.query('PRAGMA journal_mode=WAL;', { type: QueryTypes.RAW });
+    await sequelizeV2.query('PRAGMA journal_mode=WAL;', {
+      type: QueryTypes.RAW,
+    });
     // Set busy_timeout to 30 seconds (30000ms) to handle concurrent access
     // This tells SQLite to wait up to 30 seconds before returning SQLITE_BUSY
-    await sequelizeV2.query('PRAGMA busy_timeout=30000;', { type: QueryTypes.RAW });
+    await sequelizeV2.query('PRAGMA busy_timeout=30000;', {
+      type: QueryTypes.RAW,
+    });
     console.log('V2 WAL mode set successfully.');
     console.log('V2 busy_timeout set to 30000ms.');
   } catch (error) {

--- a/src/database/v2/migrations/20260301120000-add-audit-sync-indexes-v2.js
+++ b/src/database/v2/migrations/20260301120000-add-audit-sync-indexes-v2.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// Composite indexes on the V2 audit table to make the per-tick "find last
+// processed generation for this org" query usable by the SQLite/MySQL planner.
+//
+// Hot-path query in src/tasks/sync-registries-v2.js:
+//
+//   AuditV2.findOne({
+//     where: { registry_id: organization.registry_id },
+//     order: [['generation', 'DESC']],
+//   })
+//
+// V2's create-audit migration only declares the implicit `id` PK, so this
+// query degrades to a full table scan + sort once the audit table is large.
+// Symmetric with the V1 audit-sync index migration.
+
+const INDEXES = [
+  {
+    fields: ['registry_id', 'generation'],
+    name: 'audit_v2_registry_id_generation',
+  },
+  { fields: ['org_uid', 'generation'], name: 'audit_v2_org_uid_generation' },
+];
+
+const isDuplicateIndexError = (error) => {
+  const message = error?.message || '';
+  return /already exists/i.test(message) || /duplicate key name/i.test(message);
+};
+
+export default {
+  async up(queryInterface) {
+    for (const { fields, name } of INDEXES) {
+      try {
+        await queryInterface.addIndex('audit', fields, { name });
+      } catch (error) {
+        // Idempotent: ignore "already exists" so re-running the migration
+        // doesn't fail on either dialect.
+        if (!isDuplicateIndexError(error)) {
+          throw error;
+        }
+      }
+    }
+  },
+
+  async down(queryInterface) {
+    for (const { name } of INDEXES) {
+      try {
+        await queryInterface.removeIndex('audit', name);
+      } catch {
+        // Best-effort drop on rollback.
+      }
+    }
+  },
+};

--- a/src/database/v2/migrations/index.js
+++ b/src/database/v2/migrations/index.js
@@ -46,6 +46,9 @@ import DropGovernanceFromMirrorV2 from './20250219120000-drop-governance-from-mi
 // V2 Owner Field Migration
 import AddOrgUidToStandaloneTablesV2 from './20260220120000-add-org-uid-to-standalone-tables-v2.js';
 
+// V2 Sync Performance: composite audit indexes for the per-tick generation lookup
+import AddAuditSyncIndexesV2 from './20260301120000-add-audit-sync-indexes-v2.js';
+
 export const migrations = [
   {
     migration: CreateStagingV2,
@@ -182,5 +185,9 @@ export const migrations = [
   {
     migration: AddOrgUidToStandaloneTablesV2,
     name: '20260220120000-add-org-uid-to-standalone-tables-v2',
+  },
+  {
+    migration: AddAuditSyncIndexesV2,
+    name: '20260301120000-add-audit-sync-indexes-v2',
   },
 ];

--- a/src/models/audit/audit.model.js
+++ b/src/models/audit/audit.model.js
@@ -20,6 +20,17 @@ class Audit extends Model {
     return super.create(values, options);
   }
 
+  static async bulkCreate(values, options) {
+    safeMirrorDbHandler(async () => {
+      const mirrorOptions = {
+        ...options,
+        transaction: options?.mirrorTransaction,
+      };
+      await AuditMirror.bulkCreate(values, mirrorOptions);
+    });
+    return super.bulkCreate(values, options);
+  }
+
   static async destroy(options) {
     safeMirrorDbHandler(async () => {
       const mirrorOptions = {

--- a/src/tasks/sync-registries-v2.js
+++ b/src/tasks/sync-registries-v2.js
@@ -23,6 +23,10 @@ import {
   syncRegistriesTaskMutexV2,
 } from '../utils/v2-model-utils.js';
 import { SyncMismatchBackoff } from '../utils/sync-mismatch-backoff.js';
+import {
+  ensureV2FtsTriggersDeferred,
+  restoreV2FtsTriggersAndRebuildIfDeferred,
+} from '../utils/fts5-deferral-v2.js';
 
 dotenv.config({ quiet: true });
 const CONFIG = getConfig().APP;
@@ -78,8 +82,52 @@ const processJob = async () => {
     raw: true,
   });
 
-  for (const organization of organizations) {
-    await syncOrganizationAuditV2(organization);
+  // FTS5 deferral: see V1 sync-registries.js for the full rationale.
+  // When at least one subscribed org is still mid-catch-up, drop the
+  // project/unit FTS triggers and persist a flag in `meta`. After the
+  // tick finishes and all orgs are caught up, restore the triggers and
+  // rebuild the FTS tables in a single transaction.
+  //
+  // Skip the global drop in NODE_ENV=test: the integration test suite
+  // creates many `subscribed: true, synced: false` org fixtures while
+  // the V2 background sync interval is live, and FTS-dependent specs
+  // assume the project/unit triggers stay installed. The deferral
+  // behaviour itself is exercised by tests/v2/integration/sync-write-perf-v2.spec.js
+  // (which calls the helpers directly and isolates them from sync).
+  const skipFtsDeferralForTests = process.env.NODE_ENV === 'test';
+
+  const anyOrgNeedsCatchup = organizations.some(
+    (organization) => !organization.synced,
+  );
+  if (anyOrgNeedsCatchup && !skipFtsDeferralForTests) {
+    await ensureV2FtsTriggersDeferred();
+  }
+
+  try {
+    for (const organization of organizations) {
+      await syncOrganizationAuditV2(organization);
+    }
+  } finally {
+    // Run the restore decision in `finally` so a thrown sync error doesn't
+    // leave V2 FTS triggers permanently dropped until the next process
+    // restart. The next tick will retry regardless.
+    if (!skipFtsDeferralForTests) {
+      try {
+        const orgsAfter = await OrganizationsV2.findAll({
+          where: { subscribed: true },
+          attributes: ['org_uid', 'synced'],
+          raw: true,
+        });
+        const anyOrgStillCatchingUp = orgsAfter.some((o) => !o.synced);
+        if (!anyOrgStillCatchingUp) {
+          await restoreV2FtsTriggersAndRebuildIfDeferred();
+        }
+      } catch (restoreError) {
+        loggerV2.error(
+          `[v2]: FTS5 restore decision failed at tick end: ${restoreError?.message || restoreError}`,
+        );
+      }
+    }
   }
 };
 
@@ -133,7 +181,7 @@ const truncateStagingV2 = async () => {
 const syncOrganizationAuditV2 = async (organization) => {
   loggerV2.debug(`syncing organization audit for ${organization.name}`);
   try {
-    let afterCommitCallbacks = [];
+    const afterCommitCallbacks = [];
 
     loggerV2.debug('querying organization model for home org');
     const homeOrg = await OrganizationsV2.getHomeOrg();
@@ -215,7 +263,6 @@ const syncOrganizationAuditV2 = async (organization) => {
     if (CONFIG.USE_SIMULATOR) {
       console.log('USING MOCK ROOT HISTORY');
       lastRootSavedToAuditTable = rootHistory[0];
-      lastRootSavedToAuditTable.root_hash = lastRootSavedToAuditTable.root_hash;
       lastRootSavedToAuditTable.generation = 0;
     } else {
       loggerV2.debug(
@@ -232,8 +279,6 @@ const syncOrganizationAuditV2 = async (organization) => {
         lastRootSavedToAuditTable.timestamp = Number(
           lastRootSavedToAuditTable?.onchain_confirmation_time_stamp || 0,
         );
-        lastRootSavedToAuditTable.root_hash =
-          lastRootSavedToAuditTable.root_hash;
       }
     }
 
@@ -522,6 +567,30 @@ const syncOrganizationAuditV2 = async (organization) => {
         (roots [generation ${lastRootSavedToAuditTable.generation}] ${lastProcessedRoot.root_hash} and [generation ${lastRootSavedToAuditTable.generation + 1}] ${rootToBeProcessed.root_hash})`,
         );
 
+        // Hoist comment / author parsing out of the per-row diff loop. The
+        // comment and author kv-diff entries are shared across every row in
+        // the same generation, so re-running tryParseJSON(decodeHex(...)) per
+        // row is wasted work proportional to diff length.
+        const generationComment = _.get(
+          tryParseJSON(decodeHex(_.get(comment, '[0].value', encodeHex('{}')))),
+          'comment',
+          '',
+        );
+        const generationAuthor = _.get(
+          tryParseJSON(decodeHex(_.get(author, '[0].value', encodeHex('{}')))),
+          'author',
+          '',
+        );
+
+        // Buffer audit rows for a single per-generation bulkCreate at the
+        // end of the loop. One INSERT per kv-diff row was the dominant
+        // write cost on Pi-class hardware during catch-up.
+        const auditRowsForGeneration = [];
+
+        const onchainConfirmationTimestamp =
+          rootToBeProcessed.timestamp?.toString() ||
+          Math.floor(Date.now() / 1000).toString();
+
         for (const diff of optimizedKvDiff) {
           const key = decodeHex(diff.key);
           const modelKey = key.split('|')[0];
@@ -537,24 +606,10 @@ const syncOrganizationAuditV2 = async (organization) => {
             type: diff.type,
             table: modelKey,
             change: diff.value ? decodeHex(diff.value) : null, // DELETE operations don't have a value field
-            onchain_confirmation_time_stamp:
-              rootToBeProcessed.timestamp?.toString() ||
-              Math.floor(Date.now() / 1000).toString(),
+            onchain_confirmation_time_stamp: onchainConfirmationTimestamp,
             generation: toBeProcessedDatalayerGenerationIndex,
-            comment: _.get(
-              tryParseJSON(
-                decodeHex(_.get(comment, '[0].value', encodeHex('{}'))),
-              ),
-              'comment',
-              '',
-            ),
-            author: _.get(
-              tryParseJSON(
-                decodeHex(_.get(author, '[0].value', encodeHex('{}'))),
-              ),
-              'author',
-              '',
-            ),
+            comment: generationComment,
+            author: generationAuthor,
           };
 
           if (modelKey && Object.keys(ModelKeysV2).includes(modelKey)) {
@@ -657,9 +712,19 @@ const syncOrganizationAuditV2 = async (organization) => {
             }
           }
 
-          // Create the Audit record
-          loggerV2.debug('writing change record ');
-          await AuditV2.create(auditData, { transaction });
+          auditRowsForGeneration.push(auditData);
+        }
+
+        if (auditRowsForGeneration.length > 0) {
+          loggerV2.debug(
+            `[v2]: bulk-writing ${auditRowsForGeneration.length} audit row(s) for generation ${toBeProcessedDatalayerGenerationIndex}`,
+          );
+          // See V1: batchSize keeps very large generations under the
+          // SQLite SQLITE_MAX_VARIABLE_NUMBER cap.
+          await AuditV2.bulkCreate(auditRowsForGeneration, {
+            transaction,
+            batchSize: 500,
+          });
         }
       }
     };

--- a/src/tasks/sync-registries.js
+++ b/src/tasks/sync-registries.js
@@ -27,6 +27,10 @@ import {
   syncRegistriesTaskMutex,
 } from '../utils/model-utils.js';
 import { SyncMismatchBackoff } from '../utils/sync-mismatch-backoff.js';
+import {
+  ensureV1FtsTriggersDeferred,
+  restoreV1FtsTriggersAndRebuildIfDeferred,
+} from '../utils/fts5-deferral.js';
 
 dotenv.config({ quiet: true });
 const CONFIG = getConfig().APP;
@@ -99,55 +103,115 @@ const processJob = async () => {
     raw: true,
   });
 
-  for (const organization of organizations) {
-    if (CONFIG.USE_SIMULATOR || process.env.NODE_ENV === 'test') {
-      await syncOrganizationAudit(organization);
-    } else {
-      const mostRecentOrgAuditRecord = await Audit.findOne({
-        where: {
-          orgUid: organization.orgUid,
-        },
-        order: [['createdAt', 'DESC']],
-        limit: 1,
-        raw: true,
-      });
+  // FTS5 deferral: when at least one subscribed org has not yet caught up,
+  // drop the project/unit FTS triggers so the upserts in syncOrganizationAudit
+  // don't pay the per-row tokenisation cost. The restore + rebuild runs
+  // after this loop when no orgs need catch-up. The Organization.synced
+  // flag is set by the sync loop itself, so on the very first tick after
+  // a fresh boot all subscribed orgs may show synced=false until the loop
+  // determines they're actually caught up. That's fine - the worst case
+  // is that triggers are dropped one tick early and restored one tick
+  // later than strictly necessary, neither of which is a correctness
+  // problem because the rebuild reconciles regardless.
+  //
+  // Skip the global drop in NODE_ENV=test: the integration test suite
+  // creates many `subscribed: true, synced: false` org fixtures while
+  // the V1 background sync interval is live, and FTS-dependent specs
+  // assume the project/unit triggers stay installed. The deferral
+  // behaviour itself is exercised by tests/integration/sync-write-perf.spec.js
+  // (which calls the helpers directly and isolates them from sync).
+  const skipFtsDeferralForTests = process.env.NODE_ENV === 'test';
 
-      // verify that the latest organization root hash is up to date with the audit records. attempt correction.
-      if (
-        mostRecentOrgAuditRecord &&
-        mostRecentOrgAuditRecord?.rootHash !== organization?.registryHash
-      ) {
-        logger.warn(
-          `latest root hash in org table for organization ${organization.name} (orgUid ${organization.orgUid}) does not match the audit records. attempting to correct`,
-        );
-        try {
-          const result = await Organization.update(
-            { registryHash: mostRecentOrgAuditRecord.rootHash },
-            {
-              where: { orgUid: organization.orgUid },
-            },
-          );
+  const anyOrgNeedsCatchup = organizations.some(
+    (organization) => !organization.synced,
+  );
+  if (anyOrgNeedsCatchup && !skipFtsDeferralForTests) {
+    await ensureV1FtsTriggersDeferred();
+  }
 
-          if (result?.length) {
-            logger.info(
-              `registry hash record corrected for ${organization.name} (orgUid ${organization.orgUid}). proceeding with audit sync`,
-            );
-            const correctedOrganizationRecord = await Organization.findOne({
-              where: { orgUid: organization.orgUid },
-            });
-
-            await syncOrganizationAudit(correctedOrganizationRecord);
-          } else {
-            throw new Error('organizations update query affected 0 records');
-          }
-        } catch (error) {
-          logger.error(
-            `failed to update organization table record for ${organization.name} (orgUid ${organization.orgUid}) with correct root hash. Something is wrong. Skipping audit sync and trying again shortly. Error: ${error}`,
-          );
-        }
-      } else {
-        // normal state, proceed with audit sync
+  try {
+    for (const organization of organizations) {
+      if (CONFIG.USE_SIMULATOR || process.env.NODE_ENV === 'test') {
         await syncOrganizationAudit(organization);
+      } else {
+        // Order by generation (not createdAt) so this lookup is served
+        // by the audit_org_uid_generation composite index. Generation
+        // is monotonic per orgUid in the sync forward path, so the two
+        // orderings agree on the rootHash returned; ordering by
+        // generation is also semantically what we want here ("the most
+        // recently ingested generation for this org").
+        const mostRecentOrgAuditRecord = await Audit.findOne({
+          where: {
+            orgUid: organization.orgUid,
+          },
+          order: [['generation', 'DESC']],
+          limit: 1,
+          raw: true,
+        });
+
+        // verify that the latest organization root hash is up to date with the audit records. attempt correction.
+        if (
+          mostRecentOrgAuditRecord &&
+          mostRecentOrgAuditRecord?.rootHash !== organization?.registryHash
+        ) {
+          logger.warn(
+            `latest root hash in org table for organization ${organization.name} (orgUid ${organization.orgUid}) does not match the audit records. attempting to correct`,
+          );
+          try {
+            const result = await Organization.update(
+              { registryHash: mostRecentOrgAuditRecord.rootHash },
+              {
+                where: { orgUid: organization.orgUid },
+              },
+            );
+
+            if (result?.length) {
+              logger.info(
+                `registry hash record corrected for ${organization.name} (orgUid ${organization.orgUid}). proceeding with audit sync`,
+              );
+              const correctedOrganizationRecord = await Organization.findOne({
+                where: { orgUid: organization.orgUid },
+              });
+
+              await syncOrganizationAudit(correctedOrganizationRecord);
+            } else {
+              throw new Error('organizations update query affected 0 records');
+            }
+          } catch (error) {
+            logger.error(
+              `failed to update organization table record for ${organization.name} (orgUid ${organization.orgUid}) with correct root hash. Something is wrong. Skipping audit sync and trying again shortly. Error: ${error}`,
+            );
+          }
+        } else {
+          // normal state, proceed with audit sync
+          await syncOrganizationAudit(organization);
+        }
+      }
+    }
+  } finally {
+    // After processing all orgs (or after an exception bubbles out of the
+    // loop above), re-read the org table to see whether anyone is still
+    // in catch-up. If everyone is caught up and triggers are currently
+    // deferred, restore them + rebuild FTS in a single transaction. Run
+    // in `finally` so a thrown sync error doesn't leave FTS triggers
+    // permanently dropped until the next process restart.
+    if (!skipFtsDeferralForTests) {
+      try {
+        const orgsAfter = await Organization.findAll({
+          where: { subscribed: true },
+          attributes: ['orgUid', 'synced'],
+          raw: true,
+        });
+        const anyOrgStillCatchingUp = orgsAfter.some((o) => !o.synced);
+        if (!anyOrgStillCatchingUp) {
+          await restoreV1FtsTriggersAndRebuildIfDeferred();
+        }
+      } catch (restoreError) {
+        // Don't shadow the original loop error if there was one. The next
+        // tick will retry restore via the same finally block.
+        logger.error(
+          `[v1]: FTS5 restore decision failed at tick end: ${restoreError?.message || restoreError}`,
+        );
       }
     }
   }
@@ -259,7 +323,7 @@ const truncateStaging = async () => {
 const syncOrganizationAudit = async (organization) => {
   logger.debug(`[v1]: syncing organization audit for ${organization.name}`);
   try {
-    let afterCommitCallbacks = [];
+    const afterCommitCallbacks = [];
 
     logger.debug(`[v1]: querying organization model for home org`);
     const homeOrg = await Organization.getHomeOrg();
@@ -598,6 +662,26 @@ const syncOrganizationAudit = async (organization) => {
         logger.debug(`[v1]: processing optimized kv diff for ${organization.name} generation indices ${auditTableHighestProcessedGenerationIndex} and ${toBeProcessedDatalayerGenerationIndex}
         (roots [generation ${lastRootSavedToAuditTable.generation}] ${lastProcessedRoot.root_hash} and [generation ${lastRootSavedToAuditTable.generation + 1}] ${rootToBeProcessed.root_hash})`);
 
+        // Hoist comment / author parsing out of the per-row diff loop. The
+        // comment and author kv-diff entries are shared across every row in
+        // the same generation, so re-running tryParseJSON(decodeHex(...)) per
+        // row is wasted work proportional to diff length.
+        const generationComment = _.get(
+          tryParseJSON(decodeHex(_.get(comment, '[0].value', encodeHex('{}')))),
+          'comment',
+          '',
+        );
+        const generationAuthor = _.get(
+          tryParseJSON(decodeHex(_.get(author, '[0].value', encodeHex('{}')))),
+          'author',
+          '',
+        );
+
+        // Buffer audit rows for a single per-generation bulkCreate at the
+        // end of the loop. One INSERT per kv-diff row was the dominant
+        // write cost on Pi-class hardware during catch-up.
+        const auditRowsForGeneration = [];
+
         for (const diff of optimizedKvDiff) {
           const key = decodeHex(diff.key);
           const modelKey = key.split('|')[0];
@@ -614,20 +698,8 @@ const syncOrganizationAudit = async (organization) => {
             change: decodeHex(diff.value),
             onchainConfirmationTimeStamp: rootToBeProcessed.timestamp,
             generation: toBeProcessedDatalayerGenerationIndex,
-            comment: _.get(
-              tryParseJSON(
-                decodeHex(_.get(comment, '[0].value', encodeHex('{}'))),
-              ),
-              'comment',
-              '',
-            ),
-            author: _.get(
-              tryParseJSON(
-                decodeHex(_.get(author, '[0].value', encodeHex('{}'))),
-              ),
-              'author',
-              '',
-            ),
+            comment: generationComment,
+            author: generationAuthor,
           };
 
           if (modelKey && Object.keys(ModelKeys).includes(modelKey)) {
@@ -670,9 +742,23 @@ const syncOrganizationAudit = async (organization) => {
             }
           }
 
-          // Create the Audit record
-          logger.debug(`[v1]: writing change record `);
-          await Audit.create(auditData, { transaction, mirrorTransaction });
+          auditRowsForGeneration.push(auditData);
+        }
+
+        if (auditRowsForGeneration.length > 0) {
+          logger.debug(
+            `[v1]: bulk-writing ${auditRowsForGeneration.length} audit row(s) for generation ${toBeProcessedDatalayerGenerationIndex}`,
+          );
+          // batchSize caps Sequelize's multi-row INSERT size so a very
+          // large generation (rare but possible) does not blow past
+          // SQLite's SQLITE_MAX_VARIABLE_NUMBER limit. With ~10 columns
+          // per row, 500 rows/batch leaves headroom under the default
+          // 32766-variable cap.
+          await Audit.bulkCreate(auditRowsForGeneration, {
+            transaction,
+            mirrorTransaction,
+            batchSize: 500,
+          });
         }
       }
     };

--- a/src/utils/fts5-deferral-v2.js
+++ b/src/utils/fts5-deferral-v2.js
@@ -1,0 +1,266 @@
+'use strict';
+
+// V2 FTS5 trigger deferral helpers. See src/utils/fts5-deferral.js for the
+// rationale and design notes; the two files are mirror-images differing
+// only in trigger names, table names, meta-key names, and the meta backend.
+
+import { sequelizeV2 } from '../database/v2/index.js';
+import { loggerV2 } from '../config/logger.js';
+
+export const FTS5_DEFER_META_KEY_V2 = 'fts5TriggersDeferredV2';
+export const FTS5_DEFER_TRIGGERS_META_KEY_V2 = 'fts5DeferredTriggerSnapshotV2';
+
+const PROJECTS_FTS_TABLE = 'projects_v2_fts';
+const UNITS_FTS_TABLE = 'units_v2_fts';
+
+const isSqlite = () => sequelizeV2.getDialect() === 'sqlite';
+
+const ftsTableExists = async (tableName, transaction) => {
+  const [rows] = await sequelizeV2.query(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name=:tableName",
+    { replacements: { tableName }, transaction },
+  );
+  return Array.isArray(rows) && rows.length > 0;
+};
+
+const fetchFtsColumnList = async (tableName, transaction) => {
+  const rows = await sequelizeV2.query(`PRAGMA table_info('${tableName}');`, {
+    transaction,
+    type: sequelizeV2.QueryTypes.SELECT,
+  });
+  return rows.map((r) => r.name);
+};
+
+const introspectV2FtsTriggers = async (transaction) => {
+  const rows = await sequelizeV2.query(
+    `SELECT name, sql FROM sqlite_master
+     WHERE type = 'trigger'
+       AND name NOT LIKE 'sqlite_%'
+       AND sql IS NOT NULL
+       AND (sql LIKE '%projects_v2_fts%' OR sql LIKE '%units_v2_fts%')
+     ORDER BY name;`,
+    { transaction, type: sequelizeV2.QueryTypes.SELECT },
+  );
+  return rows
+    .filter((r) => typeof r.name === 'string' && typeof r.sql === 'string')
+    .map((r) => ({ name: r.name, sql: r.sql }));
+};
+
+const dropTriggersByName = async (names, transaction) => {
+  for (const name of names) {
+    await sequelizeV2.query(`DROP TRIGGER IF EXISTS ${name};`, { transaction });
+  }
+};
+
+const getMetaModel = async () => {
+  // eslint-disable-next-line no-restricted-syntax -- circular dep guard
+  const { MetaV2 } = await import('../models/v2/index.js');
+  return MetaV2;
+};
+
+const isFtsDeferralFlagSetV2 = async (transaction) => {
+  const MetaV2 = await getMetaModel();
+  const row = await MetaV2.findOne({
+    where: { meta_key: FTS5_DEFER_META_KEY_V2 },
+    raw: true,
+    transaction,
+  });
+  return !!row;
+};
+
+const readTriggerSnapshotV2 = async (transaction) => {
+  const MetaV2 = await getMetaModel();
+  const row = await MetaV2.findOne({
+    where: { meta_key: FTS5_DEFER_TRIGGERS_META_KEY_V2 },
+    raw: true,
+    transaction,
+  });
+  if (!row || typeof row.meta_value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(row.meta_value);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter(
+      (t) => t && typeof t.name === 'string' && typeof t.sql === 'string',
+    );
+  } catch (error) {
+    loggerV2.warn(
+      `[v2]: Failed to parse FTS5 trigger snapshot from meta: ${error.message}`,
+    );
+    return null;
+  }
+};
+
+const writeTriggerSnapshotV2 = async (snapshot, transaction) => {
+  const json = JSON.stringify(snapshot);
+  await sequelizeV2.query(`DELETE FROM meta WHERE meta_key = :metaKey;`, {
+    replacements: { metaKey: FTS5_DEFER_TRIGGERS_META_KEY_V2 },
+    transaction,
+  });
+  await sequelizeV2.query(
+    `INSERT INTO meta (meta_key, meta_value, created_at, updated_at)
+     VALUES (:metaKey, :metaValue, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);`,
+    {
+      replacements: {
+        metaKey: FTS5_DEFER_TRIGGERS_META_KEY_V2,
+        metaValue: json,
+      },
+      transaction,
+    },
+  );
+};
+
+const setFtsDeferralFlagV2 = async (transaction) => {
+  await sequelizeV2.query(
+    `INSERT OR IGNORE INTO meta (meta_key, meta_value, created_at, updated_at)
+     VALUES (:metaKey, '1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);`,
+    {
+      replacements: { metaKey: FTS5_DEFER_META_KEY_V2 },
+      transaction,
+    },
+  );
+};
+
+// Bypass MetaV2.destroy's 50ms back-pressure shim: this path runs inside
+// the restore transaction and the delay would needlessly extend the
+// SQLite write lock.
+const clearDeferralStateRawV2 = async (transaction) => {
+  await sequelizeV2.query(`DELETE FROM meta WHERE meta_key = :metaKey;`, {
+    replacements: { metaKey: FTS5_DEFER_META_KEY_V2 },
+    transaction,
+  });
+  await sequelizeV2.query(`DELETE FROM meta WHERE meta_key = :metaKey;`, {
+    replacements: { metaKey: FTS5_DEFER_TRIGGERS_META_KEY_V2 },
+    transaction,
+  });
+};
+
+export const dropV2FtsTriggers = async (transaction) => {
+  const snapshot = await introspectV2FtsTriggers(transaction);
+  if (snapshot.length > 0) {
+    await writeTriggerSnapshotV2(snapshot, transaction);
+    await dropTriggersByName(
+      snapshot.map((t) => t.name),
+      transaction,
+    );
+  }
+  return snapshot;
+};
+
+export const recreateV2FtsTriggers = async (transaction) => {
+  const snapshot = await readTriggerSnapshotV2(transaction);
+  if (!snapshot || snapshot.length === 0) {
+    loggerV2.warn(
+      '[v2]: No FTS5 trigger snapshot found while recreating; triggers will not be restored from this call',
+    );
+    return [];
+  }
+  for (const { name } of snapshot) {
+    await sequelizeV2.query(`DROP TRIGGER IF EXISTS ${name};`, { transaction });
+  }
+  for (const { sql } of snapshot) {
+    await sequelizeV2.query(sql, { transaction });
+  }
+  return snapshot.map((t) => t.name);
+};
+
+export const rebuildV2FtsTables = async (transaction) => {
+  if (await ftsTableExists(PROJECTS_FTS_TABLE, transaction)) {
+    const cols = await fetchFtsColumnList(PROJECTS_FTS_TABLE, transaction);
+    if (cols.length > 0) {
+      const colList = cols.join(', ');
+      await sequelizeV2.query(`DELETE FROM ${PROJECTS_FTS_TABLE};`, {
+        transaction,
+      });
+      await sequelizeV2.query(
+        `INSERT INTO ${PROJECTS_FTS_TABLE} (${colList}) SELECT ${colList} FROM project;`,
+        { transaction },
+      );
+    }
+  }
+
+  if (await ftsTableExists(UNITS_FTS_TABLE, transaction)) {
+    const cols = await fetchFtsColumnList(UNITS_FTS_TABLE, transaction);
+    if (cols.length > 0) {
+      const colList = cols.join(', ');
+      await sequelizeV2.query(`DELETE FROM ${UNITS_FTS_TABLE};`, {
+        transaction,
+      });
+      await sequelizeV2.query(
+        `INSERT INTO ${UNITS_FTS_TABLE} (${colList}) SELECT ${colList} FROM unit;`,
+        { transaction },
+      );
+    }
+  }
+};
+
+export const ensureV2FtsTriggersDeferred = async () => {
+  if (!isSqlite()) return;
+  if (await isFtsDeferralFlagSetV2()) return;
+
+  const tx = await sequelizeV2.transaction();
+  try {
+    if (await isFtsDeferralFlagSetV2(tx)) {
+      await tx.commit();
+      return;
+    }
+    const snapshot = await dropV2FtsTriggers(tx);
+    // Only mark deferral active when we actually have a snapshot to
+    // restore from. See V1 for rationale: setting the flag without a
+    // snapshot would let the next restore tick clear the flag without
+    // recreating any triggers, permanently losing the FTS triggers.
+    const restorable =
+      snapshot.length > 0 ? snapshot : await readTriggerSnapshotV2(tx);
+    if (!restorable || restorable.length === 0) {
+      loggerV2.warn(
+        '[v2]: No FTS5 triggers were installed and no snapshot is persisted; refusing to mark deferral active so the restore path cannot lose triggers',
+      );
+      await tx.rollback();
+      return;
+    }
+    await setFtsDeferralFlagV2(tx);
+    await tx.commit();
+    loggerV2.info(
+      `[v2]: FTS5 project/unit triggers deferred during sync catch-up (snapshot: ${restorable.length} trigger(s))`,
+    );
+  } catch (error) {
+    try {
+      await tx.rollback();
+    } catch {
+      // already rolled back
+    }
+    loggerV2.error(
+      `[v2]: Failed to defer FTS5 triggers for catch-up: ${error.message}`,
+    );
+  }
+};
+
+export const restoreV2FtsTriggersAndRebuildIfDeferred = async () => {
+  if (!isSqlite()) return false;
+  if (!(await isFtsDeferralFlagSetV2())) return false;
+
+  const tx = await sequelizeV2.transaction();
+  try {
+    if (!(await isFtsDeferralFlagSetV2(tx))) {
+      await tx.commit();
+      return false;
+    }
+    await recreateV2FtsTriggers(tx);
+    await rebuildV2FtsTables(tx);
+    await clearDeferralStateRawV2(tx);
+    await tx.commit();
+    loggerV2.info(
+      '[v2]: FTS5 project/unit triggers restored and projects_v2_fts / units_v2_fts rebuilt',
+    );
+    return true;
+  } catch (error) {
+    try {
+      await tx.rollback();
+    } catch {
+      // already rolled back
+    }
+    loggerV2.error(
+      `[v2]: Failed to restore FTS5 triggers / rebuild FTS tables: ${error.message}`,
+    );
+    throw error;
+  }
+};

--- a/src/utils/fts5-deferral.js
+++ b/src/utils/fts5-deferral.js
@@ -1,0 +1,344 @@
+'use strict';
+
+// V1 FTS5 trigger deferral helpers.
+//
+// On Pi-class hardware, the largest single contributor to per-row write cost
+// during catch-up is the FTS5 maintenance triggers: every project/unit
+// upsert re-tokenises ~22 columns into projects_fts / units_fts. Across a
+// 1000-row generation that runs many times during a fresh sync, this is a
+// dominant cost.
+//
+// Approach (V1):
+//   - When the sync loop notices that any subscribed org has not yet caught
+//     up, snapshot the currently-installed project/unit FTS triggers into
+//     `meta`, drop the triggers, and set a deferral flag in `meta`.
+//   - When all subscribed orgs are caught up AND the flag is set, recreate
+//     the triggers from the snapshot, rebuild projects_fts / units_fts from
+//     the source tables in a single transaction, then clear both meta keys.
+//   - On boot (prepareDb), if the flag is set, perform the recreate +
+//     rebuild + clear sequence before any FTS reads. This is the
+//     crash-recovery path: a crash mid-catch-up leaves the flag set, the
+//     triggers still dropped, and the FTS tables stale. The boot recovery
+//     restores the invariant before any reads can observe stale data.
+//
+// Why introspect-and-snapshot instead of hardcoding the DDL?
+//   - The trigger column lists in this file would otherwise have to be kept
+//     manually in sync with whatever the latest migration installs. A
+//     mismatch silently changes runtime trigger behaviour the first time a
+//     deferral cycle fires. Reading the live `sqlite_master.sql` at defer
+//     time guarantees we recreate exactly what was installed, no matter
+//     how many migrations have layered on top.
+//
+// All operations are SQLite-only (FTS5 is SQLite-specific). Callers that
+// might run on MySQL must check the dialect before invoking these helpers.
+
+import { sequelize } from '../database';
+import { logger } from '../config/logger.js';
+
+export const FTS5_DEFER_META_KEY = 'fts5TriggersDeferredV1';
+export const FTS5_DEFER_TRIGGERS_META_KEY = 'fts5DeferredTriggerSnapshotV1';
+
+const PROJECTS_FTS_TABLE = 'projects_fts';
+const UNITS_FTS_TABLE = 'units_fts';
+
+const isSqlite = () => sequelize.getDialect() === 'sqlite';
+
+const ftsTableExists = async (tableName, transaction) => {
+  const [rows] = await sequelize.query(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name=:tableName",
+    { replacements: { tableName }, transaction },
+  );
+  return Array.isArray(rows) && rows.length > 0;
+};
+
+const fetchFtsColumnList = async (tableName, transaction) => {
+  // PRAGMA table_info works on FTS5 virtual tables and returns the user-
+  // visible columns in declaration order. We use the live introspection
+  // result rather than a hardcoded list so future column additions don't
+  // silently desync the rebuild SELECT from the FTS schema.
+  const rows = await sequelize.query(`PRAGMA table_info('${tableName}');`, {
+    transaction,
+    type: sequelize.QueryTypes.SELECT,
+  });
+  return rows.map((r) => r.name);
+};
+
+// Discover all triggers whose definition mentions either V1 FTS table.
+// Returns [{ name, sql }] in a stable order. Filters out internal
+// `sqlite_*` triggers defensively.
+const introspectV1FtsTriggers = async (transaction) => {
+  const rows = await sequelize.query(
+    `SELECT name, sql FROM sqlite_master
+     WHERE type = 'trigger'
+       AND name NOT LIKE 'sqlite_%'
+       AND sql IS NOT NULL
+       AND (sql LIKE '%projects_fts%' OR sql LIKE '%units_fts%')
+     ORDER BY name;`,
+    { transaction, type: sequelize.QueryTypes.SELECT },
+  );
+  return rows
+    .filter((r) => typeof r.name === 'string' && typeof r.sql === 'string')
+    .map((r) => ({ name: r.name, sql: r.sql }));
+};
+
+const dropTriggersByName = async (names, transaction) => {
+  for (const name of names) {
+    await sequelize.query(`DROP TRIGGER IF EXISTS ${name};`, { transaction });
+  }
+};
+
+const getMetaModel = async () => {
+  // eslint-disable-next-line no-restricted-syntax -- circular dep guard
+  const { Meta } = await import('../models/index.js');
+  return Meta;
+};
+
+const isFtsDeferralFlagSet = async (transaction) => {
+  const Meta = await getMetaModel();
+  const row = await Meta.findOne({
+    where: { metaKey: FTS5_DEFER_META_KEY },
+    raw: true,
+    transaction,
+  });
+  return !!row;
+};
+
+const readTriggerSnapshot = async (transaction) => {
+  const Meta = await getMetaModel();
+  const row = await Meta.findOne({
+    where: { metaKey: FTS5_DEFER_TRIGGERS_META_KEY },
+    raw: true,
+    transaction,
+  });
+  if (!row || typeof row.metaValue !== 'string') return null;
+  try {
+    const parsed = JSON.parse(row.metaValue);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter(
+      (t) => t && typeof t.name === 'string' && typeof t.sql === 'string',
+    );
+  } catch (error) {
+    logger.warn(
+      `[v1]: Failed to parse FTS5 trigger snapshot from meta: ${error.message}`,
+    );
+    return null;
+  }
+};
+
+const writeTriggerSnapshot = async (snapshot, transaction) => {
+  const json = JSON.stringify(snapshot);
+  await sequelize.query(`DELETE FROM meta WHERE metaKey = :metaKey;`, {
+    replacements: { metaKey: FTS5_DEFER_TRIGGERS_META_KEY },
+    transaction,
+  });
+  await sequelize.query(
+    `INSERT INTO meta (metaKey, metaValue) VALUES (:metaKey, :metaValue);`,
+    {
+      replacements: {
+        metaKey: FTS5_DEFER_TRIGGERS_META_KEY,
+        metaValue: json,
+      },
+      transaction,
+    },
+  );
+};
+
+const setFtsDeferralFlag = async (transaction) => {
+  await sequelize.query(
+    `INSERT OR IGNORE INTO meta (metaKey, metaValue)
+     VALUES (:metaKey, '1');`,
+    {
+      replacements: { metaKey: FTS5_DEFER_META_KEY },
+      transaction,
+    },
+  );
+};
+
+// Bypass Meta.destroy's 50ms back-pressure shim: this path runs inside the
+// restore transaction and that delay would needlessly extend the SQLite
+// write lock.
+const clearDeferralStateRaw = async (transaction) => {
+  await sequelize.query(`DELETE FROM meta WHERE metaKey = :metaKey;`, {
+    replacements: { metaKey: FTS5_DEFER_META_KEY },
+    transaction,
+  });
+  await sequelize.query(`DELETE FROM meta WHERE metaKey = :metaKey;`, {
+    replacements: { metaKey: FTS5_DEFER_TRIGGERS_META_KEY },
+    transaction,
+  });
+};
+
+/**
+ * Snapshot the currently-installed V1 FTS triggers into `meta` then drop
+ * them. Idempotent: if no triggers are currently installed, the existing
+ * snapshot (if any) is preserved so a subsequent recreate can still work.
+ *
+ * Exported so unit tests can drive the helper directly.
+ */
+export const dropV1FtsTriggers = async (transaction) => {
+  const snapshot = await introspectV1FtsTriggers(transaction);
+  if (snapshot.length > 0) {
+    await writeTriggerSnapshot(snapshot, transaction);
+    await dropTriggersByName(
+      snapshot.map((t) => t.name),
+      transaction,
+    );
+  }
+  return snapshot;
+};
+
+/**
+ * Recreate the V1 FTS triggers from the persisted snapshot. Idempotent:
+ * any trigger of the same name is dropped first. Returns the names of
+ * the triggers that were recreated (empty array if no snapshot exists).
+ */
+export const recreateV1FtsTriggers = async (transaction) => {
+  const snapshot = await readTriggerSnapshot(transaction);
+  if (!snapshot || snapshot.length === 0) {
+    logger.warn(
+      '[v1]: No FTS5 trigger snapshot found while recreating; triggers will not be restored from this call',
+    );
+    return [];
+  }
+  for (const { name } of snapshot) {
+    await sequelize.query(`DROP TRIGGER IF EXISTS ${name};`, { transaction });
+  }
+  for (const { sql } of snapshot) {
+    await sequelize.query(sql, { transaction });
+  }
+  return snapshot.map((t) => t.name);
+};
+
+/**
+ * Rebuild projects_fts / units_fts from projects / units. Uses runtime
+ * column introspection so the SELECT list stays in sync with whatever
+ * columns the current FTS tables have.
+ *
+ * For each FTS table, we DELETE everything then INSERT (col1, ...)
+ * SELECT col1, ... FROM <source>. We deliberately don't use the FTS5
+ * 'rebuild' command here because these FTS tables are NOT external-
+ * content tables (they have no `content=projects` clause), so 'rebuild'
+ * would only re-index data already inside the FTS table - it would not
+ * pull rows from the projects/units source tables that were upserted
+ * while triggers were dropped.
+ */
+export const rebuildV1FtsTables = async (transaction) => {
+  if (await ftsTableExists(PROJECTS_FTS_TABLE, transaction)) {
+    const cols = await fetchFtsColumnList(PROJECTS_FTS_TABLE, transaction);
+    if (cols.length > 0) {
+      const colList = cols.join(', ');
+      await sequelize.query(`DELETE FROM ${PROJECTS_FTS_TABLE};`, {
+        transaction,
+      });
+      await sequelize.query(
+        `INSERT INTO ${PROJECTS_FTS_TABLE} (${colList}) SELECT ${colList} FROM projects;`,
+        { transaction },
+      );
+    }
+  }
+
+  if (await ftsTableExists(UNITS_FTS_TABLE, transaction)) {
+    const cols = await fetchFtsColumnList(UNITS_FTS_TABLE, transaction);
+    if (cols.length > 0) {
+      const colList = cols.join(', ');
+      await sequelize.query(`DELETE FROM ${UNITS_FTS_TABLE};`, { transaction });
+      await sequelize.query(
+        `INSERT INTO ${UNITS_FTS_TABLE} (${colList}) SELECT ${colList} FROM units;`,
+        { transaction },
+      );
+    }
+  }
+};
+
+/**
+ * Idempotent: snapshot + drop FTS triggers and set the deferral flag.
+ * Called at the top of each sync tick when at least one subscribed org
+ * still needs catch-up.
+ */
+export const ensureV1FtsTriggersDeferred = async () => {
+  if (!isSqlite()) return;
+  if (await isFtsDeferralFlagSet()) return;
+
+  // Snapshot + drop triggers + set flag in one transaction so a crash
+  // here either leaves all three effects (recovered on next boot) or
+  // none.
+  const tx = await sequelize.transaction();
+  try {
+    // Re-check inside the transaction to close the race window where two
+    // callers both saw the flag unset before either committed.
+    if (await isFtsDeferralFlagSet(tx)) {
+      await tx.commit();
+      return;
+    }
+    const snapshot = await dropV1FtsTriggers(tx);
+    // Only mark deferral active when we actually have a snapshot to
+    // restore from. If introspection found no triggers AND no prior
+    // snapshot is persisted, setting the flag would convince the next
+    // restore tick that it has work to do; the restore would then clear
+    // the flag without recreating any triggers, permanently losing the
+    // FTS triggers from this install.
+    const restorable =
+      snapshot.length > 0 ? snapshot : await readTriggerSnapshot(tx);
+    if (!restorable || restorable.length === 0) {
+      logger.warn(
+        '[v1]: No FTS5 triggers were installed and no snapshot is persisted; refusing to mark deferral active so the restore path cannot lose triggers',
+      );
+      await tx.rollback();
+      return;
+    }
+    await setFtsDeferralFlag(tx);
+    await tx.commit();
+    logger.info(
+      `[v1]: FTS5 project/unit triggers deferred during sync catch-up (snapshot: ${restorable.length} trigger(s))`,
+    );
+  } catch (error) {
+    try {
+      await tx.rollback();
+    } catch {
+      // already rolled back
+    }
+    logger.error(
+      `[v1]: Failed to defer FTS5 triggers for catch-up: ${error.message}`,
+    );
+  }
+};
+
+/**
+ * If the deferral flag is set, recreate triggers from the snapshot +
+ * rebuild projects_fts / units_fts from projects / units, then clear
+ * both the flag and the snapshot. All in a single transaction so a crash
+ * mid-rebuild leaves the flag set and the next boot recovery re-runs the
+ * work.
+ */
+export const restoreV1FtsTriggersAndRebuildIfDeferred = async () => {
+  if (!isSqlite()) return false;
+  if (!(await isFtsDeferralFlagSet())) return false;
+
+  const tx = await sequelize.transaction();
+  try {
+    // Re-check inside the transaction in case a parallel caller already
+    // cleared the flag between the outer check and tx open.
+    if (!(await isFtsDeferralFlagSet(tx))) {
+      await tx.commit();
+      return false;
+    }
+    await recreateV1FtsTriggers(tx);
+    await rebuildV1FtsTables(tx);
+    await clearDeferralStateRaw(tx);
+    await tx.commit();
+    logger.info(
+      '[v1]: FTS5 project/unit triggers restored and projects_fts / units_fts rebuilt',
+    );
+    return true;
+  } catch (error) {
+    try {
+      await tx.rollback();
+    } catch {
+      // already rolled back
+    }
+    logger.error(
+      `[v1]: Failed to restore FTS5 triggers / rebuild FTS tables: ${error.message}`,
+    );
+    throw error;
+  }
+};

--- a/tests/integration/sync-write-perf.spec.js
+++ b/tests/integration/sync-write-perf.spec.js
@@ -1,0 +1,722 @@
+import { expect } from 'chai';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  prepareDb,
+  sequelize,
+  sequelizeMirror,
+  checkForMigrations,
+} from '../../src/database/index.js';
+import { Audit, Meta, Project, Unit } from '../../src/models/index.js';
+import { AuditMirror } from '../../src/models/audit/audit.model.mirror.js';
+import {
+  FTS5_DEFER_META_KEY,
+  dropV1FtsTriggers,
+  recreateV1FtsTriggers,
+  rebuildV1FtsTables,
+  ensureV1FtsTriggersDeferred,
+  restoreV1FtsTriggersAndRebuildIfDeferred,
+} from '../../src/utils/fts5-deferral.js';
+import TaskManager from '../../src/tasks/index.js';
+import { getConfig, getConfigV2 } from '../../src/utils/config-loader.js';
+
+const ALL_FTS_TRIGGER_NAMES = [
+  'project_insert_fts',
+  'project_update_fts',
+  'project_delete_fts',
+  'unit_insert_fts',
+  'unit_update_fts',
+  'unit_delete_fts',
+];
+
+async function listFtsTriggers() {
+  const rows = await sequelize.query(
+    "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN (:names)",
+    {
+      replacements: { names: ALL_FTS_TRIGGER_NAMES },
+      type: sequelize.QueryTypes.SELECT,
+    },
+  );
+  return rows.map((r) => r.name).sort();
+}
+
+async function listAuditIndexes() {
+  const rows = await sequelize.query(
+    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='audit'",
+    { type: sequelize.QueryTypes.SELECT },
+  );
+  return rows.map((r) => r.name);
+}
+
+async function projectsFtsCount() {
+  const [[row]] = await sequelize.query(
+    'SELECT COUNT(*) AS c FROM projects_fts;',
+  );
+  return Number(row.c);
+}
+
+async function unitsFtsCount() {
+  const [[row]] = await sequelize.query('SELECT COUNT(*) AS c FROM units_fts;');
+  return Number(row.c);
+}
+
+describe('Sync Write Perf (V1) — recommended PR', function () {
+  this.timeout(60000);
+
+  before(async function () {
+    await prepareDb();
+    // Stop background sync tasks so they don't drop / restore FTS triggers
+    // out from under us mid-test.
+    TaskManager.stopAll();
+  });
+
+  after(async function () {
+    // Restart the task manager so tests that follow this file in the same
+    // mocha run (e.g. unit.spec.js) still get a live V1 sync interval.
+    // Without this restart the V1 sync task stays stopped for the rest of
+    // the run and subsequent end-to-end staging tests time out waiting
+    // for the sync to apply staged units. Restart BOTH V1 and V2 sides
+    // (regardless of mocha file ordering with the V2 perf spec) so this
+    // file is never the reason a side stays down.
+    const configV1 = getConfig();
+    const configV2 = getConfigV2();
+    await TaskManager.start(
+      configV1?.ENABLE !== false,
+      configV2?.ENABLE !== false,
+    );
+  });
+
+  beforeEach(async function () {
+    // Make sure triggers are present at the start of each test (a previous
+    // test that asserted "triggers dropped" or threw mid-cleanup may have
+    // left them missing; FTS DELETEs further down depend on the delete
+    // trigger to keep projects_fts/units_fts in sync).
+    const triggers = await listFtsTriggers();
+    if (triggers.length !== ALL_FTS_TRIGGER_NAMES.length) {
+      const tx = await sequelize.transaction();
+      try {
+        await recreateV1FtsTriggers(tx);
+        await tx.commit();
+      } catch (e) {
+        await tx.rollback();
+        throw e;
+      }
+    }
+
+    await Audit.destroy({ where: {} });
+    await Meta.destroy({ where: { metaKey: FTS5_DEFER_META_KEY } });
+    // Clear projects/units AND the FTS tables. The destroy on projects/
+    // units will fire AFTER DELETE triggers but only for rows visible to
+    // them at this moment; the explicit FTS truncates handle any rows
+    // left over from a test that ran with triggers dropped.
+    await Project.destroy({ where: {}, truncate: true });
+    await Unit.destroy({ where: {}, truncate: true });
+    await sequelize.query('DELETE FROM projects_fts;');
+    await sequelize.query('DELETE FROM units_fts;');
+  });
+
+  describe('audit composite indexes', function () {
+    it('creates a composite index on (registryId, generation)', async function () {
+      const indexes = await listAuditIndexes();
+      expect(indexes).to.include('audit_registry_id_generation');
+    });
+
+    it('creates a composite index on (orgUid, generation)', async function () {
+      const indexes = await listAuditIndexes();
+      expect(indexes).to.include('audit_org_uid_generation');
+    });
+
+    it('uses the orgUid composite index for the processJob mostRecentOrgAuditRecord lookup', async function () {
+      // EXPLAIN QUERY PLAN must show SQLite using audit_org_uid_generation
+      // for the per-tick `Audit.findOne where orgUid order by generation
+      // DESC limit 1` lookup in src/tasks/sync-registries.js. Without
+      // the composite index this degenerates to SCAN + sort once the
+      // audit table is large.
+      const plan = await sequelize.query(
+        `EXPLAIN QUERY PLAN
+         SELECT * FROM audit
+         WHERE orgUid = :orgUid
+         ORDER BY generation DESC
+         LIMIT 1`,
+        {
+          replacements: { orgUid: 'fake-org-uid' },
+          type: sequelize.QueryTypes.SELECT,
+        },
+      );
+      const description = plan.map((row) => row.detail).join(' ');
+      expect(description).to.match(/audit_org_uid_generation/);
+    });
+
+    it('uses the registryId composite index for the per-tick last-generation lookup', async function () {
+      // EXPLAIN QUERY PLAN should show SQLite using the composite index for
+      // the hot-path query in syncOrganizationAudit. Without the index this
+      // degenerates to a SCAN once the audit table is large.
+      const plan = await sequelize.query(
+        `EXPLAIN QUERY PLAN SELECT * FROM audit
+         WHERE registryId = :registryId
+         ORDER BY generation DESC
+         LIMIT 1`,
+        {
+          replacements: { registryId: 'fake-registry-id' },
+          type: sequelize.QueryTypes.SELECT,
+        },
+      );
+      const description = plan.map((row) => row.detail).join(' ');
+      expect(description).to.match(/audit_registry_id_generation/);
+    });
+  });
+
+  describe('Audit.bulkCreate', function () {
+    it('exposes a static bulkCreate that persists all rows', async function () {
+      const orgUid = uuidv4();
+      const registryId = uuidv4();
+      const rootHash = `0x${'a'.repeat(64)}`;
+      const rows = Array.from({ length: 10 }, (_, idx) => ({
+        orgUid,
+        registryId,
+        rootHash,
+        type: 'INSERT',
+        table: 'project',
+        change: JSON.stringify({ idx }),
+        onchainConfirmationTimeStamp: '1700000000',
+        generation: 5,
+        comment: 'bulk-test-comment',
+        author: 'bulk-test-author',
+      }));
+
+      await Audit.bulkCreate(rows);
+
+      const persisted = await Audit.findAll({
+        where: { registryId, generation: 5 },
+        raw: true,
+      });
+      expect(persisted).to.have.length(10);
+      // Every row should have inherited the per-generation comment / author
+      // (proves the hoist-out-of-loop refactor preserved the old per-row
+      // behaviour where every row got the same shared values).
+      for (const row of persisted) {
+        expect(row.comment).to.equal('bulk-test-comment');
+        expect(row.author).to.equal('bulk-test-author');
+        expect(row.orgUid).to.equal(orgUid);
+        expect(row.registryId).to.equal(registryId);
+      }
+    });
+
+    describe('mirror code path', function () {
+      // These tests verify the mirror branch of Audit.bulkCreate's static
+      // against the real V1 SQLite-fallback mirror DB (mirrorTest). The
+      // V1 mirror is enabled by default in test mode, so we just have to
+      // ensure the mirror migrations have run and that earlier tests'
+      // fire-and-forget mirror writes are drained before each case.
+
+      before(async function () {
+        await checkForMigrations(sequelizeMirror);
+      });
+
+      beforeEach(async function () {
+        // Drain any fire-and-forget mirror writes left over from prior
+        // tests in the outer describe (Audit.bulkCreate fires a mirror
+        // write asynchronously via safeMirrorDbHandler), then clear the
+        // mirror audit table so this case's assertions are independent.
+        let lastCount = -1;
+        for (let i = 0; i < 30; i += 1) {
+          const c = await AuditMirror.count();
+          if (c === lastCount) break;
+          lastCount = c;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        await AuditMirror.destroy({ where: {} });
+      });
+
+      const waitForMirrorRows = async (where, expected, timeoutMs = 5000) => {
+        const deadline = Date.now() + timeoutMs;
+        let rows = [];
+        while (Date.now() < deadline) {
+          rows = await AuditMirror.findAll({ where, raw: true });
+          if (rows.length >= expected) return rows;
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        return rows;
+      };
+
+      it('forwards rows to AuditMirror when the mirror is enabled', async function () {
+        const orgUid = uuidv4();
+        const registryId = uuidv4();
+        const rootHash = `0x${'b'.repeat(64)}`;
+        const rows = Array.from({ length: 5 }, (_, idx) => ({
+          orgUid,
+          registryId,
+          rootHash,
+          type: 'INSERT',
+          table: 'project',
+          change: JSON.stringify({ idx }),
+          onchainConfirmationTimeStamp: '1700000000',
+          generation: 7,
+          comment: 'mirror-test',
+          author: 'mirror-test',
+        }));
+
+        await Audit.bulkCreate(rows);
+
+        const mirrored = await waitForMirrorRows(
+          { registryId, generation: 7 },
+          rows.length,
+        );
+        expect(mirrored).to.have.length(rows.length);
+        for (const row of mirrored) {
+          expect(row.orgUid).to.equal(orgUid);
+          expect(row.registryId).to.equal(registryId);
+          expect(row.comment).to.equal('mirror-test');
+          expect(row.author).to.equal('mirror-test');
+        }
+      });
+
+      it('threads mirrorTransaction through so the mirror write commits with that tx, not the source tx', async function () {
+        // Open separate source and mirror transactions, hand both to
+        // Audit.bulkCreate, commit the source, then commit the mirror tx
+        // a moment later. If the static failed to swap mirrorTransaction
+        // in for `transaction` on the mirror options, the mirror write
+        // would either land outside the mirror tx (visible immediately
+        // after the source commit) or attempt to reuse the source tx
+        // handle on the mirror connection. The expected behaviour is
+        // that the mirror rows are NOT visible after the source commit
+        // and ARE visible after the mirror tx commit.
+        const orgUid = uuidv4();
+        const registryId = uuidv4();
+        const rootHash = `0x${'c'.repeat(64)}`;
+        const rows = [
+          {
+            orgUid,
+            registryId,
+            rootHash,
+            type: 'INSERT',
+            table: 'project',
+            change: '{}',
+            onchainConfirmationTimeStamp: '1700000000',
+            generation: 9,
+            comment: 'mirror-tx-test',
+            author: 'mirror-tx-test',
+          },
+        ];
+
+        const sourceTx = await sequelize.transaction();
+        const mirrorTx = await sequelizeMirror.transaction();
+        let sourceCommitted = false;
+        let mirrorCommitted = false;
+        try {
+          await Audit.bulkCreate(rows, {
+            transaction: sourceTx,
+            mirrorTransaction: mirrorTx,
+          });
+          await sourceTx.commit();
+          sourceCommitted = true;
+
+          // Source side has the row; mirror tx is still open so the row
+          // must not yet be visible to a separate mirror reader. Give
+          // the fire-and-forget mirror handler a moment to land its
+          // write on `mirrorTx` before we probe with a separate read.
+          const sourceRows = await Audit.findAll({
+            where: { registryId, generation: 9 },
+            raw: true,
+          });
+          expect(sourceRows).to.have.length(1);
+
+          // Poll briefly to give the fire-and-forget mirror branch a
+          // chance to run before we assert isolation. We expect 0 rows
+          // visible here regardless: if mirrorTransaction was correctly
+          // forwarded, the write is gated by mirrorTx and the read sees
+          // 0; if the implementation regressed and used the source tx
+          // (or no tx) on the mirror connection, the write would either
+          // error out (and never land) or commit with the source - the
+          // 0 still holds for the "wrong tx handle" case but a real
+          // regression like 'forgot to swap transaction' would land
+          // outside any tx and show up here as 1.
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          const mirrorRowsBeforeMirrorCommit = await AuditMirror.findAll({
+            where: { registryId, generation: 9 },
+            raw: true,
+          });
+          expect(
+            mirrorRowsBeforeMirrorCommit,
+            'mirror rows must not be visible until mirrorTx commits',
+          ).to.have.length(0);
+
+          await mirrorTx.commit();
+          mirrorCommitted = true;
+        } finally {
+          if (!sourceCommitted) await sourceTx.rollback();
+          if (!mirrorCommitted) await mirrorTx.rollback();
+        }
+
+        const mirrored = await waitForMirrorRows(
+          { registryId, generation: 9 },
+          1,
+        );
+        expect(mirrored).to.have.length(1);
+        expect(mirrored[0].orgUid).to.equal(orgUid);
+        expect(mirrored[0].comment).to.equal('mirror-tx-test');
+      });
+    });
+  });
+
+  describe('FTS5 deferral helpers', function () {
+    it('dropV1FtsTriggers removes all six project/unit FTS triggers idempotently', async function () {
+      const before = await listFtsTriggers();
+      expect(before).to.deep.equal([...ALL_FTS_TRIGGER_NAMES].sort());
+
+      const tx = await sequelize.transaction();
+      try {
+        await dropV1FtsTriggers(tx);
+        await tx.commit();
+      } catch (e) {
+        await tx.rollback();
+        throw e;
+      }
+
+      const afterFirst = await listFtsTriggers();
+      expect(afterFirst).to.have.length(0);
+
+      // Idempotent: a second drop on already-dropped triggers should not
+      // throw.
+      const tx2 = await sequelize.transaction();
+      try {
+        await dropV1FtsTriggers(tx2);
+        await tx2.commit();
+      } catch (e) {
+        await tx2.rollback();
+        throw e;
+      }
+
+      const afterSecond = await listFtsTriggers();
+      expect(afterSecond).to.have.length(0);
+    });
+
+    it('recreateV1FtsTriggers restores all six triggers and they fire on insert', async function () {
+      const tx = await sequelize.transaction();
+      try {
+        await dropV1FtsTriggers(tx);
+        await tx.commit();
+      } catch (e) {
+        await tx.rollback();
+        throw e;
+      }
+      expect(await listFtsTriggers()).to.have.length(0);
+
+      const tx2 = await sequelize.transaction();
+      try {
+        await recreateV1FtsTriggers(tx2);
+        await tx2.commit();
+      } catch (e) {
+        await tx2.rollback();
+        throw e;
+      }
+
+      const restored = await listFtsTriggers();
+      expect(restored).to.deep.equal([...ALL_FTS_TRIGGER_NAMES].sort());
+
+      // Insert a project; the insert trigger should populate projects_fts.
+      await sequelize.query('DELETE FROM projects_fts;');
+      const ftsCountBefore = await projectsFtsCount();
+      expect(ftsCountBefore).to.equal(0);
+
+      const projectId = uuidv4();
+      await Project.create({
+        warehouseProjectId: projectId,
+        orgUid: 'fts-trigger-test',
+        currentRegistry: 'fts-trigger-test',
+        projectId: 'fts-test',
+        originProjectId: 'fts-test',
+        registryOfOrigin: 'fts-test',
+        projectName: 'recreated-trigger-fires',
+        projectLink: 'https://example.com',
+        projectDeveloper: 'dev',
+        sector: 'sector',
+        coveredByNDC: 'no',
+        projectType: 'type',
+        projectStatus: 'Listed',
+        projectStatusDate: '2025-01-01',
+        unitMetric: 'tCO2e',
+        validationDate: '2025-01-01',
+        timeStaged: 1700000000,
+      });
+
+      const ftsCountAfter = await projectsFtsCount();
+      expect(ftsCountAfter).to.equal(1);
+
+      // Cleanup
+      await Project.destroy({ where: { warehouseProjectId: projectId } });
+    });
+
+    it('rebuildV1FtsTables repopulates projects_fts/units_fts from projects/units', async function () {
+      // Drop triggers, insert directly into projects/units (so FTS is NOT
+      // populated by triggers), then run rebuild and assert FTS reflects
+      // the source rows. This is the "during catch-up" simulation.
+      const tx = await sequelize.transaction();
+      try {
+        await dropV1FtsTriggers(tx);
+        await tx.commit();
+      } catch (e) {
+        await tx.rollback();
+        throw e;
+      }
+
+      const projectId = uuidv4();
+      await Project.create({
+        warehouseProjectId: projectId,
+        orgUid: 'fts-rebuild-test',
+        currentRegistry: 'fts-rebuild-test',
+        // Single token (no dashes / underscores) so FTS5's default
+        // tokeniser keeps the whole word as one match candidate.
+        projectId: 'rebuildsearchtoken',
+        originProjectId: 'fts-rebuild',
+        registryOfOrigin: 'fts-rebuild',
+        projectName: 'rebuildprojectname',
+        projectLink: 'https://example.com',
+        projectDeveloper: 'dev',
+        sector: 'sector',
+        coveredByNDC: 'no',
+        projectType: 'type',
+        projectStatus: 'Listed',
+        projectStatusDate: '2025-01-01',
+        unitMetric: 'tCO2e',
+        validationDate: '2025-01-01',
+        timeStaged: 1700000000,
+      });
+
+      // FTS should NOT have the row because triggers were dropped during the
+      // direct insert.
+      const beforeProjects = await projectsFtsCount();
+      expect(beforeProjects).to.equal(0);
+
+      const tx2 = await sequelize.transaction();
+      try {
+        await rebuildV1FtsTables(tx2);
+        await tx2.commit();
+      } catch (e) {
+        await tx2.rollback();
+        throw e;
+      }
+
+      const afterProjects = await projectsFtsCount();
+      expect(afterProjects).to.equal(1);
+
+      // Verify the row is searchable via FTS.
+      const [matches] = await sequelize.query(
+        "SELECT warehouseProjectId FROM projects_fts WHERE projects_fts MATCH 'rebuildsearchtoken';",
+      );
+      expect(matches.length).to.equal(1);
+      expect(matches[0].warehouseProjectId).to.equal(projectId);
+
+      // Cleanup
+      const tx3 = await sequelize.transaction();
+      try {
+        await recreateV1FtsTriggers(tx3);
+        await tx3.commit();
+      } catch (e) {
+        await tx3.rollback();
+        throw e;
+      }
+      await Project.destroy({ where: { warehouseProjectId: projectId } });
+    });
+  });
+
+  describe('FTS5 deferral state machine', function () {
+    it('ensureV1FtsTriggersDeferred drops triggers and sets the meta flag', async function () {
+      await ensureV1FtsTriggersDeferred();
+
+      const triggers = await listFtsTriggers();
+      expect(triggers).to.have.length(0);
+
+      const flagRow = await Meta.findOne({
+        where: { metaKey: FTS5_DEFER_META_KEY },
+        raw: true,
+      });
+      expect(flagRow).to.exist;
+    });
+
+    it('ensureV1FtsTriggersDeferred is idempotent (safe to call twice)', async function () {
+      await ensureV1FtsTriggersDeferred();
+      await ensureV1FtsTriggersDeferred();
+
+      const triggers = await listFtsTriggers();
+      expect(triggers).to.have.length(0);
+
+      // Only one meta row, not two.
+      const count = await Meta.count({
+        where: { metaKey: FTS5_DEFER_META_KEY },
+      });
+      expect(count).to.equal(1);
+    });
+
+    it('restoreV1FtsTriggersAndRebuildIfDeferred is a no-op when flag is unset', async function () {
+      const result = await restoreV1FtsTriggersAndRebuildIfDeferred();
+      expect(result).to.equal(false);
+
+      // Triggers untouched.
+      const triggers = await listFtsTriggers();
+      expect(triggers).to.deep.equal([...ALL_FTS_TRIGGER_NAMES].sort());
+    });
+
+    it('restoreV1FtsTriggersAndRebuildIfDeferred recreates triggers + rebuilds + clears flag when set', async function () {
+      // Set up a "during catch-up" state: triggers dropped, project written
+      // directly into the source table without the trigger updating FTS.
+      await ensureV1FtsTriggersDeferred();
+      expect(await listFtsTriggers()).to.have.length(0);
+
+      const projectId = uuidv4();
+      await Project.create({
+        warehouseProjectId: projectId,
+        orgUid: 'fts-restore-test',
+        currentRegistry: 'fts-restore-test',
+        projectId: 'restoresearchtoken',
+        originProjectId: 'fts-restore',
+        registryOfOrigin: 'fts-restore',
+        projectName: 'restoreprojectname',
+        projectLink: 'https://example.com',
+        projectDeveloper: 'dev',
+        sector: 'sector',
+        coveredByNDC: 'no',
+        projectType: 'type',
+        projectStatus: 'Listed',
+        projectStatusDate: '2025-01-01',
+        unitMetric: 'tCO2e',
+        validationDate: '2025-01-01',
+        timeStaged: 1700000000,
+      });
+
+      expect(await projectsFtsCount()).to.equal(0);
+
+      const result = await restoreV1FtsTriggersAndRebuildIfDeferred();
+      expect(result).to.equal(true);
+
+      const triggers = await listFtsTriggers();
+      expect(triggers).to.deep.equal([...ALL_FTS_TRIGGER_NAMES].sort());
+
+      const flagRow = await Meta.findOne({
+        where: { metaKey: FTS5_DEFER_META_KEY },
+        raw: true,
+      });
+      expect(flagRow).to.equal(null);
+
+      const ftsCount = await projectsFtsCount();
+      expect(ftsCount).to.equal(1);
+
+      const [matches] = await sequelize.query(
+        "SELECT warehouseProjectId FROM projects_fts WHERE projects_fts MATCH 'restoresearchtoken';",
+      );
+      expect(matches.length).to.equal(1);
+
+      // Cleanup
+      await Project.destroy({ where: { warehouseProjectId: projectId } });
+    });
+
+    it('rebuild reflects rows in BOTH projects_fts and units_fts', async function () {
+      await ensureV1FtsTriggersDeferred();
+
+      const projectId = uuidv4();
+      const unitId = uuidv4();
+
+      await Project.create({
+        warehouseProjectId: projectId,
+        orgUid: 'fts-both-test',
+        currentRegistry: 'fts-both-test',
+        projectId: 'p',
+        originProjectId: 'p',
+        registryOfOrigin: 'p',
+        projectName: 'p',
+        projectLink: 'https://example.com',
+        projectDeveloper: 'dev',
+        sector: 'sector',
+        coveredByNDC: 'no',
+        projectType: 'type',
+        projectStatus: 'Listed',
+        projectStatusDate: '2025-01-01',
+        unitMetric: 'tCO2e',
+        validationDate: '2025-01-01',
+        timeStaged: 1700000000,
+      });
+
+      await Unit.create({
+        warehouseUnitId: unitId,
+        orgUid: 'fts-both-test',
+        issuanceId: uuidv4(),
+        projectLocationId: 'loc',
+        unitOwner: 'owner',
+        countryJurisdictionOfOwner: 'US',
+        inCountryJurisdictionOfOwner: 'US',
+        serialNumberBlock: 'AAA1-AAA1',
+        vintageYear: 2025,
+        unitType: 'Reduction - Nature',
+        marketplace: 'mp',
+        marketplaceLink: 'https://example.com',
+        marketplaceIdentifier: 'id',
+        unitTags: 'tag',
+        unitStatus: 'Held',
+        unitStatusReason: 'na',
+        unitRegistryLink: 'https://example.com',
+        correspondingAdjustmentDeclaration: 'Unknown',
+        correspondingAdjustmentStatus: 'Not Started',
+        unitBlockStart: 'AAA1',
+        unitBlockEnd: 'AAA1',
+        unitCount: 1,
+        timeStaged: 1700000000,
+      });
+
+      expect(await projectsFtsCount()).to.equal(0);
+      expect(await unitsFtsCount()).to.equal(0);
+
+      await restoreV1FtsTriggersAndRebuildIfDeferred();
+
+      expect(await projectsFtsCount()).to.equal(1);
+      expect(await unitsFtsCount()).to.equal(1);
+
+      // Cleanup
+      await Project.destroy({ where: { warehouseProjectId: projectId } });
+      await Unit.destroy({ where: { warehouseUnitId: unitId } });
+    });
+
+    it('boot recovery: prepareDb-style restore runs when meta flag is pre-set', async function () {
+      // Simulate a crash mid-catch-up: meta flag set, triggers still
+      // dropped, projects table has rows, FTS is empty.
+      await ensureV1FtsTriggersDeferred();
+
+      const projectId = uuidv4();
+      await Project.create({
+        warehouseProjectId: projectId,
+        orgUid: 'fts-boot-recovery-test',
+        currentRegistry: 'fts-boot-recovery-test',
+        projectId: 'crashrecoverytoken',
+        originProjectId: 'p',
+        registryOfOrigin: 'p',
+        projectName: 'crashrecoveryname',
+        projectLink: 'https://example.com',
+        projectDeveloper: 'dev',
+        sector: 'sector',
+        coveredByNDC: 'no',
+        projectType: 'type',
+        projectStatus: 'Listed',
+        projectStatusDate: '2025-01-01',
+        unitMetric: 'tCO2e',
+        validationDate: '2025-01-01',
+        timeStaged: 1700000000,
+      });
+
+      // Boot recovery: this is what prepareDb() invokes after migrations.
+      const recovered = await restoreV1FtsTriggersAndRebuildIfDeferred();
+      expect(recovered).to.equal(true);
+
+      // Triggers back, flag cleared, FTS has the row.
+      expect(await listFtsTriggers()).to.deep.equal(
+        [...ALL_FTS_TRIGGER_NAMES].sort(),
+      );
+      const flagRow = await Meta.findOne({
+        where: { metaKey: FTS5_DEFER_META_KEY },
+        raw: true,
+      });
+      expect(flagRow).to.equal(null);
+      expect(await projectsFtsCount()).to.equal(1);
+
+      // Cleanup
+      await Project.destroy({ where: { warehouseProjectId: projectId } });
+    });
+  });
+});

--- a/tests/v2/integration/sync-write-perf-v2.spec.js
+++ b/tests/v2/integration/sync-write-perf-v2.spec.js
@@ -1,0 +1,455 @@
+import { expect } from 'chai';
+import { v4 as uuidv4 } from 'uuid';
+import { sequelizeV2, prepareV2Db } from '../../../src/database/v2/index.js';
+import {
+  AuditV2,
+  MetaV2,
+  ProjectV2,
+  UnitV2,
+  IssuanceV2,
+  OrganizationsV2,
+} from '../../../src/models/v2/index.js';
+import {
+  FTS5_DEFER_META_KEY_V2,
+  dropV2FtsTriggers,
+  recreateV2FtsTriggers,
+  rebuildV2FtsTables,
+  ensureV2FtsTriggersDeferred,
+  restoreV2FtsTriggersAndRebuildIfDeferred,
+} from '../../../src/utils/fts5-deferral-v2.js';
+import TaskManager from '../../../src/tasks/index.js';
+import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
+
+const ALL_V2_FTS_TRIGGER_NAMES = [
+  'project_v2_insert_fts',
+  'project_v2_update_fts',
+  'project_v2_delete_fts',
+  'unit_v2_insert_fts',
+  'unit_v2_update_fts',
+  'unit_v2_delete_fts',
+];
+
+async function listV2FtsTriggers() {
+  const rows = await sequelizeV2.query(
+    "SELECT name FROM sqlite_master WHERE type='trigger' AND name IN (:names)",
+    {
+      replacements: { names: ALL_V2_FTS_TRIGGER_NAMES },
+      type: sequelizeV2.QueryTypes.SELECT,
+    },
+  );
+  return rows.map((r) => r.name).sort();
+}
+
+async function listAuditV2Indexes() {
+  const rows = await sequelizeV2.query(
+    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='audit'",
+    { type: sequelizeV2.QueryTypes.SELECT },
+  );
+  return rows.map((r) => r.name);
+}
+
+async function projectsV2FtsCount() {
+  const [[row]] = await sequelizeV2.query(
+    'SELECT COUNT(*) AS c FROM projects_v2_fts;',
+  );
+  return Number(row.c);
+}
+
+async function unitsV2FtsCount() {
+  const [[row]] = await sequelizeV2.query(
+    'SELECT COUNT(*) AS c FROM units_v2_fts;',
+  );
+  return Number(row.c);
+}
+
+describe('Sync Write Perf (V2) — recommended PR', function () {
+  this.timeout(60000);
+
+  before(async function () {
+    await prepareV2Db();
+    TaskManager.stopAll();
+  });
+
+  after(async function () {
+    // Restart BOTH V1 and V2 sides so this file is never the reason a
+    // side stays down for follow-on specs in the same mocha run,
+    // regardless of file ordering relative to the V1 perf spec.
+    const configV1 = getConfig();
+    const configV2 = getConfigV2();
+    await TaskManager.start(
+      configV1?.ENABLE !== false,
+      configV2?.ENABLE !== false,
+    );
+  });
+
+  beforeEach(async function () {
+    // Re-create triggers if a previous test left them dropped (so the
+    // delete trigger fires for cleanup destroys that follow).
+    const triggers = await listV2FtsTriggers();
+    if (triggers.length !== ALL_V2_FTS_TRIGGER_NAMES.length) {
+      const tx = await sequelizeV2.transaction();
+      try {
+        await recreateV2FtsTriggers(tx);
+        await tx.commit();
+      } catch (e) {
+        await tx.rollback();
+        throw e;
+      }
+    }
+
+    await AuditV2.destroy({ where: {} });
+    await UnitV2.destroy({ where: {}, truncate: true });
+    await IssuanceV2.destroy({ where: {}, truncate: true });
+    await ProjectV2.destroy({ where: {}, truncate: true });
+    await MetaV2.destroy({ where: { meta_key: FTS5_DEFER_META_KEY_V2 } });
+    // Explicit FTS truncation in case a prior test wrote to project/unit
+    // while triggers were dropped (the cleanup destroys above only fire
+    // delete triggers for rows currently visible to them).
+    await sequelizeV2.query('DELETE FROM projects_v2_fts;');
+    await sequelizeV2.query('DELETE FROM units_v2_fts;');
+  });
+
+  describe('audit composite indexes', function () {
+    it('creates a composite index on (registry_id, generation)', async function () {
+      const indexes = await listAuditV2Indexes();
+      expect(indexes).to.include('audit_v2_registry_id_generation');
+    });
+
+    it('creates a composite index on (org_uid, generation)', async function () {
+      const indexes = await listAuditV2Indexes();
+      expect(indexes).to.include('audit_v2_org_uid_generation');
+    });
+
+    it('uses the registry_id composite index for the per-tick last-generation lookup', async function () {
+      const plan = await sequelizeV2.query(
+        `EXPLAIN QUERY PLAN SELECT * FROM audit
+         WHERE registry_id = :registryId
+         ORDER BY generation DESC
+         LIMIT 1`,
+        {
+          replacements: { registryId: 'fake-registry-id' },
+          type: sequelizeV2.QueryTypes.SELECT,
+        },
+      );
+      const description = plan.map((row) => row.detail).join(' ');
+      expect(description).to.match(/audit_v2_registry_id_generation/);
+    });
+
+    it('uses the org_uid composite index for the processJob mostRecentOrgAuditRecord lookup', async function () {
+      // V2 audit lookup symmetric with V1 - see the V1 perf spec for
+      // rationale.
+      const plan = await sequelizeV2.query(
+        `EXPLAIN QUERY PLAN SELECT * FROM audit
+         WHERE org_uid = :orgUid
+         ORDER BY generation DESC
+         LIMIT 1`,
+        {
+          replacements: { orgUid: 'fake-org-uid' },
+          type: sequelizeV2.QueryTypes.SELECT,
+        },
+      );
+      const description = plan.map((row) => row.detail).join(' ');
+      expect(description).to.match(/audit_v2_org_uid_generation/);
+    });
+  });
+
+  describe('AuditV2.bulkCreate (already exposed) preserves audit row shape', function () {
+    it('persists all rows with shared per-generation comment / author', async function () {
+      const orgUid = uuidv4();
+      const registryId = uuidv4();
+      const rootHash = `0x${'a'.repeat(64)}`;
+      const rows = Array.from({ length: 10 }, (_, idx) => ({
+        org_uid: orgUid,
+        registry_id: registryId,
+        root_hash: rootHash,
+        type: 'INSERT',
+        table: 'project',
+        change: JSON.stringify({ idx }),
+        onchain_confirmation_time_stamp: '1700000000',
+        generation: 5,
+        comment: 'bulk-test-comment',
+        author: 'bulk-test-author',
+      }));
+
+      await AuditV2.bulkCreate(rows);
+
+      const persisted = await AuditV2.findAll({
+        where: { registry_id: registryId, generation: 5 },
+        raw: true,
+      });
+      expect(persisted).to.have.length(10);
+      for (const row of persisted) {
+        expect(row.comment).to.equal('bulk-test-comment');
+        expect(row.author).to.equal('bulk-test-author');
+        expect(row.org_uid).to.equal(orgUid);
+        expect(row.registry_id).to.equal(registryId);
+      }
+    });
+  });
+
+  describe('FTS5 deferral helpers', function () {
+    it('dropV2FtsTriggers removes all six project/unit FTS triggers idempotently', async function () {
+      expect(await listV2FtsTriggers()).to.deep.equal(
+        [...ALL_V2_FTS_TRIGGER_NAMES].sort(),
+      );
+
+      const tx = await sequelizeV2.transaction();
+      try {
+        await dropV2FtsTriggers(tx);
+        await tx.commit();
+      } catch (e) {
+        await tx.rollback();
+        throw e;
+      }
+      expect(await listV2FtsTriggers()).to.have.length(0);
+
+      // Idempotent re-drop.
+      const tx2 = await sequelizeV2.transaction();
+      try {
+        await dropV2FtsTriggers(tx2);
+        await tx2.commit();
+      } catch (e) {
+        await tx2.rollback();
+        throw e;
+      }
+      expect(await listV2FtsTriggers()).to.have.length(0);
+    });
+
+    it('rebuildV2FtsTables repopulates projects_v2_fts/units_v2_fts from project/unit', async function () {
+      // Drop triggers, insert directly into project/unit (so FTS is NOT
+      // populated by triggers), then run rebuild.
+      const tx = await sequelizeV2.transaction();
+      try {
+        await dropV2FtsTriggers(tx);
+        await tx.commit();
+      } catch (e) {
+        await tx.rollback();
+        throw e;
+      }
+
+      const projectId = uuidv4();
+      const orgUid = uuidv4();
+      await ProjectV2.create({
+        cadTrustProjectId: projectId,
+        orgUid,
+        projectRegistryName: 'reg',
+        projectId: 'rebuildv2searchtoken',
+        projectName: 'rebuildv2name',
+      });
+
+      expect(await projectsV2FtsCount()).to.equal(0);
+
+      const tx2 = await sequelizeV2.transaction();
+      try {
+        await rebuildV2FtsTables(tx2);
+        await tx2.commit();
+      } catch (e) {
+        await tx2.rollback();
+        throw e;
+      }
+
+      expect(await projectsV2FtsCount()).to.equal(1);
+
+      const [matches] = await sequelizeV2.query(
+        "SELECT cad_trust_project_id FROM projects_v2_fts WHERE projects_v2_fts MATCH 'rebuildv2searchtoken';",
+      );
+      expect(matches.length).to.equal(1);
+      expect(matches[0].cad_trust_project_id).to.equal(projectId);
+
+      // Cleanup
+      const tx3 = await sequelizeV2.transaction();
+      try {
+        await recreateV2FtsTriggers(tx3);
+        await tx3.commit();
+      } catch (e) {
+        await tx3.rollback();
+        throw e;
+      }
+      await ProjectV2.destroy({
+        where: { cadTrustProjectId: projectId },
+      });
+    });
+  });
+
+  describe('FTS5 deferral state machine', function () {
+    it('ensureV2FtsTriggersDeferred drops triggers and sets the meta flag', async function () {
+      await ensureV2FtsTriggersDeferred();
+
+      expect(await listV2FtsTriggers()).to.have.length(0);
+
+      const flagRow = await MetaV2.findOne({
+        where: { meta_key: FTS5_DEFER_META_KEY_V2 },
+        raw: true,
+      });
+      expect(flagRow).to.exist;
+    });
+
+    it('ensureV2FtsTriggersDeferred is idempotent (safe to call twice)', async function () {
+      await ensureV2FtsTriggersDeferred();
+      await ensureV2FtsTriggersDeferred();
+
+      expect(await listV2FtsTriggers()).to.have.length(0);
+
+      const count = await MetaV2.count({
+        where: { meta_key: FTS5_DEFER_META_KEY_V2 },
+      });
+      expect(count).to.equal(1);
+    });
+
+    it('restoreV2FtsTriggersAndRebuildIfDeferred is a no-op when flag is unset', async function () {
+      const result = await restoreV2FtsTriggersAndRebuildIfDeferred();
+      expect(result).to.equal(false);
+
+      expect(await listV2FtsTriggers()).to.deep.equal(
+        [...ALL_V2_FTS_TRIGGER_NAMES].sort(),
+      );
+    });
+
+    it('restoreV2FtsTriggersAndRebuildIfDeferred recreates triggers + rebuilds + clears flag when set', async function () {
+      await ensureV2FtsTriggersDeferred();
+      expect(await listV2FtsTriggers()).to.have.length(0);
+
+      const projectId = uuidv4();
+      const orgUid = uuidv4();
+      await ProjectV2.create({
+        cadTrustProjectId: projectId,
+        orgUid,
+        projectRegistryName: 'reg',
+        projectId: 'restorev2searchtoken',
+        projectName: 'restorev2name',
+      });
+
+      expect(await projectsV2FtsCount()).to.equal(0);
+
+      const result = await restoreV2FtsTriggersAndRebuildIfDeferred();
+      expect(result).to.equal(true);
+
+      expect(await listV2FtsTriggers()).to.deep.equal(
+        [...ALL_V2_FTS_TRIGGER_NAMES].sort(),
+      );
+
+      const flagRow = await MetaV2.findOne({
+        where: { meta_key: FTS5_DEFER_META_KEY_V2 },
+        raw: true,
+      });
+      expect(flagRow).to.equal(null);
+
+      expect(await projectsV2FtsCount()).to.equal(1);
+
+      const [matches] = await sequelizeV2.query(
+        "SELECT cad_trust_project_id FROM projects_v2_fts WHERE projects_v2_fts MATCH 'restorev2searchtoken';",
+      );
+      expect(matches.length).to.equal(1);
+
+      // Cleanup
+      await ProjectV2.destroy({
+        where: { cadTrustProjectId: projectId },
+      });
+    });
+
+    it('rebuild reflects rows in BOTH projects_v2_fts and units_v2_fts', async function () {
+      await ensureV2FtsTriggersDeferred();
+
+      const projectId = uuidv4();
+      const unitId = uuidv4();
+      const issuanceId = uuidv4();
+      const orgUid = uuidv4();
+
+      // First create a parent organization for context (V2 does not enforce
+      // FK at the DB level, but we keep a coherent shape).
+      await OrganizationsV2.findOrCreate({
+        where: { org_uid: orgUid },
+        defaults: {
+          org_uid: orgUid,
+          name: 'fts-perf-both-test',
+          is_home: false,
+          subscribed: true,
+          synced: false,
+          sync_remaining: 0,
+          balance: '0',
+          pending_balance: '0',
+          metadata: '{}',
+        },
+      });
+
+      await ProjectV2.create({
+        cadTrustProjectId: projectId,
+        orgUid,
+        projectRegistryName: 'reg',
+        projectId: 'p',
+        projectName: 'p',
+      });
+
+      // IssuanceV2's required application-level fields are issuanceId,
+      // cadTrustVerificationId, cadTrustProjectMethodologyId. We supply
+      // placeholders; FTS doesn't depend on issuance content.
+      await IssuanceV2.create({
+        cadTrustIssuanceId: issuanceId,
+        issuanceId: 'iss-' + issuanceId,
+        cadTrustVerificationId: uuidv4(),
+        cadTrustProjectMethodologyId: 'methodology-1',
+      });
+
+      await UnitV2.create({
+        cadTrustUnitId: unitId,
+        orgUid,
+        cadTrustIssuanceId: issuanceId,
+        unitSerialId: 'AAA1',
+        unitStartBlock: 'AAA1',
+        unitEndBlock: 'AAA1',
+        unitCount: 1,
+        unitVintageYear: 2025,
+      });
+
+      expect(await projectsV2FtsCount()).to.equal(0);
+      expect(await unitsV2FtsCount()).to.equal(0);
+
+      await restoreV2FtsTriggersAndRebuildIfDeferred();
+
+      expect(await projectsV2FtsCount()).to.equal(1);
+      expect(await unitsV2FtsCount()).to.equal(1);
+
+      // Cleanup
+      await UnitV2.destroy({ where: { cadTrustUnitId: unitId } });
+      await IssuanceV2.destroy({
+        where: { cadTrustIssuanceId: issuanceId },
+      });
+      await ProjectV2.destroy({
+        where: { cadTrustProjectId: projectId },
+      });
+      await OrganizationsV2.destroy({ where: { org_uid: orgUid } });
+    });
+
+    it('boot recovery: prepareV2Db-style restore runs when meta flag is pre-set', async function () {
+      await ensureV2FtsTriggersDeferred();
+
+      const projectId = uuidv4();
+      const orgUid = uuidv4();
+      await ProjectV2.create({
+        cadTrustProjectId: projectId,
+        orgUid,
+        projectRegistryName: 'reg',
+        projectId: 'crashrecoverytokenv2',
+        projectName: 'crashrecoveryv2',
+      });
+
+      const recovered = await restoreV2FtsTriggersAndRebuildIfDeferred();
+      expect(recovered).to.equal(true);
+
+      expect(await listV2FtsTriggers()).to.deep.equal(
+        [...ALL_V2_FTS_TRIGGER_NAMES].sort(),
+      );
+      const flagRow = await MetaV2.findOne({
+        where: { meta_key: FTS5_DEFER_META_KEY_V2 },
+        raw: true,
+      });
+      expect(flagRow).to.equal(null);
+      expect(await projectsV2FtsCount()).to.equal(1);
+
+      // Cleanup
+      await ProjectV2.destroy({
+        where: { cadTrustProjectId: projectId },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Reduces sync write cost on large catch-ups (primarily Pi-class hardware) via three independent improvements applied to both V1 and V2:

- **Audit composite indexes.** New migrations add `(registryId, generation)` + `(orgUid, generation)` to V1 `audit`, and `(registry_id, generation)` + `(org_uid, generation)` to V2 `audit`. The V1 `mostRecentOrgAuditRecord` lookup in `sync-registries.js` was changed from `ORDER BY createdAt DESC` to `ORDER BY generation DESC` so the new composite index actually serves the query (a comment at the call site flags the deliberate change). Generation is monotonic per orgUid in the sync forward path so the rootHash returned is unchanged in steady state.
- **Bulk audit writes.** Replaces per-row `Audit.create` with a single `Audit.bulkCreate` per generation in V1 and V2 sync. V1 grows a new `Audit.bulkCreate` static that threads `mirrorTransaction` through to the mirror's `bulkCreate`. Both sides cap `batchSize` at 500 so very large generations stay well under SQLite's `SQLITE_MAX_VARIABLE_NUMBER`.
- **FTS5 trigger deferral.** New helpers in `src/utils/fts5-deferral.js` and `src/utils/fts5-deferral-v2.js` snapshot the currently-installed `projects_fts` / `units_fts` (V1) and `projects_v2_fts` / `units_v2_fts` (V2) maintenance triggers into `meta` via `sqlite_master` introspection, drop them while any subscribed org is mid-catch-up, and recreate them from the snapshot once all orgs are caught up — followed by a one-shot rebuild of the FTS tables from the source rows. Snapshotting at defer time instead of hardcoding DDL removes a silent schema-drift class entirely. Deferral state is persisted in `meta` so a crash mid-catch-up is recovered on the next boot. The post-loop restore decision runs in a `finally` block so a thrown sync error doesn't leave triggers permanently dropped, and boot recovery is non-fatal so a transient FTS rebuild failure can't brick startup.

The deferral path is gated on `NODE_ENV !== 'test'` so the existing integration-test fixtures (which seed many `subscribed: true, synced: false` orgs alongside live FTS-dependent specs) keep their FTS triggers installed; the new perf specs exercise the deferral helpers directly.

## Adversarial review

Two rounds of fresh-context diff review were run before push. All critical / warning findings were addressed in this branch — most notably:

- Trigger DDL drift: the helpers now introspect `sqlite_master` at defer time and recreate from the saved DDL, instead of carrying hardcoded copies of the migration text.
- `try/finally` around the org loop so the restore decision runs even when sync throws.
- `ensureV*FtsTriggersDeferred` refuses to set the deferral flag if there is no snapshot to restore from (prevents permanent loss of triggers in degenerate states).
- Boot FTS recovery downgraded from fatal to log-and-continue.
- Mirror code-path test added for `Audit.bulkCreate` against the real V1 SQLite-fallback mirror, including an isolation assertion between source and mirror transactions.
- Both new perf specs restart both V1 and V2 sides of `TaskManager` in their `after` hooks regardless of file ordering.

## Test plan

- [x] `npm test -- --grep "Sync Write Perf \(V1\)"` — 16 passing
- [x] `npm run test:v2 -- --grep "Sync Write Perf \(V2\)"` — 13 passing
- [x] Full V1 integration suite (`npm test`) — 143 passing, 0 failing
- [x] Full V2 integration suite (`npm run test:v2`) — 1565 passing; 2 flaky failures (rating-v2) match the `v2-rc2` baseline and pass in isolation
- [x] `npx prettier --write` + `npx eslint` clean on all changed files (only pre-existing `no-console` warnings)

New tests included in this branch:

- Audit composite indexes exist + `EXPLAIN QUERY PLAN` verifies both `registryId` and `orgUid` paths use the new index (V1 and V2)
- Per-generation `Audit.bulkCreate` row shape, plus V1 mirror branch verified against the real SQLite-fallback mirror including source/mirror transaction isolation
- FTS5 deferral helpers (drop / recreate / rebuild) + state-machine (`ensure*` / `restore*`) + boot recovery (V1 and V2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sync loop behavior, database migrations, and FTS trigger lifecycle; mistakes could cause stale search results or slower/failed sync until recovery runs, though changes are guarded (SQLite-only, idempotent migrations, best-effort recovery) and covered by integration tests.
> 
> **Overview**
> Reduces catch-up sync write cost for both V1 and V2 by **adding composite `audit` indexes** for the hot-path “latest generation per org/registry” lookup and updating the V1 per-tick lookup to `ORDER BY generation DESC` so the new index is used.
> 
> Switches per-diff-row audit writes to **per-generation `bulkCreate`** (with a 500-row batch cap) and hoists per-generation comment/author parsing out of the inner loop; V1’s `Audit` model now mirrors `bulkCreate` to `AuditMirror` with proper `mirrorTransaction` threading.
> 
> Introduces **SQLite-only FTS5 trigger deferral** for project/unit catch-up: new `fts5-deferral` helpers snapshot+drop triggers when any subscribed org is behind, then restore triggers and rebuild FTS tables once all orgs are caught up (run in `finally`), with non-fatal boot-time recovery in `prepareDb`/`prepareV2Db`; extensive new V1/V2 integration perf specs validate indexes, bulk writes (including mirror behavior), and the deferral state machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81428f10eeed2b9ec303a68e8a0ef47582d0ef61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->