### PR TITLE
fix: override vulnerable serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "cadt",
       "version": "1.7.25",
+      "hasInstallScript": true,
       "dependencies": {
         "async-mutex": "^0.5.0",
         "body-parser": "^2.2.2",
@@ -8477,16 +8478,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8916,13 +8907,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,10 @@
   "overrides": {
     "diff": "8.0.3",
     "esbuild": "0.27.3",
-    "tar": "7.5.13"
+    "tar": "7.5.13",
+    "mocha": {
+      "serialize-javascript": "7.0.5"
+    }
   },
   "contributors": [
     "Michael Taylor <5665004+MichaelTaylor3D@users.noreply.github.com>",


### PR DESCRIPTION
## Summary
- Add a scoped npm override so Mocha resolves `serialize-javascript` to `7.0.5`.
- Regenerate the lockfile to remove the vulnerable `6.0.2` transitive dependency.

## Test plan
- Validated `package.json` and `package-lock.json` parse as JSON.
- Confirmed the lockfile resolves `node_modules/serialize-javascript` to `7.0.5`.
- Ran `npm audit`; the `serialize-javascript` advisory is no longer reported. Existing unrelated advisories remain for `brace-expansion`, `express-rate-limit`/`ip-address`, `lodash`, and `uuid`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/lockfile-only change that forces Mocha’s transitive `serialize-javascript` to a non-vulnerable version; main risk is unexpected test tooling behavior changes from the upgraded package.
> 
> **Overview**
> Resolves a vulnerable transitive dependency by adding an `npm overrides` rule that pins Mocha’s `serialize-javascript` to `7.0.5`.
> 
> Regenerates `package-lock.json` to reflect the new resolution (now `serialize-javascript@7.0.5` and related lockfile metadata updates, including removal of the previous `randombytes` dependency).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b865a0a94243bc0b1feae3647c24cfac0b406df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->