### PR TITLE
fix: synchronize mirror writes within transactional sync path

### DIFF
--- a/src/database/index.js
+++ b/src/database/index.js
@@ -351,6 +351,25 @@ export const safeMirrorDbHandler = (callback) => {
   });
 };
 
+// When a mirrorTransaction is provided the caller already authenticated and
+// started the transaction (see createAndProcessTransaction in
+// sync-registries), so we can run the callback directly and synchronously.
+// This avoids the fire-and-forget race in safeMirrorDbHandler where the
+// transaction is committed before detached writes complete.  When no
+// mirrorTransaction is present we fall back to the existing best-effort
+// fire-and-forget path so non-transactional API writes are unaffected.
+export const mirrorWrite = async (callback, mirrorTransaction) => {
+  if (mirrorTransaction) {
+    try {
+      await callback();
+    } catch (e) {
+      logger.error(`mirror_error:${e.message}`);
+    }
+  } else {
+    safeMirrorDbHandler(callback);
+  }
+};
+
 // Initialize a V1 mirror Sequelize Model synchronously at module-load time.
 //
 // Model.init() only registers schema metadata on the Sequelize instance; it

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -324,6 +324,21 @@ export const safeMirrorDbHandlerV2 = (callback) => {
   });
 };
 
+// Synchronous mirror write when a mirrorTransaction is provided; fire-and-
+// forget via safeMirrorDbHandlerV2 otherwise.  See mirrorWrite in the V1
+// database module for full rationale.
+export const mirrorWriteV2 = async (callback, mirrorTransaction) => {
+  if (mirrorTransaction) {
+    try {
+      await callback();
+    } catch (e) {
+      loggerV2.error(`v2_mirror_error:${e.message}`);
+    }
+  } else {
+    safeMirrorDbHandlerV2(callback);
+  }
+};
+
 // Initialize a V2 mirror Sequelize Model synchronously at module-load time.
 //
 // Model.init() only registers schema metadata on the Sequelize instance; it

--- a/src/models/audit/audit.model.js
+++ b/src/models/audit/audit.model.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Sequelize, Model } from 'sequelize';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, mirrorWrite } from '../../database';
 import { AuditMirror } from './audit.model.mirror';
 import ModelTypes from './audit.modeltypes.js';
 import findDuplicateIssuancesSql from './sql/find-duplicate-issuances.sql.js';
@@ -10,46 +10,46 @@ import { waitForSyncRegistriesTransaction } from '../../utils/model-utils.js';
 
 class Audit extends Model {
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditMirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.bulkCreate(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 

--- a/src/models/co-benefits/co-benefits.model.js
+++ b/src/models/co-benefits/co-benefits.model.js
@@ -2,7 +2,7 @@
 import { Model } from 'sequelize';
 
 import { CoBenefitMirror } from './co-benefits.model.mirror';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, safeMirrorDbHandler, mirrorWrite } from '../../database';
 import { Project } from '../projects';
 import ModelTypes from './co-benefits.modeltypes.js';
 
@@ -24,35 +24,35 @@ class CoBenefit extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 }

--- a/src/models/estimations/estimations.model.js
+++ b/src/models/estimations/estimations.model.js
@@ -2,7 +2,7 @@
 import { Model } from 'sequelize';
 
 import { EstimationMirror } from './estimations.model.mirror';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, safeMirrorDbHandler, mirrorWrite } from '../../database';
 import { Project } from '../projects';
 import ModelTypes from './estimations.modeltypes.js';
 
@@ -24,36 +24,36 @@ class Estimation extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
 
       await EstimationMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await EstimationMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await EstimationMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 }

--- a/src/models/issuances/issuances.model.js
+++ b/src/models/issuances/issuances.model.js
@@ -1,6 +1,6 @@
 'use strict';
 import { Model } from 'sequelize';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, safeMirrorDbHandler, mirrorWrite } from '../../database';
 import { Project, Unit } from '..';
 
 import ModelTypes from './issuances.modeltypes.js';
@@ -31,35 +31,35 @@ class Issuance extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 }

