### PR TITLE
perf: tune SQLite connection pragmas

### DIFF
--- a/src/database/index.js
+++ b/src/database/index.js
@@ -41,12 +41,12 @@ if (nodeEnv === 'test') {
 }
 
 export const sequelize = new Sequelize(config[dbConfigKey]);
-installSqlitePragmas(sequelize);
+installSqlitePragmas(sequelize, logger);
 
 const mirrorConfig =
   (process.env.NODE_ENV || 'local') === 'local' ? 'mirror' : 'mirrorTest';
 export const sequelizeMirror = new Sequelize(config[mirrorConfig]);
-installSqlitePragmas(sequelizeMirror);
+installSqlitePragmas(sequelizeMirror, logger);
 
 // Snapshot of whether V1 MIRROR_DB was fully configured at module-load time.
 // Captured alongside sequelizeMirror construction so mirrorDBEnabled() stays

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -12,6 +12,7 @@ import { migrations } from './migrations';
 import { seeders } from './seeders';
 
 import dotenv from 'dotenv';
+import { installSqlitePragmas } from './sqlite-pragmas.js';
 dotenv.config({ quiet: true });
 
 // possible values: local, test
@@ -40,10 +41,12 @@ if (nodeEnv === 'test') {
 }
 
 export const sequelize = new Sequelize(config[dbConfigKey]);
+installSqlitePragmas(sequelize);
 
 const mirrorConfig =
   (process.env.NODE_ENV || 'local') === 'local' ? 'mirror' : 'mirrorTest';
 export const sequelizeMirror = new Sequelize(config[mirrorConfig]);
+installSqlitePragmas(sequelizeMirror);
 
 // Snapshot of whether V1 MIRROR_DB was fully configured at module-load time.
 // Captured alongside sequelizeMirror construction so mirrorDBEnabled() stays

