### PR TITLE
fix: update uuid to patched release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10099,9 +10099,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"


### PR DESCRIPTION
## Summary
- Update the locked runtime `uuid` package from the vulnerable 13.0.0 release to 13.0.2.
- Resolve Dependabot alert 144 / GHSA-w5hq-g745-h8pq for the v2-rc2 branch.

## Test plan
- Validated `package-lock.json` parses as JSON.
- Confirmed the lockfile resolves `node_modules/uuid` to 13.0.2.
- Integration tests not run locally; CI will validate this lockfile-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only dependency patch update; no application logic changes, but runtime behavior could shift slightly if `uuid` has bugfixes.
> 
> **Overview**
> Updates `package-lock.json` to resolve `uuid` from `13.0.0` to `13.0.2` (new tarball URL and integrity), addressing the patched release without changing application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6adaa0aea44c95c101f54dfba8f35c0626398114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->