--- a/src/models/labelUnits/labelUnits.model.js
+++ b/src/models/labelUnits/labelUnits.model.js
@@ -1,42 +1,42 @@
 'use strict';
 
 import { Model } from 'sequelize';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, mirrorWrite } from '../../database';
 
 import ModelTypes from './labelUnits.modeltypes.js';
 import { LabelUnitMirror } from './labelUnits.model.mirror';
 
 class LabelUnit extends Model {
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelUnitMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelUnitMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelUnitMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 }

--- a/src/models/labels/labels.model.js
+++ b/src/models/labels/labels.model.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Model } from 'sequelize';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, safeMirrorDbHandler, mirrorWrite } from '../../database';
 import { Project } from '../projects';
 import { Unit } from '../units';
 
@@ -37,35 +37,35 @@ class Label extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 }

--- a/src/models/locations/locations.model.js
+++ b/src/models/locations/locations.model.js
@@ -2,7 +2,7 @@
 
 import { Model } from 'sequelize';
 
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, safeMirrorDbHandler, mirrorWrite } from '../../database';
 import { Project } from '../projects';
 import { Unit } from '../units';
 
@@ -33,35 +33,35 @@ class ProjectLocation extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectLocationMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectLocationMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectLocationMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 }

--- a/src/models/projects/projects.model.js
+++ b/src/models/projects/projects.model.js
@@ -7,6 +7,7 @@ import * as rxjs from 'rxjs';
 import {
   sequelize,
   safeMirrorDbHandler,
+  mirrorWrite,
   sanitizeSqliteFtsQuery,
 } from '../../database';
 
@@ -123,13 +124,13 @@ class Project extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const createResult = await super.create(values, options);
 
@@ -141,27 +142,27 @@ class Project extends Model {
   }
 
   static async destroy(options) {
-    await safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
 
       await ProjectMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     Project.changes.next(['projects']);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const upsertResult = await super.upsert(values, options);
 
     const { orgUid } = values;

--- a/src/models/ratings/ratings.model.js
+++ b/src/models/ratings/ratings.model.js
@@ -1,6 +1,6 @@
 'use strict';
 import { Model } from 'sequelize';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, safeMirrorDbHandler, mirrorWrite } from '../../database';
 import { Project } from '../projects/index';
 
 import ModelTypes from './ratings.modeltypes.js';
@@ -24,35 +24,35 @@ class Rating extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 }

--- a/src/models/related-projects/related-projects.model.js
+++ b/src/models/related-projects/related-projects.model.js
@@ -1,6 +1,6 @@
 'use strict';
 import { Model } from 'sequelize';
-import { sequelize, safeMirrorDbHandler } from '../../database';
+import { sequelize, safeMirrorDbHandler, mirrorWrite } from '../../database';
 
 import ModelTypes from './related-projects.modeltypes.js';
 import { RelatedProjectMirror } from './related-projects.model.mirror';
@@ -25,35 +25,35 @@ class RelatedProject extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RelatedProjectMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.create(values, options);
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RelatedProjectMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.destroy(options);
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RelatedProjectMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     return super.upsert(values, options);
   }
 }

--- a/src/models/units/units.model.js
+++ b/src/models/units/units.model.js
@@ -6,6 +6,7 @@ import * as rxjs from 'rxjs';
 import {
   sequelize,
   safeMirrorDbHandler,
+  mirrorWrite,
   sanitizeSqliteFtsQuery,
 } from '../../database';
 import { Label, Issuance, Staging, Organization } from '../../models';
