### PR TITLE
fix: update lodash to patched release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "express-rate-limit": "^8.2.1",
         "joi": "^17.13.3",
         "js-yaml": "^4.1.1",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "log-update": "^7.0.2",
         "multer": "^2.0.2",
         "mysql2": "^3.16.3",
@@ -6936,9 +6936,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "express-rate-limit": "^8.2.1",
     "joi": "^17.13.3",
     "js-yaml": "^4.1.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "log-update": "^7.0.2",
     "multer": "^2.0.2",
     "mysql2": "^3.16.3",


### PR DESCRIPTION
## Summary
- Update direct `lodash` dependency and lockfile entry from `4.17.23` to `4.18.1`.
- Resolves the vulnerable lodash range reported by Dependabot alert 141.

## Test plan
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('package-lock.json','utf8')); console.log('JSON is valid')"`
- `npm audit --json` no longer reports `lodash`; remaining findings are unrelated existing dependencies.
- `npm run test:v1` passed: 127 passing, 5 pending.
- `npm run test:v2` reports one project-delete failure that also reproduces on untouched `v2-rc2`; the failing test passes when run in isolation.
- Pre-push diff review: no issues found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; primary impact is potential minor behavioral differences in `lodash` across versions, but no application logic was modified.
> 
> **Overview**
> Updates the direct `lodash` dependency from `4.17.23` to `4.18.1` in `package.json` and refreshes `package-lock.json` to pin the new resolved tarball and integrity hash.
> 
> This is a security/maintenance bump intended to move off the previously flagged vulnerable `lodash` version range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d95f57751a8f466ac970c6f98b8e34435a6356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->