### PR TITLE
fix: persist v1/v2 org-creation progress incrementally and fix v2 helper endpoint

### DIFF
--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -51,6 +51,7 @@ import {
   loadCreationState,
   clearCreationState,
   hasInProgressCreation,
+  createIncrementalStateWriter,
 } from '../../utils/organization-creation-state.js';
 import { mirrorOrgStores } from '../../tasks/mirror-check.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
@@ -497,18 +498,39 @@ class Organization extends Model {
     const maxRetries = 10;
     const retryDelayMs = 30000;
 
-    // Create all stores in parallel, each with independent retry logic
+    // Persist each successful store creation immediately so the
+    // /v1/organizations/creation-status endpoint reflects partial progress.
+    // Without this, all 4 stores stay marked pending until the slowest
+    // promise resolves, which makes the live-api "stuck state" detector
+    // fire while the server is still actively making progress.
+    const stateWriter = createIncrementalStateWriter(state, Meta);
+
+    // Create all stores in parallel, each with independent retry logic.
+    // The persist call is wrapped in its own try so that a transient
+    // saveCreationState failure (DB busy, sequelize hiccup) does NOT
+    // mask a successful on-chain store creation as a creation failure;
+    // any missing persist will be reconciled in a final save below.
     const createPromises = storesToCreate.map(async (storeType) => {
       for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
-          logState(state, `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
+          logState(stateWriter.getCurrent(), `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
           const storeId = await datalayer.createDataLayerStoreWithRetry();
-          logState(state, `Created ${storeType} store: ${storeId}`);
+          logState(stateWriter.getCurrent(), `Created ${storeType} store: ${storeId}`);
+          try {
+            await stateWriter.persistStoreCreated(storeType, storeId);
+          } catch (persistError) {
+            logState(
+              stateWriter.getCurrent(),
+              `Created ${storeType} store ${storeId} but failed to persist incremental progress: ` +
+                `${persistError.message}. Store id retained in result; final save will reconcile.`,
+              'warn',
+            );
+          }
           return { storeType, storeId, success: true };
         } catch (error) {
           if (isTransientWalletError(error) && attempt < maxRetries) {
             logState(
-              state,
+              stateWriter.getCurrent(),
               `Transient error creating ${storeType} store ` +
                 `(attempt ${attempt}/${maxRetries}): ${error.message}. ` +
                 `Retrying in ${retryDelayMs / 1000}s...`,
@@ -517,7 +539,7 @@ class Organization extends Model {
             await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
             continue;
           }
-          logState(state, `Failed to create ${storeType} store: ${error.message}`, 'error');
+          logState(stateWriter.getCurrent(), `Failed to create ${storeType} store: ${error.message}`, 'error');
           return { storeType, storeId: null, success: false, error: error.message };
         }
       }
@@ -526,13 +548,21 @@ class Organization extends Model {
 
     const results = await Promise.all(createPromises);
 
-    // Update state with created store IDs
+    // Reconcile: pick up incremental updates that already landed, then
+    // re-apply any successful storeIds whose persist failed mid-flight.
+    // A single final saveCreationState makes sure the persisted view
+    // matches in-memory state before returning.
+    state = stateWriter.getCurrent();
+    let reconcileNeeded = false;
     for (const result of results) {
-      if (result.success) {
+      if (result.success && state.stores[result.storeType].id !== result.storeId) {
         state = markStoreCreated(state, result.storeType, result.storeId);
+        reconcileNeeded = true;
       }
     }
-    await saveCreationState(state, Meta);
+    if (reconcileNeeded) {
+      await saveCreationState(state, Meta);
+    }
 
     // Check if all stores were created
     const failed = results.filter((r) => !r.success);

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -70,6 +70,7 @@ import {
   loadCreationState,
   clearCreationState,
   hasInProgressCreation,
+  createIncrementalStateWriter,
 } from '../../utils/organization-creation-state.js';
 
 import ModelTypes from './organizations-v2.modeltypes.js';
@@ -523,18 +524,39 @@ class OrganizationsV2 extends Model {
     const maxRetries = 10;
     const retryDelayMs = 30000;
 
-    // Create all stores in parallel, each with independent retry logic
+    // Persist each successful store creation immediately so the
+    // /v2/organizations/creation-status endpoint reflects partial progress.
+    // Without this, all 4 stores stay marked pending until the slowest
+    // promise resolves, which makes the live-api "stuck state" detector
+    // fire while the server is still actively making progress.
+    const stateWriter = createIncrementalStateWriter(state, MetaV2);
+
+    // Create all stores in parallel, each with independent retry logic.
+    // The persist call is wrapped in its own try so that a transient
+    // saveCreationState failure (DB busy, sequelize hiccup) does NOT
+    // mask a successful on-chain store creation as a creation failure;
+    // any missing persist will be reconciled in a final save below.
     const createPromises = storesToCreate.map(async (storeType) => {
       for (let attempt = 1; attempt <= maxRetries; attempt++) {
         try {
-          logState(state, `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
+          logState(stateWriter.getCurrent(), `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
           const storeId = await datalayer.createDataLayerStoreWithRetry();
-          logState(state, `Created ${storeType} store: ${storeId}`);
+          logState(stateWriter.getCurrent(), `Created ${storeType} store: ${storeId}`);
+          try {
+            await stateWriter.persistStoreCreated(storeType, storeId);
+          } catch (persistError) {
+            logState(
+              stateWriter.getCurrent(),
+              `Created ${storeType} store ${storeId} but failed to persist incremental progress: ` +
+                `${persistError.message}. Store id retained in result; final save will reconcile.`,
+              'warn',
+            );
+          }
           return { storeType, storeId, success: true };
         } catch (error) {
           if (isTransientWalletError(error) && attempt < maxRetries) {
             logState(
-              state,
+              stateWriter.getCurrent(),
               `Transient error creating ${storeType} store ` +
                 `(attempt ${attempt}/${maxRetries}): ${error.message}. ` +
                 `Retrying in ${retryDelayMs / 1000}s...`,
@@ -543,7 +565,7 @@ class OrganizationsV2 extends Model {
             await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
             continue;
           }
-          logState(state, `Failed to create ${storeType} store: ${error.message}`, 'error');
+          logState(stateWriter.getCurrent(), `Failed to create ${storeType} store: ${error.message}`, 'error');
           return { storeType, storeId: null, success: false, error: error.message };
         }
       }
@@ -552,13 +574,21 @@ class OrganizationsV2 extends Model {
 
     const results = await Promise.all(createPromises);
 
-    // Update state with created store IDs
+    // Reconcile: pick up incremental updates that already landed, then
+    // re-apply any successful storeIds whose persist failed mid-flight.
+    // A single final saveCreationState makes sure the persisted view
+    // matches in-memory state before returning.
+    state = stateWriter.getCurrent();
+    let reconcileNeeded = false;
     for (const result of results) {
-      if (result.success) {
+      if (result.success && state.stores[result.storeType].id !== result.storeId) {
         state = markStoreCreated(state, result.storeType, result.storeId);
+        reconcileNeeded = true;
       }
     }
-    await saveCreationState(state, MetaV2);
+    if (reconcileNeeded) {
+      await saveCreationState(state, MetaV2);
+    }
 
     // Check if all stores were created
     const failed = results.filter((r) => !r.success);

--- a/src/utils/organization-creation-state.js
+++ b/src/utils/organization-creation-state.js
@@ -14,6 +14,8 @@
  * - FAILED: Organization creation failed after max retries
  */
 
+import { Mutex } from 'async-mutex';
+
 import { logger, loggerV2 } from '../config/logger.js';
 
 // State constants
@@ -477,4 +479,46 @@ export const hasInProgressCreation = async (MetaModel, apiVersion) => {
     return false;
   }
   return true;
+};
+
+/**
+ * Creates a mutex-protected state writer that lets multiple concurrent
+ * store-creation promises in `_createStoresInParallel` mark each
+ * successful creation immediately and persist it to the Meta table
+ * without clobbering each other's updates.
+ *
+ * Without this helper, `state` is a closure variable that each promise
+ * would read-then-overwrite at the end of `Promise.all`, so the
+ * /v{1,2}/organizations/creation-status endpoint cannot reflect partial
+ * progress until the slowest store finishes. That made the live-api
+ * "stuck state" detector fire in cases where 1-3 of the 4 stores were
+ * actually completing on the server side.
+ *
+ * @param {Object} initialState - Starting state object
+ * @param {Object} MetaModel - The Meta model to persist into (Meta or MetaV2)
+ * @returns {{ persistStoreCreated: Function, getCurrent: Function }}
+ */
+export const createIncrementalStateWriter = (initialState, MetaModel) => {
+  const stateRef = { current: initialState };
+  const stateMutex = new Mutex();
+
+  const persistStoreCreated = async (storeType, storeId) => {
+    const release = await stateMutex.acquire();
+    try {
+      // Compute the next state, persist it first, and only update the
+      // shared reference if the write succeeds. If saveCreationState
+      // throws, stateRef.current still matches what is on disk, which
+      // keeps the in-memory and persisted views consistent for any
+      // other reader that picks up the writer mid-flight.
+      const next = markStoreCreated(stateRef.current, storeType, storeId);
+      await saveCreationState(next, MetaModel);
+      stateRef.current = next;
+    } finally {
+      release();
+    }
+  };
+
+  const getCurrent = () => stateRef.current;
+
+  return { persistStoreCreated, getCurrent };
 };

--- a/tests/v2/integration/organization-creation-status-v2.spec.js
+++ b/tests/v2/integration/organization-creation-status-v2.spec.js
@@ -19,6 +19,7 @@ import {
   markStoreConfirmed,
   markStoreDataWritten,
   STORE_TYPES,
+  createIncrementalStateWriter,
 } from '../../../src/utils/organization-creation-state.js';
 
 const { USE_SIMULATOR } = getConfig().APP;
@@ -175,6 +176,160 @@ describe('Organization Creation Status Tests', function () {
 
       const inProgress = await hasInProgressCreation(MetaV2, 'v2');
       expect(inProgress).to.be.false;
+    });
+  });
+
+  describe('createIncrementalStateWriter', function () {
+    it('should persist each store creation immediately so partial progress is visible', async function () {
+      // Simulates the production race: 4 parallel store-creation promises
+      // resolve at different times, and the live-api stuck-state detector
+      // polls the creation-status endpoint between them. With the writer,
+      // each completion makes the next poll see new progress and reset
+      // the detector's timer.
+      const initialState = createInitialState('Incremental V2 Org', '', 'v2', 'v2');
+      initialState.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(initialState, MetaV2);
+
+      const writer = createIncrementalStateWriter(initialState, MetaV2);
+
+      const storeIds = {
+        [STORE_TYPES.ORG_UID]: 'orgUid-id',
+        [STORE_TYPES.REGISTRY]: 'registry-id',
+        [STORE_TYPES.DATA_MODEL_VERSION]: 'dataModelVersion-id',
+        [STORE_TYPES.FILE_STORE]: 'fileStore-id',
+      };
+      const orderOfCompletion = [
+        STORE_TYPES.REGISTRY,
+        STORE_TYPES.DATA_MODEL_VERSION,
+        STORE_TYPES.ORG_UID,
+        STORE_TYPES.FILE_STORE,
+      ];
+
+      const persistedAfterEach = [];
+      for (const storeType of orderOfCompletion) {
+        await writer.persistStoreCreated(storeType, storeIds[storeType]);
+        const persisted = await loadCreationState(MetaV2, 'v2');
+        persistedAfterEach.push(persisted);
+      }
+
+      // After 1st write the registry is set and the rest are still null.
+      expect(persistedAfterEach[0].stores[STORE_TYPES.REGISTRY].id).to.equal('registry-id');
+      expect(persistedAfterEach[0].stores[STORE_TYPES.ORG_UID].id).to.be.null;
+      expect(persistedAfterEach[0].stores[STORE_TYPES.DATA_MODEL_VERSION].id).to.be.null;
+      expect(persistedAfterEach[0].stores[STORE_TYPES.FILE_STORE].id).to.be.null;
+
+      // After 2nd write registry + dataModelVersion are set.
+      expect(persistedAfterEach[1].stores[STORE_TYPES.REGISTRY].id).to.equal('registry-id');
+      expect(persistedAfterEach[1].stores[STORE_TYPES.DATA_MODEL_VERSION].id).to.equal('dataModelVersion-id');
+      expect(persistedAfterEach[1].stores[STORE_TYPES.ORG_UID].id).to.be.null;
+      expect(persistedAfterEach[1].stores[STORE_TYPES.FILE_STORE].id).to.be.null;
+
+      // After 3rd write three of four are set.
+      expect(persistedAfterEach[2].stores[STORE_TYPES.ORG_UID].id).to.equal('orgUid-id');
+      expect(persistedAfterEach[2].stores[STORE_TYPES.FILE_STORE].id).to.be.null;
+
+      // Final state: all four set, in-memory and persisted match.
+      const final = persistedAfterEach[3];
+      expect(final.stores[STORE_TYPES.ORG_UID].id).to.equal('orgUid-id');
+      expect(final.stores[STORE_TYPES.REGISTRY].id).to.equal('registry-id');
+      expect(final.stores[STORE_TYPES.DATA_MODEL_VERSION].id).to.equal('dataModelVersion-id');
+      expect(final.stores[STORE_TYPES.FILE_STORE].id).to.equal('fileStore-id');
+
+      const current = writer.getCurrent();
+      expect(current.stores[STORE_TYPES.ORG_UID].id).to.equal('orgUid-id');
+      expect(current.stores[STORE_TYPES.REGISTRY].id).to.equal('registry-id');
+      expect(current.stores[STORE_TYPES.DATA_MODEL_VERSION].id).to.equal('dataModelVersion-id');
+      expect(current.stores[STORE_TYPES.FILE_STORE].id).to.equal('fileStore-id');
+    });
+
+    it('should preserve all updates when persistStoreCreated calls are awaited in Promise.all', async function () {
+      // Sanity check that running the four writes in parallel via
+      // Promise.all does not lose any of them and that both the
+      // in-memory and persisted views agree at the end. This isn't a
+      // strict regression guard against removing the mutex (single-
+      // threaded JS plus serialised SQLite writes would still produce
+      // the same final state in many cases), but it does protect
+      // against any future change that reorders the snapshot/persist
+      // steps such that an early failure would leave a fake storeId
+      // in the in-memory state.
+      const initialState = createInitialState('Concurrent V2 Org', '', 'v2', 'v2');
+      initialState.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(initialState, MetaV2);
+
+      const writer = createIncrementalStateWriter(initialState, MetaV2);
+
+      await Promise.all([
+        writer.persistStoreCreated(STORE_TYPES.ORG_UID, 'concurrent-org-uid'),
+        writer.persistStoreCreated(STORE_TYPES.REGISTRY, 'concurrent-registry'),
+        writer.persistStoreCreated(STORE_TYPES.DATA_MODEL_VERSION, 'concurrent-dmv'),
+        writer.persistStoreCreated(STORE_TYPES.FILE_STORE, 'concurrent-filestore'),
+      ]);
+
+      const current = writer.getCurrent();
+      expect(current.stores[STORE_TYPES.ORG_UID].id).to.equal('concurrent-org-uid');
+      expect(current.stores[STORE_TYPES.REGISTRY].id).to.equal('concurrent-registry');
+      expect(current.stores[STORE_TYPES.DATA_MODEL_VERSION].id).to.equal('concurrent-dmv');
+      expect(current.stores[STORE_TYPES.FILE_STORE].id).to.equal('concurrent-filestore');
+
+      const persisted = await loadCreationState(MetaV2, 'v2');
+      expect(persisted.stores[STORE_TYPES.ORG_UID].id).to.equal('concurrent-org-uid');
+      expect(persisted.stores[STORE_TYPES.REGISTRY].id).to.equal('concurrent-registry');
+      expect(persisted.stores[STORE_TYPES.DATA_MODEL_VERSION].id).to.equal('concurrent-dmv');
+      expect(persisted.stores[STORE_TYPES.FILE_STORE].id).to.equal('concurrent-filestore');
+    });
+
+    it('should NOT update stateRef.current when saveCreationState fails', async function () {
+      // Ensures the writer keeps its in-memory state in sync with what
+      // is on disk: if persistence throws, the storeId we just tried to
+      // record is NOT silently kept in stateRef.current. This is what
+      // lets a caller treat a failed persist as "store creation failed"
+      // without leaking a half-applied update.
+      const initialState = createInitialState('Failing Persist Org', '', 'v2', 'v2');
+      initialState.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(initialState, MetaV2);
+
+      const writer = createIncrementalStateWriter(initialState, MetaV2);
+
+      const failingMeta = {
+        findOne: async () => { throw new Error('simulated DB outage'); },
+        update: async () => { throw new Error('simulated DB outage'); },
+        create: async () => { throw new Error('simulated DB outage'); },
+      };
+      const failingWriter = createIncrementalStateWriter(initialState, failingMeta);
+
+      try {
+        await failingWriter.persistStoreCreated(STORE_TYPES.ORG_UID, 'should-not-leak');
+        expect.fail('persistStoreCreated should have thrown');
+      } catch (e) {
+        expect(e.message).to.include('simulated DB outage');
+      }
+
+      // In-memory state must not contain the un-persisted storeId.
+      expect(failingWriter.getCurrent().stores[STORE_TYPES.ORG_UID].id).to.be.null;
+
+      // Original successful writer is unaffected.
+      await writer.persistStoreCreated(STORE_TYPES.ORG_UID, 'good-id');
+      expect(writer.getCurrent().stores[STORE_TYPES.ORG_UID].id).to.equal('good-id');
+      const persisted = await loadCreationState(MetaV2, 'v2');
+      expect(persisted.stores[STORE_TYPES.ORG_UID].id).to.equal('good-id');
+    });
+
+    it('should also work for V1 (Meta model)', async function () {
+      const initialState = createInitialState('Incremental V1 Org', '', 'v1', 'v1');
+      initialState.state = ORG_CREATION_STATES.STORES_CREATING;
+      await saveCreationState(initialState, Meta);
+
+      const writer = createIncrementalStateWriter(initialState, Meta);
+
+      await writer.persistStoreCreated(STORE_TYPES.ORG_UID, 'v1-org-uid');
+      let persisted = await loadCreationState(Meta, 'v1');
+      expect(persisted.stores[STORE_TYPES.ORG_UID].id).to.equal('v1-org-uid');
+      expect(persisted.stores[STORE_TYPES.REGISTRY].id).to.be.null;
+
+      await writer.persistStoreCreated(STORE_TYPES.REGISTRY, 'v1-registry');
+      persisted = await loadCreationState(Meta, 'v1');
+      expect(persisted.stores[STORE_TYPES.ORG_UID].id).to.equal('v1-org-uid');
+      expect(persisted.stores[STORE_TYPES.REGISTRY].id).to.equal('v1-registry');
     });
   });
 

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -1190,7 +1190,7 @@ export const getLiveApiRequest = async (options = {}) => {
 /**
  * Wait for V2 organization to be created and ready
  * Polls GET /v2/organizations until organization appears and is synced
- * Also checks /v2/organizations/status for creation progress details
+ * Also checks /v2/organizations/creation-status for creation progress details
  * @param {Object} request - supertest request instance
  * @param {string} [orgName] - Optional organization name to match (if not provided, finds home org)
  * @param {number} maxWaitTime - Maximum wait time in milliseconds (default: 900000 = 15 minutes)
@@ -1221,16 +1221,27 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
   const noProgressThreshold = isUpgrade ? 60 : 6;
   let lastState = null;
   let lastStateChangeTime = Date.now();
-  const stuckStateThresholdMs = 300000;
+  // 10 min: V1/V2 org creation can legitimately take 5+ min when wallet
+  // sync transients trigger 30s retry backoffs and per-store blockchain
+  // confirmation polling. The server-side incremental state persistence
+  // means stateKey changes whenever any of the 4 stores transitions, so
+  // this only fires when no store has progressed for the full window.
+  const stuckStateThresholdMs = 600000;
 
   while (Date.now() - startTime < maxWaitTime) {
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
     let creationInProgress = false;
 
     try {
-      // First, check creation status endpoint for detailed progress
+      // First, check creation status endpoint for detailed progress.
+      // Note: this MUST be /v2/organizations/creation-status (returns
+      // {state, stores, inProgress, error}). The other endpoint
+      // /v2/organizations/status is homeOrgSyncStatus and returns
+      // {ready, status, success} — using it here makes status.state
+      // and status.stores undefined and silently disables both the
+      // FAILED-fast-fail and the stuck-state detector below.
       try {
-        const statusResponse = await request.get('/v2/organizations/status');
+        const statusResponse = await request.get('/v2/organizations/creation-status');
         if (statusResponse.status === 200 && statusResponse.body) {
           const status = statusResponse.body;
 
@@ -1384,7 +1395,7 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
 
             // Try to get more details about what went wrong
             try {
-              const statusResponse = await request.get('/v2/organizations/status');
+              const statusResponse = await request.get('/v2/organizations/creation-status');
               if (statusResponse.body) {
                 console.log(`  Final status: ${JSON.stringify(statusResponse.body, null, 2)}`);
               }
@@ -1408,7 +1419,7 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
 
                 // Try to get status
                 try {
-                  const statusResponse = await request.get('/v2/organizations/status');
+                  const statusResponse = await request.get('/v2/organizations/creation-status');
                   if (statusResponse.body) {
                     console.log(`  Final status: ${JSON.stringify(statusResponse.body, null, 2)}`);
                   }
@@ -1473,7 +1484,7 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
 
   // Also try to get final creation status
   try {
-    const finalStatusResponse = await request.get('/v2/organizations/status');
+    const finalStatusResponse = await request.get('/v2/organizations/creation-status');
     if (finalStatusResponse.status === 200 && finalStatusResponse.body) {
       console.log(`Final creation status: ${JSON.stringify(finalStatusResponse.body, null, 2)}`);
     }
@@ -1515,7 +1526,12 @@ export const waitForV1OrganizationReady = async (request, orgName = null, maxWai
   const noProgressThreshold = 6;
   let lastState = null;
   let lastStateChangeTime = Date.now();
-  const stuckStateThresholdMs = 300000;
+  // 10 min: V1/V2 org creation can legitimately take 5+ min when wallet
+  // sync transients trigger 30s retry backoffs and per-store blockchain
+  // confirmation polling. The server-side incremental state persistence
+  // means stateKey changes whenever any of the 4 stores transitions, so
+  // this only fires when no store has progressed for the full window.
+  const stuckStateThresholdMs = 600000;
 
   while (Date.now() - startTime < maxWaitTime) {
     const elapsed = Math.floor((Date.now() - startTime) / 1000);

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -1307,8 +1307,17 @@ export const waitForV2OrganizationReady = async (request, orgName = null, maxWai
           }
         }
       } catch (statusError) {
-        // Re-throw stuck state errors
-        if (statusError.message?.includes('appears stuck')) {
+        // Re-throw terminal errors we explicitly threw above (FAILED
+        // state, stuck-state) so the outer org-list catch can decide
+        // what to do with them. HTTP-level errors from the status
+        // endpoint (e.g. 404 on older builds, transient 5xx) fall
+        // through and are silently logged so the loop can keep
+        // polling the org list.
+        if (
+          statusError.message?.includes('Organization creation failed') ||
+          statusError.message?.includes('appears stuck') ||
+          statusError.message?.includes('creation FAILED')
+        ) {
           throw statusError;
         }
         // Status endpoint might not exist or may fail - that's okay
@@ -1606,8 +1615,17 @@ export const waitForV1OrganizationReady = async (request, orgName = null, maxWai
           }
         }
       } catch (statusError) {
-        // Re-throw stuck state errors
-        if (statusError.message?.includes('appears stuck')) {
+        // Re-throw terminal errors we explicitly threw above (FAILED
+        // state, stuck-state) so the outer org-list catch can decide
+        // what to do with them. HTTP-level errors from the status
+        // endpoint (e.g. 404 on older builds, transient 5xx) fall
+        // through and are silently logged so the loop can keep
+        // polling the org list.
+        if (
+          statusError.message?.includes('Organization creation failed') ||
+          statusError.message?.includes('appears stuck') ||
+          statusError.message?.includes('creation FAILED')
+        ) {
           throw statusError;
         }
         // Status endpoint might not exist or may fail - that's okay


### PR DESCRIPTION
## Summary

Fixes the v1-to-v2 upgrade test (and any other live-api test that relies on `waitForV{1,2}OrganizationReady`) when V1/V2 home org creation legitimately needs more than 5 minutes — which it does whenever a transient wallet desync forces 30s retry backoffs in `createDataLayerStoreWithRetry` plus per-store blockchain-confirmation polling.

This was the root cause of [run 25574422326's `v1 to v2 upgrade test` failure](https://github.com/Chia-Network/cadt/actions/runs/25574422326/job/75077942083?pr=1621): the CADT server was actively making progress (one V1 store created, another waiting for confirmation) when the test gave up at exactly 305s.

### Server-side fix: incremental state persistence

`_createStoresInParallel` (V1 `organizations.model.js`, V2 `organizations-v2.model.js`) used to persist store-id state via a single `saveCreationState` call after `Promise.all` resolved. A slow store hid the other 3 successful creations from `GET /v{1,2}/organizations/creation-status`, so the live-api stuck-state detector fired even though the server was working.

Introduce `createIncrementalStateWriter` in `src/utils/organization-creation-state.js`:

- Mutex-protected (via `async-mutex`) so concurrent persists don't clobber each other.
- Snapshot-then-persist: `saveCreationState` is awaited BEFORE updating the shared `stateRef.current`, so a save failure never leaves the in-memory and persisted views inconsistent.
- A persist failure inside `_createStoresInParallel` is no longer treated as a creation failure: the on-chain `storeId` is retained in the per-store result and reconciled in a single final save before returning. This prevents the previous worst-case where a transient SQLite hiccup would cause us to throw `Failed to create stores: <type>` for an actually-created store and leak it on retry.

### Test-side fixes

1. **Bump `stuckStateThresholdMs` from 5 min → 10 min** in both `waitForV1OrganizationReady` and `waitForV2OrganizationReady` (`tests/v2/live-api/helpers/live-api-helpers.js`). Realistic V1/V2 org creation can take 5+ min when wallet sync transients trigger 30s retry backoffs and per-store confirmation polling. With the new server-side incremental persistence, the threshold only fires when no store has progressed for the full window.
2. **Fix V2 helper polling the wrong endpoint.** `waitForV2OrganizationReady` was polling `/v2/organizations/status` (which is `homeOrgSyncStatus`, returning `{ready, status, success}`) instead of `/v2/organizations/creation-status` (which returns `{state, stores, inProgress, error}`). The wrong endpoint silently disabled both the FAILED-fast-fail and the stuck-state detector for V2. All four occurrences were updated; the V1 helper was already correct.

### New tests

`tests/v2/integration/organization-creation-status-v2.spec.js` adds a `createIncrementalStateWriter` describe block with four tests covering:

- Each persist immediately reflects in `loadCreationState` (V2 `MetaV2`)
- Concurrent `Promise.all` of four persists preserves all updates in both in-memory and persisted views
- V1 (`Meta` model) variant
- A failing persist (mock `MetaModel` whose CRUD throws) does NOT update `stateRef.current`, so the rollback invariant holds

## Test plan

- [x] Targeted: `tests/v2/integration/organization-creation-status-v2.spec.js` (32 passing, +4 new)
- [x] Full V1 integration suite (`npm run test:v1`): 143 passing
- [x] Full V2 integration suite (`npm run test:v2`): 1573 passing
- [x] Adversarial pre-push diff review (fresh-context subagent): 1 warning + 3 info on round 1 (warning fixed, others addressed); 1 warning + 3 info on round 2 (warning fixed); residual info-level items deferred (e.g. `_pushDataInParallel` could use the same writer; deferred to a follow-up since the data-push phase has a different per-step bound)
- [ ] CI live-api pipeline against this branch — primary regression target is `v1 to v2 upgrade test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org-creation state persistence during parallel store creation for both v1/v2, which affects a critical provisioning flow and adds additional Meta-table writes under concurrency. Risk is mitigated by mutex protection and new integration coverage, but regressions could still impact creation/resume behavior.
> 
> **Overview**
> **Organization creation now persists partial progress during parallel store creation (v1 + v2).** `_createStoresInParallel` updates the persisted creation state after each store is successfully created so `/v{1,2}/organizations/creation-status` can reflect real-time progress instead of waiting for `Promise.all` to finish.
> 
> This introduces `createIncrementalStateWriter` (mutex-protected) to safely persist per-store updates without concurrent clobbering, and adds reconciliation logic to ensure a final persisted state matches in-memory results even if an incremental `saveCreationState` fails mid-flight.
> 
> **Tests/helpers updated for reliability.** Adds integration tests covering the incremental writer (sequential, concurrent, and failure cases; v1+v2), fixes `waitForV2OrganizationReady` to poll `/v2/organizations/creation-status` (not `/v2/organizations/status`), and increases the stuck-state threshold from 5 to 10 minutes in the live-api wait helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db63b08163f9fa03d081880fc5ea4231d1776393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->