### PR TITLE
fix: upgrade express-rate-limit to 8.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3101,7 +3100,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3303,7 +3301,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3878,7 +3875,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4614,7 +4610,6 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4958,31 +4953,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -5233,7 +5203,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5556,7 +5525,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6493,9 +6461,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
+      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6777,7 +6745,6 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
       "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -8130,7 +8097,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10168,7 +10134,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "express-joi-validation": "^6.1.0",
-        "express-rate-limit": "^8.2.1",
+        "express-rate-limit": "^8.5.1",
         "joi": "^17.13.3",
         "js-yaml": "^4.1.1",
         "lodash": "^4.18.1",
@@ -5576,12 +5576,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6461,9 +6461,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "express-joi-validation": "^6.1.0",
-    "express-rate-limit": "^8.2.1",
+    "express-rate-limit": "^8.5.1",
     "joi": "^17.13.3",
     "js-yaml": "^4.1.1",
     "lodash": "^4.18.1",
@@ -123,7 +123,6 @@
   "overrides": {
     "diff": "8.0.3",
     "esbuild": "0.27.3",
-    "ip-address": "10.1.1",
     "tar": "7.5.13",
     "mocha": {
       "serialize-javascript": "7.0.5"

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
   "overrides": {
     "diff": "8.0.3",
     "esbuild": "0.27.3",
+    "ip-address": "10.1.1",
     "tar": "7.5.13",
     "mocha": {
       "serialize-javascript": "7.0.5"

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -20,6 +20,7 @@ import { Organization } from './models';
 import { OrganizationsV2 } from './models/v2/index.js';
 import { logger } from './config/logger.js';
 import { sendReadOnlyError } from './utils/read-only-response.js';
+import { getRateLimitRetryAfterSeconds } from './utils/rate-limit.js';
 
 const { USE_SIMULATOR } = getConfig().APP;
 
@@ -68,7 +69,7 @@ const generalLimiter = rateLimit({
       message: 'Too many requests. Please slow down and try again later.',
       error: 'RATE_LIMIT_EXCEEDED',
       success: false,
-      retryAfter: Math.ceil(req.rateLimit.resetTime / 1000), // seconds until reset
+      retryAfter: getRateLimitRetryAfterSeconds(req.rateLimit?.resetTime),
     });
   },
 });

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -1,0 +1,12 @@
+export const getRateLimitRetryAfterSeconds = (resetTime, now = Date.now()) => {
+  if (!(resetTime instanceof Date)) {
+    return 0;
+  }
+
+  const resetTimestamp = resetTime.getTime();
+  if (Number.isNaN(resetTimestamp)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.ceil((resetTimestamp - now) / 1000));
+};

--- a/tests/resources/rate-limit.spec.js
+++ b/tests/resources/rate-limit.spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { getRateLimitRetryAfterSeconds } from '../../src/utils/rate-limit.js';
+
+describe('Rate limit utilities', function () {
+  it('returns seconds remaining until reset', function () {
+    const now = 1_700_000_000_000;
+    const resetTime = new Date(now + 4_500);
+
+    expect(getRateLimitRetryAfterSeconds(resetTime, now)).to.equal(5);
+  });
+
+  it('returns zero when the reset time has already passed', function () {
+    const now = 1_700_000_000_000;
+    const resetTime = new Date(now - 1_000);
+
+    expect(getRateLimitRetryAfterSeconds(resetTime, now)).to.equal(0);
+  });
+
+  it('returns zero when reset time is missing or invalid', function () {
+    expect(getRateLimitRetryAfterSeconds()).to.equal(0);
+    expect(getRateLimitRetryAfterSeconds(new Date('invalid date'))).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary
- upgrade `express-rate-limit` to `^8.5.1` and remove the temporary `ip-address` override so the patched dependency is resolved through the direct package update
- keep the CADT limiter configuration compatible with the upstream changes: `8.3.2` only adjusts `skipFailedRequests`, `8.4.1` adds an optional logger, and `8.5.0` adds async store init handling; CADT uses none of those options and still uses the default store
- fix CADT's custom 429 `retryAfter` payload to return seconds remaining instead of the absolute reset timestamp, and add focused regression coverage for that helper

## Test plan
- [x] `eval "$(fnm env)" && fnm use && npm audit --omit=dev --json`
- [x] `eval "$(fnm env)" && fnm use && npm ls express-rate-limit ip-address`
- [x] `eval "$(fnm env)" && fnm use && npx mocha --loader node_modules/extensionless/src/register.js tests/resources/rate-limit.spec.js --reporter spec --exit --timeout 300000`
- [x] `eval "$(fnm env)" && fnm use && npm run test:v1`
- [x] `eval "$(fnm env)" && fnm use && npm run test:v2`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `express-rate-limit` dependency (and transitive `ip-address`) and changes the 429 response payload calculation, which could subtly affect rate-limiting behavior and client backoff handling.
> 
> **Overview**
> Bumps `express-rate-limit` to `^8.5.1` (and updates related lockfile resolutions, including `ip-address`), regenerating `package-lock.json` accordingly.
> 
> Hardens the API’s 429 response by computing `retryAfter` via a new `getRateLimitRetryAfterSeconds` helper (handles missing/invalid `resetTime` safely) and adds unit tests for the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec3e31afb8e01983ede3075aef5e40dbf246c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->