### PR TITLE
chore(DATALAYER): demote existing-mirror log line to verbose

### DIFF
--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -311,7 +311,7 @@ const addMirrorInner = async (storeId, url, forceAddMirror) => {
   );
 
   if (mirror) {
-    logger.info(`Mirror already available for ${storeId} at ${url}`);
+    logger.verbose(`Mirror already available for ${storeId} at ${url}`);
     logger.silly('[MIRROR_DEBUG] Mirror already exists, returning true');
     return true;
   }


### PR DESCRIPTION
Reduce default `info` log noise during mirror checks: when the mirror URL is already registered for the store, log at `verbose` instead of `info`. Operators still see `Checking mirrors for storeID...` at `info`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes log verbosity for an already-handled control path and does not alter mirror creation behavior or RPC calls.
> 
> **Overview**
> Demotes the "mirror already available" message in `src/datalayer/persistance.js` from `logger.info` to `logger.verbose` when `addMirror` finds an existing mirror entry.
> 
> This keeps the code path and return value the same while reducing default `info`-level log noise during routine mirror checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795b44cbc0c565ec351c2c41d73f44c192377655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->