@@ -68,13 +69,13 @@ class Unit extends Model {
   }
 
   static async create(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitMirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const createResult = await super.create(values, options);
     const { orgUid } = createResult;
@@ -85,13 +86,13 @@ class Unit extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitMirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const upsertResult = await super.upsert(values, options);
 
@@ -103,13 +104,13 @@ class Unit extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandler(async () => {
+    await mirrorWrite(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitMirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     Unit.changes.next(['units']);
     return super.destroy(options);

--- a/src/models/v2/aef-t1-submission-v2.model.js
+++ b/src/models/v2/aef-t1-submission-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import ModelTypes from './aef-t1-submission-v2.modeltypes.js';
 import { AefT1SubmissionV2Mirror } from './aef-t1-submission-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,13 +13,13 @@ import {
 
 class AefT1SubmissionV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT1SubmissionV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -27,13 +27,13 @@ class AefT1SubmissionV2 extends Model {
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT1SubmissionV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -41,13 +41,13 @@ class AefT1SubmissionV2 extends Model {
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT1SubmissionV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -55,13 +55,13 @@ class AefT1SubmissionV2 extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT1SubmissionV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -69,13 +69,13 @@ class AefT1SubmissionV2 extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT1SubmissionV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/models/v2/aef-t2-authorizations-v2.model.js
+++ b/src/models/v2/aef-t2-authorizations-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import ModelTypes from './aef-t2-authorizations-v2.modeltypes.js';
 import { AefT2AuthorizationsV2Mirror } from './aef-t2-authorizations-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,13 +13,13 @@ import {
 
 class AefT2AuthorizationsV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT2AuthorizationsV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -27,13 +27,13 @@ class AefT2AuthorizationsV2 extends Model {
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT2AuthorizationsV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -41,13 +41,13 @@ class AefT2AuthorizationsV2 extends Model {
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT2AuthorizationsV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -55,13 +55,13 @@ class AefT2AuthorizationsV2 extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT2AuthorizationsV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -69,13 +69,13 @@ class AefT2AuthorizationsV2 extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT2AuthorizationsV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/models/v2/aef-t3-actions-v2.model.js
+++ b/src/models/v2/aef-t3-actions-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import ModelTypes from './aef-t3-actions-v2.modeltypes.js';
 import { AefT3ActionsV2Mirror } from './aef-t3-actions-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,13 +13,13 @@ import {
 
 class AefT3ActionsV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT3ActionsV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -27,13 +27,13 @@ class AefT3ActionsV2 extends Model {
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT3ActionsV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -41,13 +41,13 @@ class AefT3ActionsV2 extends Model {
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT3ActionsV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -55,13 +55,13 @@ class AefT3ActionsV2 extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT3ActionsV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -69,13 +69,13 @@ class AefT3ActionsV2 extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT3ActionsV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/models/v2/aef-t4-holdings-v2.model.js
+++ b/src/models/v2/aef-t4-holdings-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import ModelTypes from './aef-t4-holdings-v2.modeltypes.js';
 import { AefT4HoldingsV2Mirror } from './aef-t4-holdings-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,13 +13,13 @@ import {
 
 class AefT4HoldingsV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT4HoldingsV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -27,13 +27,13 @@ class AefT4HoldingsV2 extends Model {
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT4HoldingsV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -41,13 +41,13 @@ class AefT4HoldingsV2 extends Model {
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT4HoldingsV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -55,13 +55,13 @@ class AefT4HoldingsV2 extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT4HoldingsV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -69,13 +69,13 @@ class AefT4HoldingsV2 extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT4HoldingsV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/models/v2/aef-t5-authorized-entities-v2.model.js
+++ b/src/models/v2/aef-t5-authorized-entities-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import ModelTypes from './aef-t5-authorized-entities-v2.modeltypes.js';
 import { AefT5AuthorizedEntitiesV2Mirror } from './aef-t5-authorized-entities-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,13 +13,13 @@ import {
 
 class AefT5AuthorizedEntitiesV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT5AuthorizedEntitiesV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -27,13 +27,13 @@ class AefT5AuthorizedEntitiesV2 extends Model {
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT5AuthorizedEntitiesV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -41,13 +41,13 @@ class AefT5AuthorizedEntitiesV2 extends Model {
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT5AuthorizedEntitiesV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -55,13 +55,13 @@ class AefT5AuthorizedEntitiesV2 extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT5AuthorizedEntitiesV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
@@ -69,13 +69,13 @@ class AefT5AuthorizedEntitiesV2 extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AefT5AuthorizedEntitiesV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));

--- a/src/models/v2/audit-v2.model.js
+++ b/src/models/v2/audit-v2.model.js
@@ -2,7 +2,7 @@
 
 import { Sequelize, Model } from 'sequelize';
 
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import AuditV2Mirror from './audit-v2.model.mirror.js';
 import OrganizationsV2 from './organizations-v2.model.js';
 import { loggerV2 } from '../../config/logger.js';
@@ -11,65 +11,65 @@ import ModelTypes from './audit-v2.modeltypes.js';
 
 class AuditV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await AuditV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/co-benefit-v2.model.js
+++ b/src/models/v2/co-benefit-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { CoBenefitV2Mirror } from './co-benefit-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -15,65 +15,65 @@ import { loggerV2 } from '../../config/logger.js';
 
 class CoBenefitV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await CoBenefitV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/estimation-v2.model.js
+++ b/src/models/v2/estimation-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { EstimationV2Mirror } from './estimation-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -15,65 +15,65 @@ import { loggerV2 } from '../../config/logger.js';
 
 class EstimationV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await EstimationV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await EstimationV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await EstimationV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await EstimationV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await EstimationV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/issuance-v2.model.js
+++ b/src/models/v2/issuance-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { IssuanceV2Mirror } from './issuance-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -15,65 +15,65 @@ import { UnitV2 } from './unit-v2.model.js';
 
 class IssuanceV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await IssuanceV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/label-v2.model.js
+++ b/src/models/v2/label-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { LabelV2Mirror } from './label-v2.model.mirror.js';
 import ModelTypes from './label-v2.modeltypes.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,65 +13,65 @@ import {
 
 class LabelV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LabelV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/location-v2.model.js
+++ b/src/models/v2/location-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { LocationV2Mirror } from './location-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -12,65 +12,65 @@ import {
 
 class LocationV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LocationV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LocationV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LocationV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LocationV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await LocationV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/methodology-v2.model.js
+++ b/src/models/v2/methodology-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import ModelTypes from './methodology-v2.modeltypes.js';
 import { MethodologyV2Mirror } from './methodology-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
@@ -14,65 +14,65 @@ import { loggerV2 } from '../../config/logger.js';
 
 class MethodologyV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await MethodologyV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.create(values, options);
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await MethodologyV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.bulkCreate(values, options);
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await MethodologyV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.update(values, options);
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await MethodologyV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.upsert(values, options);
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await MethodologyV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const result = await super.destroy(options);
     return result;

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -3,7 +3,7 @@
 import { Sequelize, Model } from 'sequelize';
 import _ from 'lodash';
 
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import OrganizationsV2Mirror from './organizations-v2.model.mirror.js';
 import datalayer from '../../datalayer';
 import { getStoreData as getRawStoreData } from '../../datalayer/persistance.js';
@@ -80,65 +80,65 @@ const { isTransientWalletError } = wallet;
 
 class OrganizationsV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await OrganizationsV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await OrganizationsV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await OrganizationsV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await OrganizationsV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await OrganizationsV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/program-v2.model.js
+++ b/src/models/v2/program-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { ProgramV2Mirror } from './program-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -12,65 +12,65 @@ import {
 
 class ProgramV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProgramV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProgramV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProgramV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProgramV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProgramV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/project-methodology-v2.model.js
+++ b/src/models/v2/project-methodology-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { ProjectMethodologyV2Mirror } from './project-methodology-v2.model.mirror.js';
 import ModelTypes from './project-methodology-v2.modeltypes.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,65 +13,65 @@ import {
 
 class ProjectMethodologyV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectMethodologyV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectMethodologyV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectMethodologyV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectMethodologyV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectMethodologyV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/project-v2.model.js
+++ b/src/models/v2/project-v2.model.js
@@ -3,7 +3,7 @@
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
 import * as rxjs from 'rxjs';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { ProjectV2Mirror } from './project-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -105,13 +105,13 @@ class ProjectV2 extends Model {
   ];
 
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const createResult = await super.create(values, options);
     const { org_uid } = values;
@@ -121,13 +121,13 @@ class ProjectV2 extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const upsertResult = await super.upsert(values, options);
     const { org_uid } = values;
@@ -137,13 +137,13 @@ class ProjectV2 extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ProjectV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     ProjectV2.changes.next(['projects']);
     const result = await super.destroy(options);

--- a/src/models/v2/rating-v2.model.js
+++ b/src/models/v2/rating-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { RatingV2Mirror } from './rating-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -15,65 +15,65 @@ import { loggerV2 } from '../../config/logger.js';
 
 class RatingV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await RatingV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/stakeholder-projects-v2.model.js
+++ b/src/models/v2/stakeholder-projects-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { StakeholderProjectV2Mirror } from './stakeholder-projects-v2.model.mirror.js';
 import ModelTypes from './stakeholder-projects-v2.modeltypes.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,65 +13,65 @@ import {
 
 class StakeholderProjectV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderProjectV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderProjectV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderProjectV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderProjectV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderProjectV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/stakeholder-v2.model.js
+++ b/src/models/v2/stakeholder-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { StakeholderV2Mirror } from './stakeholder-v2.model.mirror.js';
 import ModelTypes from './stakeholder-v2.modeltypes.js';
 import StagingV2 from './staging-v2.model.js';
@@ -13,65 +13,65 @@ import {
 
 class StakeholderV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await StakeholderV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/unit-label-v2.model.js
+++ b/src/models/v2/unit-label-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { UnitLabelV2Mirror } from './unit-label-v2.model.mirror.js';
 import ModelTypes from './unit-label-v2.modeltypes.js';
 import StagingV2 from './staging-v2.model.js';
@@ -14,65 +14,65 @@ import { loggerV2 } from '../../config/logger.js';
 
 class UnitLabelV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitLabelV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitLabelV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitLabelV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitLabelV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitLabelV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/unit-v2.model.js
+++ b/src/models/v2/unit-v2.model.js
@@ -6,7 +6,7 @@ import * as rxjs from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 import { Readable } from 'stream';
 import csv from 'csvtojson';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { UnitV2Mirror } from './unit-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import OrganizationsV2 from './organizations-v2.model.js';
@@ -68,13 +68,13 @@ class UnitV2 extends Model {
   static getAssociatedModels = () => [{ model: UnitLabelV2, pluralize: true }];
 
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const createResult = await super.create(values, options);
     const { org_uid } = createResult;
@@ -84,13 +84,13 @@ class UnitV2 extends Model {
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     const upsertResult = await super.upsert(values, options);
     const { org_uid } = values;
@@ -101,13 +101,13 @@ class UnitV2 extends Model {
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await UnitV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
 
     UnitV2.changes.next(['units']);
     const result = await super.destroy(options);

--- a/src/models/v2/validation-v2.model.js
+++ b/src/models/v2/validation-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { ValidationV2Mirror } from './validation-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -12,65 +12,65 @@ import {
 
 class ValidationV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ValidationV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ValidationV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ValidationV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ValidationV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await ValidationV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/models/v2/verification-v2.model.js
+++ b/src/models/v2/verification-v2.model.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 import { Sequelize, Model } from 'sequelize';
-import { sequelizeV2, safeMirrorDbHandlerV2 } from '../../database/v2/index.js';
+import { sequelizeV2, mirrorWriteV2 } from '../../database/v2/index.js';
 import { VerificationV2Mirror } from './verification-v2.model.mirror.js';
 import StagingV2 from './staging-v2.model.js';
 import {
@@ -12,65 +12,65 @@ import {
 
 class VerificationV2 extends Model {
   static async create(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await VerificationV2Mirror.create(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.create(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await VerificationV2Mirror.bulkCreate(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await VerificationV2Mirror.update(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.update(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await VerificationV2Mirror.upsert(values, mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
-    safeMirrorDbHandlerV2(async () => {
+    await mirrorWriteV2(async () => {
       const mirrorOptions = {
         ...options,
         transaction: options?.mirrorTransaction,
       };
       await VerificationV2Mirror.destroy(mirrorOptions);
-    });
+    }, options?.mirrorTransaction);
     const result = await super.destroy(options);
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;

--- a/src/tasks/sync-registries.js
+++ b/src/tasks/sync-registries.js
@@ -259,8 +259,15 @@ async function createAndProcessTransaction(callback, afterCommitCallbacks) {
         `encountered error syncing organization audit. Rolling back transaction. Error: ${error}`,
       );
       await transaction.rollback();
-      return false;
     }
+    if (mirrorTransaction) {
+      try {
+        await mirrorTransaction.rollback();
+      } catch (rollbackErr) {
+        logger.error(`mirror transaction rollback failed: ${rollbackErr.message}`);
+      }
+    }
+    return false;
   } finally {
     releaseTransactionMutex();
   }

--- a/src/tasks/sync-registries.js
+++ b/src/tasks/sync-registries.js
@@ -253,12 +253,15 @@ async function createAndProcessTransaction(callback, afterCommitCallbacks) {
 
     return true;
   } catch (error) {
-    // Roll back the transaction if an error occurs
+    logger.error(
+      `encountered error syncing organization audit. Rolling back transaction. Error: ${error}`,
+    );
     if (transaction) {
-      logger.error(
-        `encountered error syncing organization audit. Rolling back transaction. Error: ${error}`,
-      );
-      await transaction.rollback();
+      try {
+        await transaction.rollback();
+      } catch (rollbackErr) {
+        logger.error(`transaction rollback failed: ${rollbackErr.message}`);
+      }
     }
     if (mirrorTransaction) {
       try {


### PR DESCRIPTION
## Summary

- **Root cause**: `safeMirrorDbHandler` / `safeMirrorDbHandlerV2` resolve immediately via `finally { resolve() }` before the mirror write callback executes, making every mirror write fire-and-forget. When `createAndProcessTransaction` calls `mirrorTransaction.commit()`, the detached writes may not have completed, producing "commit has been called on this transaction" errors and leaving the mirror with stale data.
- **Fix**: Add `mirrorWrite` / `mirrorWriteV2` helpers that `await` the callback directly when a `mirrorTransaction` is provided, ensuring mirror writes complete before the transaction commits. Non-transactional writes (direct API calls) keep the existing fire-and-forget path.
- Roll back `mirrorTransaction` on error in `createAndProcessTransaction` to prevent connection pool leaks.
- Remove dead `safeMirrorDbHandlerV2` imports from all V2 model files.

## Files changed

- `src/database/index.js` — add `mirrorWrite` helper
- `src/database/v2/index.js` — add `mirrorWriteV2` helper
- `src/tasks/sync-registries.js` — add mirror transaction rollback on error
- 11 V1 model files — use `mirrorWrite` in `create`/`upsert`/`destroy`/`bulkCreate`
- 23 V2 model files — use `mirrorWriteV2` in `create`/`bulkCreate`/`update`/`upsert`/`destroy`

## Test plan

- [x] `npm run test:v1` — 127 passing, 5 pending (matches base branch)
- [x] `npm run test:v2` — 1552 passing, 3 failing (pre-existing project delete flakes, same as base branch)
- [ ] CI: v1 live API tests with MySQL mirror verification should pass consistently (previously flaky)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how mirror writes execute during the transactional sync path, affecting commit/rollback ordering across two databases; mistakes could cause partial mirror updates or longer transaction durations. Scope is broad (many models in both V1/V2) but behavior is largely preserved for non-transactional writes.
> 
> **Overview**
> **Eliminates a race between mirror writes and transaction commits** by introducing `mirrorWrite` / `mirrorWriteV2`, which run mirror write callbacks *synchronously* when an explicit `mirrorTransaction` is supplied, while keeping the existing fire-and-forget behavior for non-transactional writes.
> 
> Updates V1 and V2 models’ `create`/`bulkCreate`/`update`/`upsert`/`destroy` mirror paths to use these helpers so mirror mutations complete before `mirrorTransaction.commit()` in the sync flow.
> 
> Improves failure handling in `createAndProcessTransaction` (`sync-registries.js`) by rolling back both the primary `transaction` and the `mirrorTransaction` (with guarded error logging) on sync errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c15a2b6be8b623ad841d9650d9645a8068d2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->