--- a/src/database/sqlite-pragmas.js
+++ b/src/database/sqlite-pragmas.js
@@ -1,0 +1,43 @@
+const SQLITE_PRAGMAS = [
+  'PRAGMA synchronous = NORMAL',
+  'PRAGMA cache_size = -65536',
+  'PRAGMA temp_store = MEMORY',
+  'PRAGMA mmap_size = 268435456',
+];
+
+const applySqlitePragmas = async (connection) => {
+  if (!connection || typeof connection.exec !== 'function') {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    connection.exec(SQLITE_PRAGMAS.join('; '), (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+};
+
+export const installSqlitePragmas = (sequelize) => {
+  if (sequelize.getDialect() !== 'sqlite') {
+    return;
+  }
+
+  const configuredConnections = new WeakSet();
+  const { connectionManager } = sequelize;
+  const getConnection = connectionManager.getConnection.bind(connectionManager);
+
+  connectionManager.getConnection = async (...args) => {
+    const connection = await getConnection(...args);
+
+    if (!configuredConnections.has(connection)) {
+      await applySqlitePragmas(connection);
+      configuredConnections.add(connection);
+    }
+
+    return connection;
+  };
+};

--- a/src/database/sqlite-pragmas.js
+++ b/src/database/sqlite-pragmas.js
@@ -1,5 +1,3 @@
-import { logger } from '../config/logger.js';
-
 const SQLITE_PRAGMAS = [
   'PRAGMA journal_mode = WAL',
   'PRAGMA synchronous = NORMAL',
@@ -24,7 +22,7 @@ const applySqlitePragmas = async (connection) => {
   });
 };
 
-export const installSqlitePragmas = (sequelize) => {
+export const installSqlitePragmas = (sequelize, pragmaLogger = console) => {
   if (sequelize.getDialect() !== 'sqlite') {
     return;
   }
@@ -42,7 +40,7 @@ export const installSqlitePragmas = (sequelize) => {
         configuredConnections.add(connection);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        logger.warn(`Could not apply SQLite PRAGMAs: ${message}`);
+        pragmaLogger.warn(`Could not apply SQLite PRAGMAs: ${message}`);
       }
     }
 

--- a/src/database/sqlite-pragmas.js
+++ b/src/database/sqlite-pragmas.js
@@ -1,6 +1,7 @@
 import { logger } from '../config/logger.js';
 
 const SQLITE_PRAGMAS = [
+  'PRAGMA journal_mode = WAL',
   'PRAGMA synchronous = NORMAL',
   'PRAGMA cache_size = -65536',
   'PRAGMA temp_store = MEMORY',

--- a/src/database/sqlite-pragmas.js
+++ b/src/database/sqlite-pragmas.js
@@ -1,3 +1,5 @@
+import { logger } from '../config/logger.js';
+
 const SQLITE_PRAGMAS = [
   'PRAGMA synchronous = NORMAL',
   'PRAGMA cache_size = -65536',
@@ -34,8 +36,13 @@ export const installSqlitePragmas = (sequelize) => {
     const connection = await getConnection(...args);
 
     if (!configuredConnections.has(connection)) {
-      await applySqlitePragmas(connection);
-      configuredConnections.add(connection);
+      try {
+        await applySqlitePragmas(connection);
+        configuredConnections.add(connection);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn(`Could not apply SQLite PRAGMAs: ${message}`);
+      }
     }
 
     return connection;

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -11,6 +11,7 @@ import { migrations } from './migrations';
 import { seeders } from './seeders';
 
 import dotenv from 'dotenv';
+import { installSqlitePragmas } from '../sqlite-pragmas.js';
 dotenv.config({ quiet: true });
 
 // possible values: local, test
@@ -39,6 +40,7 @@ if (nodeEnv === 'test') {
 }
 
 export const sequelizeV2 = new Sequelize(config[dbConfigKey]);
+installSqlitePragmas(sequelizeV2);
 
 // Determine if MySQL mirror is configured by checking the actual config values
 // This allows MySQL mirror to work in any environment (local, test, production)
@@ -80,6 +82,7 @@ const isMysqlMirrorConfiguredForReconnectV2 = () => {
 };
 
 export const sequelizeV2Mirror = new Sequelize(config[mirrorConfig]);
+installSqlitePragmas(sequelizeV2Mirror);
 
 // Snapshot of "is the mirror Sequelize instance actually pointing at MySQL"
 // taken at module-load time, alongside sequelizeV2Mirror construction.

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -40,7 +40,7 @@ if (nodeEnv === 'test') {
 }
 
 export const sequelizeV2 = new Sequelize(config[dbConfigKey]);
-installSqlitePragmas(sequelizeV2);
+installSqlitePragmas(sequelizeV2, loggerV2);
 
 // Determine if MySQL mirror is configured by checking the actual config values
 // This allows MySQL mirror to work in any environment (local, test, production)
@@ -82,7 +82,7 @@ const isMysqlMirrorConfiguredForReconnectV2 = () => {
 };
 
 export const sequelizeV2Mirror = new Sequelize(config[mirrorConfig]);
-installSqlitePragmas(sequelizeV2Mirror);
+installSqlitePragmas(sequelizeV2Mirror, loggerV2);
 
 // Snapshot of "is the mirror Sequelize instance actually pointing at MySQL"
 // taken at module-load time, alongside sequelizeV2Mirror construction.


### PR DESCRIPTION
## Summary
- Apply SQLite connection PRAGMAs for V1 and V2 Sequelize instances, including SQLite mirror fallbacks.
- Set WAL mode before `synchronous=NORMAL`, then use a fixed 64 MiB SQLite page cache, memory temp storage, and 256 MiB mmap limit.
- Keep PRAGMA setup best-effort and route warnings to the matching V1/V2 logger.

## Test plan
- `NODE_ENV=test` direct V1 connection check for `journal_mode=wal`, `cache_size=-65536`, `temp_store=2`, and `synchronous=1`.
- `NODE_ENV=test` direct V2 and V2 mirror fallback connection checks for the same PRAGMAs.
- `npm run build`
- `npm run preflight-check:v1v2` attempted, but local CADT server was not running on the configured port, so preflight could not complete.

## Notes
- `synchronous=NORMAL` is intentionally applied after WAL mode is set. The tradeoff is reduced fsync durability for the latest commit under power loss, while sync can replay missed data on restart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default SQLite connection settings (WAL, synchronous mode, cache/temp/mmap) for all V1/V2 Sequelize instances, which can impact durability and concurrency behavior if misapplied. Implementation is best-effort, but it hooks into connection acquisition and could affect all SQLite environments (not just tests).
> 
> **Overview**
> **SQLite connections now get tuned PRAGMAs automatically.** A new `installSqlitePragmas()` hook applies `journal_mode=WAL`, `synchronous=NORMAL`, a fixed page cache size, in-memory temp storage, and an `mmap_size` limit whenever Sequelize acquires a SQLite connection.
> 
> This is wired into both V1 (`sequelize`, `sequelizeMirror`) and V2 (`sequelizeV2`, `sequelizeV2Mirror`) initialization, with PRAGMA failures treated as best-effort and logged via the appropriate V1/V2 logger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc6b2472c505bcafc589ac9a9f4b929e2c4c0e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->