### PR TITLE
feat(API): add /diagnostics endpoint for system-wide debug snapshot

### DIFF
--- a/src/datalayer/fullNodeRpc.js
+++ b/src/datalayer/fullNodeRpc.js
@@ -14,6 +14,8 @@ import fs from 'fs';
 import path from 'path';
 import superagent from 'superagent';
 
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
+
 import _ from 'lodash';
 
 import { getChiaConfig } from './fullNode.js';

--- a/src/datalayer/fullNodeRpc.js
+++ b/src/datalayer/fullNodeRpc.js
@@ -86,7 +86,7 @@ export const getBlockchainState = async (options = {}) => {
       synced: state.sync?.synced === true,
       syncing: state.sync?.sync_mode === true,
       peakHeight: state.peak?.height ?? null,
-      syncMode: state.sync?.sync_mode === true ? 'syncing' : state.sync?.synced ? 'synced' : 'not_synced',
+      syncMode: state.sync?.sync_mode === true ? 'syncing' : state.sync?.synced === true ? 'synced' : 'not_synced',
       genesisChallengeInitialized: state.genesis_challenge_initialized ?? null,
     };
   } catch (error) {

--- a/src/datalayer/fullNodeRpc.js
+++ b/src/datalayer/fullNodeRpc.js
@@ -1,0 +1,126 @@
+/**
+ * Minimal RPC client for the locally-running chia full-node, used only by
+ * the /diagnostics endpoint. CADT does not depend on the full node for any
+ * other functionality; this client exists so we can answer "is the full
+ * node running locally, and if so is it synced?".
+ *
+ * Like the wallet client, we use mTLS with the standard chia SSL files
+ * under `${chiaRoot}/config/ssl/full_node/`. If those files are missing
+ * (e.g. on a CADT-only host), the helpers return `{ reachable: false }`
+ * instead of throwing.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import superagent from 'superagent';
+
+import _ from 'lodash';
+
+import { getChiaConfig } from './fullNode.js';
+import { getChiaRoot } from '../utils/chia-root.js';
+import { getActiveConfig } from '../utils/config-loader.js';
+import { logger } from '../config/logger.js';
+
+const DEFAULT_FULL_NODE_RPC_PORT = 8555;
+// 10s matches the outer settle() default in routes/diagnostics.js. A full node
+// catching up under heavy load can take several seconds to answer
+// get_blockchain_state, and falsely tagging it unreachable is worse than
+// waiting a bit longer.
+const DEFAULT_TIMEOUT_MS = 10000;
+
+const getCertificateFolderPath = () => {
+  const chiaRoot = getChiaRoot();
+  const overridden = getActiveConfig()?.APP?.CERTIFICATE_FOLDER_PATH;
+  return overridden || `${chiaRoot}/config/ssl`;
+};
+
+const getRpcPort = () => {
+  try {
+    const chiaConfig = getChiaConfig();
+    return _.get(chiaConfig, 'full_node.rpc_port', DEFAULT_FULL_NODE_RPC_PORT);
+  } catch (error) {
+    logger.debug(`[diagnostics]: could not read chia config for full-node rpc_port: ${error.message}`);
+    return DEFAULT_FULL_NODE_RPC_PORT;
+  }
+};
+
+const buildRpcUrl = () => `https://localhost:${getRpcPort()}`;
+
+const loadFullNodeCerts = () => {
+  const certificateFolderPath = getCertificateFolderPath();
+  const certFile = path.resolve(`${certificateFolderPath}/full_node/private_full_node.crt`);
+  const keyFile = path.resolve(`${certificateFolderPath}/full_node/private_full_node.key`);
+  return {
+    cert: fs.readFileSync(certFile),
+    key: fs.readFileSync(keyFile),
+  };
+};
+
+const callRpc = async (endpoint, payload = {}, { timeout = DEFAULT_TIMEOUT_MS } = {}) => {
+  const url = `${buildRpcUrl()}${endpoint}`;
+  const { cert, key } = loadFullNodeCerts();
+  const response = await superagent
+    .post(url)
+    .key(key)
+    .cert(cert)
+    .timeout(timeout)
+    .send(payload);
+  return response.body || JSON.parse(response.text);
+};
+
+/**
+ * Fetch full-node blockchain state.
+ * @returns {Promise<Object>} `{ reachable, synced, syncing, peakHeight, syncMode, error? }`
+ */
+export const getBlockchainState = async (options = {}) => {
+  const rpcUrl = buildRpcUrl();
+  try {
+    const data = await callRpc('/get_blockchain_state', {}, options);
+    if (!data?.success) {
+      return { rpcUrl, reachable: true, error: data?.error || 'unknown error' };
+    }
+    const state = data.blockchain_state || {};
+    return {
+      rpcUrl,
+      reachable: true,
+      synced: state.sync?.synced === true,
+      syncing: state.sync?.sync_mode === true,
+      peakHeight: state.peak?.height ?? null,
+      syncMode: state.sync?.sync_mode === true ? 'syncing' : state.sync?.synced ? 'synced' : 'not_synced',
+      genesisChallengeInitialized: state.genesis_challenge_initialized ?? null,
+    };
+  } catch (error) {
+    logger.debug(`[diagnostics]: full-node get_blockchain_state failed: ${error.message}`);
+    return { rpcUrl, reachable: false, error: error.message };
+  }
+};
+
+/**
+ * Fetch full-node peer connections. We only return the host strings; CADT
+ * never needs to act on peer details. Used to count outbound peers for the
+ * diagnostics view.
+ * @returns {Promise<{rpcUrl: string, reachable: boolean, connections?: Array, error?: string}>}
+ */
+export const getFullNodeConnections = async (options = {}) => {
+  const rpcUrl = buildRpcUrl();
+  try {
+    const data = await callRpc('/get_connections', {}, options);
+    if (!data?.success) {
+      return { rpcUrl, reachable: true, error: data?.error || 'unknown error' };
+    }
+    const connections = (data.connections || []).map((c) => ({
+      peerHost: c.peer_host,
+      peerPort: c.peer_port,
+      type: c.type,
+    }));
+    return { rpcUrl, reachable: true, connections };
+  } catch (error) {
+    logger.debug(`[diagnostics]: full-node get_connections failed: ${error.message}`);
+    return { rpcUrl, reachable: false, error: error.message };
+  }
+};
+
+export default {
+  getBlockchainState,
+  getFullNodeConnections,
+};

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -329,6 +329,28 @@ const getActiveNetwork = async () => {
   }
 };
 
+const getChiaVersion = async () => {
+  const url = `${rpcUrl}/get_version`;
+  const { cert, key, timeout } = getBaseOptions();
+
+  try {
+    const response = await superagent
+      .post(url)
+      .key(key)
+      .cert(cert)
+      .timeout(timeout)
+      .send(JSON.stringify({}));
+
+    const data = response.body;
+    if (data.success) {
+      return data.version || null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
 /**
  * Return the wallet's peer connections (used by /diagnostics to cross-reference
  * connected full-node peers against the trusted_peers map in the chia config).
@@ -927,6 +949,7 @@ export default {
   waitForAllTransactionsToConfirm,
   waitForSpendableCoins,
   getActiveNetwork,
+  getChiaVersion,
   getWalletConnections,
   getLastWalletSyncError,
   getWalletBlockchainSyncStatus,

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -333,18 +333,23 @@ const getChiaVersion = async () => {
   const url = `${rpcUrl}/get_version`;
   const { cert, key, timeout } = getBaseOptions();
 
-  const response = await superagent
-    .post(url)
-    .key(key)
-    .cert(cert)
-    .timeout(timeout)
-    .send(JSON.stringify({}));
+  try {
+    const response = await superagent
+      .post(url)
+      .key(key)
+      .cert(cert)
+      .timeout(timeout)
+      .send(JSON.stringify({}));
 
-  const data = response.body;
-  if (data.success) {
-    return data.version || null;
+    const data = response.body;
+    if (data.success) {
+      return data.version || null;
+    }
+    return null;
+  } catch (error) {
+    logger.debug(`[diagnostics]: wallet get_version failed: ${error.message}`);
+    return null;
   }
-  return null;
 };
 
 /**

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -330,6 +330,49 @@ const getActiveNetwork = async () => {
 };
 
 /**
+ * Return the wallet's peer connections (used by /diagnostics to cross-reference
+ * connected full-node peers against the trusted_peers map in the chia config).
+ *
+ * Returns an object with `success: false` on connection errors instead of
+ * throwing, so the diagnostics endpoint can degrade gracefully without
+ * bringing down the rest of the response.
+ *
+ * @returns {Promise<{success: boolean, connections?: Array, error?: string}>}
+ */
+const getWalletConnections = async () => {
+  if (USE_SIMULATOR) {
+    return { success: true, connections: [] };
+  }
+
+  const url = `${rpcUrl}/get_connections`;
+  try {
+    const { cert, key, timeout } = getBaseOptions();
+    const response = await superagent
+      .post(url)
+      .key(key)
+      .cert(cert)
+      .timeout(timeout)
+      .send({});
+
+    const data = response.body || JSON.parse(response.text);
+    if (!data?.success) {
+      return { success: false, error: data?.error || 'unknown error' };
+    }
+
+    const connections = (data.connections || []).map((c) => ({
+      peerHost: c.peer_host,
+      peerPort: c.peer_port,
+      type: c.type,
+      nodeId: c.node_id,
+    }));
+    return { success: true, connections };
+  } catch (error) {
+    logger.debug(`[diagnostics]: wallet get_connections failed: ${error.message}`);
+    return { success: false, error: error.message };
+  }
+};
+
+/**
  * Get coin records from the wallet (includes coin IDs)
  * @returns {Promise<{success: boolean, coin_records: Array}>} Object with coin_records array and success flag
  */
@@ -884,6 +927,7 @@ export default {
   waitForAllTransactionsToConfirm,
   waitForSpendableCoins,
   getActiveNetwork,
+  getWalletConnections,
   getLastWalletSyncError,
   getWalletBlockchainSyncStatus,
   getCoinRecords,

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -333,22 +333,18 @@ const getChiaVersion = async () => {
   const url = `${rpcUrl}/get_version`;
   const { cert, key, timeout } = getBaseOptions();
 
-  try {
-    const response = await superagent
-      .post(url)
-      .key(key)
-      .cert(cert)
-      .timeout(timeout)
-      .send(JSON.stringify({}));
+  const response = await superagent
+    .post(url)
+    .key(key)
+    .cert(cert)
+    .timeout(timeout)
+    .send(JSON.stringify({}));
 
-    const data = response.body;
-    if (data.success) {
-      return data.version || null;
-    }
-    return null;
-  } catch {
-    return null;
+  const data = response.body;
+  if (data.success) {
+    return data.version || null;
   }
+  return null;
 };
 
 /**

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -41,6 +41,7 @@ const HEALTH_ENDPOINTS = new Set([
   '/v2/health',
   '/v1/health/wallet',
   '/v2/health/wallet',
+  '/diagnostics',
 ]);
 
 const isHealthEndpoint = (path) => HEALTH_ENDPOINTS.has(path);
@@ -314,6 +315,13 @@ app.use(function (req, res, next) {
 });
 
 app.use(async function (req, res, next) {
+  // Skip the home-organization-synced header probe on health endpoints so
+  // /diagnostics (and /health*) can respond even when migrations or the
+  // organizations table are slow to come up.
+  if (isHealthEndpoint(req.path)) {
+    return next();
+  }
+
   if (process.env.NODE_ENV !== 'test') {
     // Wait for migrations to complete before accessing organizations table
     const { waitForMigrations } = await import('./routes/index.js');
@@ -396,6 +404,13 @@ app.use(async function (req, res, next) {
 });
 
 app.use(async function (req, res, next) {
+  // Skip the all-data-synced header probe on health endpoints so /diagnostics
+  // (and /health*) can respond even when migrations or the organizations
+  // table are slow to come up.
+  if (isHealthEndpoint(req.path)) {
+    return next();
+  }
+
   // Wait for migrations to complete before accessing organizations table
   const { waitForMigrations } = await import('./routes/index.js');
   await waitForMigrations();
@@ -474,6 +489,14 @@ app.use(async function (req, res, next) {
 });
 
 app.use(async function (req, res, next) {
+  // Skip the wallet-synced header probe for health endpoints. walletIsSynced
+  // can hang for up to 300s when the wallet RPC is unreachable, which would
+  // defeat the purpose of /diagnostics (and slow down /health) precisely in
+  // the scenarios where those endpoints are most useful.
+  if (isHealthEndpoint(req.path)) {
+    return next();
+  }
+
   if (USE_SIMULATOR) {
     res.setHeader(headerKeys.WALLET_SYNCED, true);
   } else {
@@ -488,6 +511,38 @@ app.get('/health', (req, res) => {
     message: 'OK',
     timestamp: new Date().toISOString(),
   });
+});
+
+// System-wide diagnostics. Mounted on the root app (not under /v1 or /v2) so
+// it can report CADT, Chia, and machine status independent of the data-model
+// version. Lives in HEALTH_ENDPOINTS above so it bypasses the rate limiter,
+// startup gates, and the Chia/datalayer assertions -- this endpoint is meant
+// to be useful precisely when those subsystems are broken.
+//
+// Auth: handled by the global API-key middleware further up, which runs for
+// EVERY route including HEALTH_ENDPOINTS. When CADT_API_KEY is configured the
+// caller must present x-api-key before reaching this handler. We rely on
+// that single enforcement point rather than duplicating the constant-time
+// check here.
+//
+// Read-only: when V1 or V2 READ_ONLY is set we strip sensitive fields
+// (balances, transaction details, peer details, subscription IDs, home org
+// IDs) the same way wallet-health.js does for /v{1,2}/health/wallet.
+app.get('/diagnostics', async (req, res) => {
+  try {
+    const configV1 = getConfig();
+    const configV2 = getConfigV2();
+    const readOnly = configV2.READ_ONLY === true || configV1.READ_ONLY === true;
+    const { getDiagnosticsResponse } = await import('./routes/diagnostics.js');
+    const result = await getDiagnosticsResponse({ readOnly });
+    return res.status(200).json(result);
+  } catch (error) {
+    logger.error(`[diagnostics]: unexpected error building response: ${error.message}`);
+    return res.status(200).json({
+      timestamp: new Date().toISOString(),
+      error: `Failed to build diagnostics response: ${error.message}`,
+    });
+  }
 });
 
 // Conditionally mount V1 and V2 routes based on config

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -532,7 +532,7 @@ app.get('/diagnostics', async (req, res) => {
   try {
     const configV1 = getConfig();
     const configV2 = getConfigV2();
-    const readOnly = configV2.READ_ONLY === true || configV1.READ_ONLY === true;
+    const readOnly = !!(configV2.READ_ONLY || configV1.READ_ONLY);
     const { getDiagnosticsResponse } = await import('./routes/diagnostics.js');
     const result = await getDiagnosticsResponse({ readOnly });
     return res.status(200).json(result);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -542,7 +542,7 @@ app.get('/diagnostics', async (req, res) => {
     return res.status(200).json(result);
   } catch (error) {
     logger.error(`[diagnostics]: unexpected error building response: ${error.message}`);
-    return res.status(200).json({
+    return res.status(500).json({
       timestamp: new Date().toISOString(),
       error: `Failed to build diagnostics response: ${error.message}`,
     });

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -525,16 +525,20 @@ app.get('/health', (req, res) => {
 // that single enforcement point rather than duplicating the constant-time
 // check here.
 //
-// Read-only: when V1 or V2 READ_ONLY is set we strip sensitive fields
-// (balances, transaction details, peer details, subscription IDs, home org
-// IDs) the same way wallet-health.js does for /v{1,2}/health/wallet.
+// Disabled in read-only mode: the diagnostics payload exposes system details
+// (paths, wallet balances, peer IPs, subscription IDs) that should not be
+// served on unauthenticated public-observer nodes.
 app.get('/diagnostics', async (req, res) => {
   try {
     const configV1 = getConfig();
     const configV2 = getConfigV2();
-    const readOnly = !!(configV2.READ_ONLY || configV1.READ_ONLY);
+    if (configV2.READ_ONLY || configV1.READ_ONLY) {
+      return res.status(403).json({
+        error: 'The /diagnostics endpoint is not available on read-only nodes',
+      });
+    }
     const { getDiagnosticsResponse } = await import('./routes/diagnostics.js');
-    const result = await getDiagnosticsResponse({ readOnly });
+    const result = await getDiagnosticsResponse();
     return res.status(200).json(result);
   } catch (error) {
     logger.error(`[diagnostics]: unexpected error building response: ${error.message}`);

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -7,9 +7,8 @@
  * when something is broken, so every external call is fenced behind
  * `Promise.allSettled` with a per-call timeout. The route never throws.
  *
- * In read-only mode the same shape is returned but with sensitive fields
- * (balances, transaction details, peer host details, subscription IDs,
- * home org IDs) stripped, matching the convention from wallet-health.js.
+ * The endpoint is disabled entirely in read-only mode (handled by
+ * middleware returning 403), so there is no reduced-information path.
  */
 
 import _ from 'lodash';
@@ -215,31 +214,13 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
  * Heavy module dependencies (database models, datalayer RPC clients) are
  * loaded dynamically so this file is safe to import from contexts where
  * those modules aren't ready yet (tests, early startup).
- *
- * In read-only mode we deliberately skip the expensive wallet/datalayer/
- * full-node RPC fan-out -- read-only ("public observer") deployments
- * should not be making per-request authenticated wallet RPC calls on
- * unauthenticated public hits. This matches the precedent in
- * src/routes/wallet-health.js, which also short-circuits before fetch.
  */
-export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
+export const getDiagnosticsResponse = async () => {
   const timestamp = new Date().toISOString();
 
   const configV1 = getConfig();
   const configV2 = getConfigV2();
   const appConfig = configV1.APP || {};
-
-  // Short-circuit BEFORE pulling in the heavy wallet/datalayer/model
-  // dependencies. The read-only path only needs system-info / process-scan /
-  // chia-tools probes plus the synchronously-available config, so importing
-  // wallet.js or models/v2/index.js here would (a) defeat the "no
-  // authenticated RPC on unauthenticated public hits" property and (b)
-  // make /diagnostics itself fail whenever the DB/wallet modules can't
-  // initialize -- which is precisely the failure mode this endpoint exists
-  // to diagnose.
-  if (readOnly) {
-    return buildReadOnlyResponse({ timestamp, configV1, configV2, appConfig });
-  }
 
   const wallet = (await import('../datalayer/wallet.js')).default;
   const fullNodeRpc = (await import('../datalayer/fullNodeRpc.js')).default;
@@ -475,7 +456,6 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   // ---- Full response ------------------------------------------------------
   const fullResponse = {
     timestamp,
-    readOnly: false,
     cadt: cadtSection,
     network: {
       chia: actualNetwork,
@@ -495,68 +475,6 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   };
 
   return fullResponse;
-};
-
-/**
- * Read-only diagnostics: only cheap, public-safe data. We short-circuit
- * BEFORE the wallet/datalayer/full-node RPC fan-out so a read-only
- * deployment doesn't make per-request authenticated wallet RPC calls on
- * unauthenticated public hits.
- */
-const buildReadOnlyResponse = async ({ timestamp, configV1, configV2, appConfig }) => {
-  const enableV1 = configV1?.ENABLE !== false;
-  const enableV2 = configV2?.ENABLE !== false;
-  const chiaRoot = getChiaRoot();
-
-  const [systemInfoRes, chiaProcessesRes, chiaToolsRes] = await Promise.all([
-    settle('getSystemInfo', () => getSystemInfo(), DEFAULT_TIMEOUT_MS),
-    settle('scanChiaProcesses', () => scanChiaProcesses(), DEFAULT_TIMEOUT_MS),
-    settle('probeChiaTools', () => probeChiaTools(), DEFAULT_TIMEOUT_MS),
-  ]);
-
-  const processesValue = chiaProcessesRes.ok
-    ? chiaProcessesRes.value
-    : { matches: [], installPaths: [], multipleVersionsDetected: false, error: chiaProcessesRes.error };
-  const chiaToolsSection = chiaToolsRes.ok
-    ? chiaToolsRes.value
-    : { installed: false, version: null, error: chiaToolsRes.error };
-  const systemSection = systemInfoRes.ok ? systemInfoRes.value : { error: systemInfoRes.error };
-
-  return {
-    timestamp,
-    readOnly: true,
-    message: 'Operational details are not available on read-only nodes',
-    cadt: {
-      version: packageJson.version,
-      configDir: `${chiaRoot}/cadt`,
-      configFile: `${chiaRoot}/cadt/config.yaml`,
-      datalayerUrl: appConfig.DATALAYER_URL || null,
-      datalayerFileServerUrl: appConfig.DATALAYER_FILE_SERVER_URL || null,
-      useSimulator: appConfig.USE_SIMULATOR === true,
-      v1: {
-        enabled: enableV1,
-        readOnly: configV1.READ_ONLY === true,
-        isGovernanceBody: configV1.IS_GOVERNANCE_BODY === true,
-        apiKeyConfigured: !!(configV1.CADT_API_KEY && configV1.CADT_API_KEY !== ''),
-        governanceBodyId: configV1.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
-      },
-      v2: {
-        enabled: enableV2,
-        readOnly: configV2.READ_ONLY === true,
-        isGovernanceBody: configV2.IS_GOVERNANCE_BODY === true,
-        apiKeyConfigured: !!(configV2.CADT_API_KEY && configV2.CADT_API_KEY !== ''),
-        governanceBodyId: configV2.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
-      },
-    },
-    network: { cadt: appConfig.CHIA_NETWORK || null },
-    chia: {
-      chiaTools: { installed: chiaToolsSection.installed, version: chiaToolsSection.version },
-      runningProcesses: {
-        multipleVersionsDetected: processesValue.multipleVersionsDetected,
-      },
-    },
-    system: systemSection,
-  };
 };
 
 export const __test = {

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -1,0 +1,525 @@
+/**
+ * System-wide /diagnostics endpoint builder.
+ *
+ * Returns a single JSON object summarizing CADT, Chia, DataLayer, and the
+ * underlying machine. Designed to degrade gracefully when subsystems are
+ * unreachable -- the whole point of a diagnostics endpoint is to be useful
+ * when something is broken, so every external call is fenced behind
+ * `Promise.allSettled` with a per-call timeout. The route never throws.
+ *
+ * In read-only mode the same shape is returned but with sensitive fields
+ * (balances, transaction details, peer host details, subscription IDs,
+ * home org IDs) stripped, matching the convention from wallet-health.js.
+ */
+
+import os from 'os';
+
+import _ from 'lodash';
+
+import { getConfig, getConfigV2 } from '../utils/config-loader.js';
+import { getChiaRoot } from '../utils/chia-root.js';
+import { getWalletHealthResponse } from './wallet-health.js';
+import { getSystemInfo } from '../utils/system-info.js';
+import { scanChiaProcesses } from '../utils/chia-process-scan.js';
+import { probeChiaTools } from '../utils/chia-tools-probe.js';
+import { logger } from '../config/logger.js';
+import packageJson from '../../package.json' with { type: 'json' };
+
+// Timeouts deliberately err on the generous side: /diagnostics is allowed to
+// be slow if the goal is a comprehensive snapshot. A busy-but-healthy wallet
+// (e.g. long-syncing while operators are debugging) regularly takes several
+// seconds to answer get_wallet_balance, so tighter values would falsely flag
+// healthy subsystems as broken. Worst-case wall-clock response is roughly
+// max(DEFAULT_TIMEOUT_MS, SUBSCRIPTION_BUDGET_MS) ~= 30s when something
+// upstream is wedged.
+const DEFAULT_TIMEOUT_MS = 10000;
+const SUBSCRIPTION_BUDGET_MS = 30000;
+const SUBSCRIPTION_CONCURRENCY = 10;
+
+/**
+ * Run an async producer with a hard wall-clock timeout. The returned promise
+ * always resolves -- success becomes `{ ok: true, value }`, failure or
+ * timeout becomes `{ ok: false, error }`.
+ */
+const settle = async (label, producer, timeoutMs = DEFAULT_TIMEOUT_MS) => {
+  let timer;
+  try {
+    const timeoutPromise = new Promise((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    });
+    const value = await Promise.race([producer(), timeoutPromise]);
+    return { ok: true, value };
+  } catch (error) {
+    logger.debug(`[diagnostics]: ${label} failed: ${error.message}`);
+    return { ok: false, error: error.message };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
+
+const readHomeOrgId = async (Model, getter = 'getHomeOrg') => {
+  try {
+    // includeAddress=false avoids a wallet RPC call inside getHomeOrg --
+    // /diagnostics must keep working when the wallet is unreachable.
+    const homeOrg = await Model[getter](false);
+    if (!homeOrg) return null;
+    // V1 uses `orgUid`, V2 uses `org_uid`
+    return homeOrg.orgUid || homeOrg.org_uid || null;
+  } catch (error) {
+    logger.debug(`[diagnostics]: home org lookup failed: ${error.message}`);
+    return null;
+  }
+};
+
+/**
+ * Resolve datalayer subscriptions plus per-store sync status, with overall
+ * budget. Returns `{ available, subscriptions, truncated, totalSubscriptions }`.
+ */
+const collectSubscriptions = async (persistance) => {
+  const startedAt = Date.now();
+  let storeIds = [];
+  let available = false;
+  try {
+    const result = await persistance.getSubscriptions();
+    available = result.success === true;
+    storeIds = result.storeIds || [];
+  } catch (error) {
+    logger.debug(`[diagnostics]: getSubscriptions failed: ${error.message}`);
+    return { available: false, subscriptions: [], truncated: false, totalSubscriptions: 0 };
+  }
+
+  if (storeIds.length === 0) {
+    return { available, subscriptions: [], truncated: false, totalSubscriptions: 0 };
+  }
+
+  const results = new Array(storeIds.length);
+  let truncated = false;
+
+  const processOne = async (storeId, index) => {
+    if (Date.now() - startedAt >= SUBSCRIPTION_BUDGET_MS) {
+      truncated = true;
+      return;
+    }
+    try {
+      const data = await persistance.getDataLayerStoreSyncStatus(storeId);
+      const syncStatus = data?.sync_status;
+      if (!syncStatus) {
+        results[index] = { storeId, synced: null, error: 'no sync status returned' };
+        return;
+      }
+      const { generation, target_generation: targetGeneration } = syncStatus;
+      // Guard against generation/target_generation being undefined together,
+      // which would otherwise compare equal and falsely report synced=true.
+      const synced =
+        Number.isFinite(generation) &&
+        Number.isFinite(targetGeneration) &&
+        generation === targetGeneration;
+      results[index] = {
+        storeId,
+        synced,
+        generation: generation ?? null,
+        targetGeneration: targetGeneration ?? null,
+      };
+    } catch (error) {
+      results[index] = { storeId, synced: null, error: error.message };
+    }
+  };
+
+  // Bounded-concurrency worker pool.
+  let nextIndex = 0;
+  const worker = async () => {
+    while (true) {
+      const i = nextIndex++;
+      if (i >= storeIds.length) return;
+      if (Date.now() - startedAt >= SUBSCRIPTION_BUDGET_MS) {
+        truncated = true;
+        return;
+      }
+      await processOne(storeIds[i], i);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(SUBSCRIPTION_CONCURRENCY, storeIds.length) }, () => worker()),
+  );
+
+  const subscriptions = results.filter(Boolean);
+
+  return {
+    available,
+    subscriptions,
+    truncated,
+    totalSubscriptions: storeIds.length,
+  };
+};
+
+/**
+ * Normalize a chia peer node_id for comparison: strip a leading 0x and
+ * lowercase. Both the chia config's `wallet.trusted_peers` keys and the
+ * `get_connections` RPC values are hex, but they differ on the 0x prefix
+ * and case, so we have to normalize before comparing.
+ */
+const normalizeNodeId = (id) => {
+  if (id == null) return '';
+  const s = String(id).toLowerCase();
+  return s.startsWith('0x') ? s.slice(2) : s;
+};
+
+/**
+ * Cross-reference connected wallet peers against the trusted_peers map in
+ * the chia config.yaml. Returns a small object suitable for embedding in
+ * the diagnostics response, including whether at least one connection is
+ * trusted.
+ */
+const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
+  const view = {
+    configuredTrustedNodeIds: [],
+    connected: [],
+    hasTrustedConnection: false,
+  };
+
+  let normalizedTrustedSet = null;
+  if (chiaConfigResult?.ok) {
+    const trustedPeerMap = _.get(chiaConfigResult.value, 'wallet.trusted_peers', null);
+    if (trustedPeerMap && typeof trustedPeerMap === 'object') {
+      // trusted_peers is `{ <peer_node_id>: <cert_path or 'Does_not_matter'> }`
+      // -- lowercase hex without 0x. We keep the node-id keys so callers can
+      // spot misconfigurations.
+      const keys = Object.keys(trustedPeerMap);
+      view.configuredTrustedNodeIds = keys;
+      normalizedTrustedSet = new Set(keys.map(normalizeNodeId));
+    }
+  } else if (chiaConfigResult) {
+    view.chiaConfigError = chiaConfigResult.error;
+  }
+
+  if (connectionsResult?.ok) {
+    const connections = connectionsResult.value?.connections || [];
+    view.connected = connections.map((c) => {
+      const trusted = !!(
+        normalizedTrustedSet && normalizedTrustedSet.has(normalizeNodeId(c.nodeId))
+      );
+      if (trusted) view.hasTrustedConnection = true;
+      return { peerHost: c.peerHost, peerPort: c.peerPort, type: c.type, trusted };
+    });
+  } else if (connectionsResult) {
+    view.connectionsError = connectionsResult.error;
+  }
+
+  return view;
+};
+
+/**
+ * Build the full /diagnostics response payload.
+ *
+ * Heavy module dependencies (database models, datalayer RPC clients) are
+ * loaded dynamically so this file is safe to import from contexts where
+ * those modules aren't ready yet (tests, early startup).
+ *
+ * In read-only mode we deliberately skip the expensive wallet/datalayer/
+ * full-node RPC fan-out -- read-only ("public observer") deployments
+ * should not be making per-request authenticated wallet RPC calls on
+ * unauthenticated public hits. This matches the precedent in
+ * src/routes/wallet-health.js, which also short-circuits before fetch.
+ */
+export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
+  const timestamp = new Date().toISOString();
+
+  const wallet = (await import('../datalayer/wallet.js')).default;
+  const fullNodeRpc = (await import('../datalayer/fullNodeRpc.js')).default;
+  const persistance = await import('../datalayer/persistance.js');
+  const { Organization } = await import('../models/index.js');
+  const { OrganizationsV2 } = await import('../models/v2/index.js');
+  const fullNodeModule = await import('../datalayer/fullNode.js');
+
+  const configV1 = getConfig();
+  const configV2 = getConfigV2();
+  const appConfig = configV1.APP || {};
+
+  if (readOnly) {
+    return buildReadOnlyResponse({ timestamp, configV1, configV2, appConfig });
+  }
+
+  // Kick off every external call in parallel. None of these can throw.
+  const [
+    activeNetworkRes,
+    walletSyncedRes,
+    walletBalanceRes,
+    walletConnectionsRes,
+    walletHealthRes,
+    fullNodeStateRes,
+    fullNodeConnectionsRes,
+    chiaConfigRes,
+    datalayerAvailableRes,
+    subscriptionsRes,
+    homeOrgV1Res,
+    homeOrgV2Res,
+    systemInfoRes,
+    chiaProcessesRes,
+    chiaToolsRes,
+  ] = await Promise.all([
+    settle('wallet.getActiveNetwork', () => wallet.getActiveNetwork(), DEFAULT_TIMEOUT_MS),
+    settle('wallet.walletIsSynced', () => wallet.walletIsSynced(), DEFAULT_TIMEOUT_MS),
+    settle('wallet.getWalletBalance', () => wallet.getWalletBalance(), DEFAULT_TIMEOUT_MS),
+    settle('wallet.getWalletConnections', () => wallet.getWalletConnections(), DEFAULT_TIMEOUT_MS),
+    settle(
+      'getWalletHealthResponse',
+      () => getWalletHealthResponse(wallet, { readOnly: false }),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    settle('fullNode.getBlockchainState', () => fullNodeRpc.getBlockchainState(), DEFAULT_TIMEOUT_MS),
+    settle(
+      'fullNode.getFullNodeConnections',
+      () => fullNodeRpc.getFullNodeConnections(),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    settle('getChiaConfig', () => Promise.resolve(fullNodeModule.getChiaConfig()), 1000),
+    settle('persistance.dataLayerAvailable', () => persistance.dataLayerAvailable(), DEFAULT_TIMEOUT_MS),
+    settle(
+      'collectSubscriptions',
+      () => collectSubscriptions(persistance),
+      SUBSCRIPTION_BUDGET_MS + 1000,
+    ),
+    settle('Organization.getHomeOrg', () => readHomeOrgId(Organization), DEFAULT_TIMEOUT_MS),
+    settle('OrganizationsV2.getHomeOrg', () => readHomeOrgId(OrganizationsV2), DEFAULT_TIMEOUT_MS),
+    settle('getSystemInfo', () => getSystemInfo(), DEFAULT_TIMEOUT_MS),
+    settle('scanChiaProcesses', () => scanChiaProcesses(), DEFAULT_TIMEOUT_MS),
+    settle('probeChiaTools', () => probeChiaTools(), DEFAULT_TIMEOUT_MS),
+  ]);
+
+  // walletReachable: derived from the get_network_info RPC return value, NOT
+  // from settle().ok -- walletIsSynced and getWalletBalance both swallow
+  // errors and return `false`, so settle().ok would be `true` even when the
+  // wallet is unreachable. getActiveNetwork returns the response object on
+  // success and literal `false` on any failure, so we use that as the
+  // ground-truth reachability probe.
+  const walletReachable = activeNetworkRes.ok && activeNetworkRes.value !== false;
+
+  // lastWalletSyncError is a module-level slot in wallet.js that walletIsSynced
+  // overwrites on every call. It's our best signal for the SPECIFIC connection
+  // error (ECONNREFUSED, ETIMEDOUT, etc.) but it can be `null` if a
+  // concurrent caller cleared it after our walletIsSynced returned. When the
+  // wallet is unreachable but the slot is empty, we fall back to a synthetic
+  // message so operators looking at the JSON always know unreachability is
+  // distinct from "reachable but unsynced".
+  const walletConnectionError = wallet.getLastWalletSyncError?.();
+
+  const enableV1 = configV1?.ENABLE !== false;
+  const enableV2 = configV2?.ENABLE !== false;
+  const chiaRoot = getChiaRoot();
+
+  // ---- CADT section -------------------------------------------------------
+  const cadtSection = {
+    version: packageJson.version,
+    configDir: `${chiaRoot}/cadt`,
+    configFile: `${chiaRoot}/cadt/config.yaml`,
+    datalayerUrl: appConfig.DATALAYER_URL || null,
+    datalayerFileServerUrl: appConfig.DATALAYER_FILE_SERVER_URL || null,
+    walletRpcUrl: appConfig.WALLET_URL || null,
+    useSimulator: appConfig.USE_SIMULATOR === true,
+    databases: {
+      v1: enableV1 ? `${chiaRoot}/cadt/v1/data.sqlite3` : null,
+      v2: enableV2 ? `${chiaRoot}/cadt/v2/data.sqlite3` : null,
+    },
+    v1: {
+      enabled: enableV1,
+      readOnly: configV1.READ_ONLY === true,
+      isGovernanceBody: configV1.IS_GOVERNANCE_BODY === true,
+      apiKeyConfigured: !!(configV1.CADT_API_KEY && configV1.CADT_API_KEY !== ''),
+      governanceBodyId: configV1.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
+      homeOrgId: homeOrgV1Res.ok ? homeOrgV1Res.value : null,
+    },
+    v2: {
+      enabled: enableV2,
+      readOnly: configV2.READ_ONLY === true,
+      isGovernanceBody: configV2.IS_GOVERNANCE_BODY === true,
+      apiKeyConfigured: !!(configV2.CADT_API_KEY && configV2.CADT_API_KEY !== ''),
+      governanceBodyId: configV2.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
+      homeOrgId: homeOrgV2Res.ok ? homeOrgV2Res.value : null,
+    },
+  };
+
+  // ---- Chia: network match ------------------------------------------------
+  const actualNetwork = activeNetworkRes.ok
+    ? activeNetworkRes.value?.network_name || null
+    : null;
+  const configuredNetwork = appConfig.CHIA_NETWORK || null;
+  const networkMatches =
+    actualNetwork && configuredNetwork ? actualNetwork.includes(configuredNetwork) : null;
+
+  // ---- Chia: wallet -------------------------------------------------------
+  // connectionError is non-empty whenever the wallet is unreachable, even
+  // for AggregateError-style failures whose `.message` is empty -- otherwise
+  // an operator looking at the JSON can't tell "wallet is reachable but
+  // unsynced" from "wallet RPC refused our connection".
+  let walletConnectionErrorMessage = null;
+  if (!walletReachable) {
+    walletConnectionErrorMessage =
+      walletConnectionError?.message ||
+      `Wallet RPC at ${walletConnectionError?.walletRpcUrl || appConfig.WALLET_URL || 'configured URL'} did not respond`;
+  }
+
+  const walletSection = {
+    rpcUrl: appConfig.WALLET_URL || null,
+    reachable: walletReachable,
+    connectionError: walletConnectionErrorMessage,
+    synced: walletSyncedRes.ok ? walletSyncedRes.value === true : false,
+    balanceXch:
+      walletReachable && walletBalanceRes.ok && walletBalanceRes.value !== false
+        ? walletBalanceRes.value
+        : null,
+    pendingTransactions: walletHealthRes.ok ? walletHealthRes.value : { error: walletHealthRes.error },
+    trustedFullNodePeers: buildTrustedPeerView(walletConnectionsRes, chiaConfigRes),
+  };
+
+  // ---- Chia: full node ----------------------------------------------------
+  const fullNodeSection = (() => {
+    const base = fullNodeStateRes.ok
+      ? fullNodeStateRes.value
+      : { reachable: false, error: fullNodeStateRes.error };
+    const connections = fullNodeConnectionsRes.ok
+      ? fullNodeConnectionsRes.value
+      : { reachable: false, error: fullNodeConnectionsRes.error };
+    return {
+      ...base,
+      peerCount: connections.connections ? connections.connections.length : null,
+      connectionsError: connections.error || null,
+    };
+  })();
+
+  // ---- Chia: datalayer ---------------------------------------------------
+  const datalayerSection = (() => {
+    const reachable = datalayerAvailableRes.ok ? datalayerAvailableRes.value === true : false;
+    const subscriptionsValue = subscriptionsRes.ok
+      ? subscriptionsRes.value
+      : { available: false, subscriptions: [], truncated: false, totalSubscriptions: 0, error: subscriptionsRes.error };
+    return {
+      rpcUrl: appConfig.DATALAYER_URL || null,
+      reachable,
+      subscriptions: subscriptionsValue.subscriptions,
+      totalSubscriptions: subscriptionsValue.totalSubscriptions,
+      truncated: subscriptionsValue.truncated,
+      ...(subscriptionsValue.error ? { subscriptionsError: subscriptionsValue.error } : {}),
+    };
+  })();
+
+  // ---- Chia: services / chia-tools / processes ---------------------------
+  const servicesSection = {
+    walletReachable,
+    fullNodeReachable: fullNodeStateRes.ok ? !!fullNodeStateRes.value?.reachable : false,
+    datalayerReachable: datalayerAvailableRes.ok ? datalayerAvailableRes.value === true : false,
+  };
+
+  const chiaToolsSection = chiaToolsRes.ok
+    ? chiaToolsRes.value
+    : { installed: false, version: null, error: chiaToolsRes.error, note: 'probe failed' };
+
+  const processesSection = chiaProcessesRes.ok
+    ? chiaProcessesRes.value
+    : {
+        supported: false,
+        platform: os.platform(),
+        matches: [],
+        multipleVersionsDetected: false,
+        error: chiaProcessesRes.error,
+      };
+
+  // ---- System -------------------------------------------------------------
+  const systemSection = systemInfoRes.ok
+    ? systemInfoRes.value
+    : { error: systemInfoRes.error };
+
+  // ---- Full response ------------------------------------------------------
+  const fullResponse = {
+    timestamp,
+    readOnly: false,
+    cadt: cadtSection,
+    chia: {
+      network: {
+        actual: actualNetwork,
+        configured: configuredNetwork,
+        matches: networkMatches,
+      },
+      wallet: walletSection,
+      fullNode: fullNodeSection,
+      datalayer: datalayerSection,
+      services: servicesSection,
+      chiaTools: chiaToolsSection,
+      processes: processesSection,
+    },
+    system: systemSection,
+  };
+
+  return fullResponse;
+};
+
+/**
+ * Read-only diagnostics: only cheap, public-safe data. We short-circuit
+ * BEFORE the wallet/datalayer/full-node RPC fan-out so a read-only
+ * deployment doesn't make per-request authenticated wallet RPC calls on
+ * unauthenticated public hits.
+ */
+const buildReadOnlyResponse = async ({ timestamp, configV1, configV2, appConfig }) => {
+  const enableV1 = configV1?.ENABLE !== false;
+  const enableV2 = configV2?.ENABLE !== false;
+  const chiaRoot = getChiaRoot();
+
+  const [systemInfoRes, chiaProcessesRes, chiaToolsRes] = await Promise.all([
+    settle('getSystemInfo', () => getSystemInfo(), DEFAULT_TIMEOUT_MS),
+    settle('scanChiaProcesses', () => scanChiaProcesses(), DEFAULT_TIMEOUT_MS),
+    settle('probeChiaTools', () => probeChiaTools(), DEFAULT_TIMEOUT_MS),
+  ]);
+
+  const processesSection = chiaProcessesRes.ok
+    ? chiaProcessesRes.value
+    : { supported: false, matches: [], multipleVersionsDetected: false, error: chiaProcessesRes.error };
+  const chiaToolsSection = chiaToolsRes.ok
+    ? chiaToolsRes.value
+    : { installed: false, version: null, error: chiaToolsRes.error };
+  const systemSection = systemInfoRes.ok ? systemInfoRes.value : { error: systemInfoRes.error };
+
+  return {
+    timestamp,
+    readOnly: true,
+    message: 'Operational details are not available on read-only nodes',
+    cadt: {
+      version: packageJson.version,
+      configDir: `${chiaRoot}/cadt`,
+      configFile: `${chiaRoot}/cadt/config.yaml`,
+      datalayerUrl: appConfig.DATALAYER_URL || null,
+      datalayerFileServerUrl: appConfig.DATALAYER_FILE_SERVER_URL || null,
+      useSimulator: appConfig.USE_SIMULATOR === true,
+      v1: {
+        enabled: enableV1,
+        readOnly: configV1.READ_ONLY === true,
+        isGovernanceBody: configV1.IS_GOVERNANCE_BODY === true,
+        apiKeyConfigured: !!(configV1.CADT_API_KEY && configV1.CADT_API_KEY !== ''),
+        governanceBodyId: configV1.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
+      },
+      v2: {
+        enabled: enableV2,
+        readOnly: configV2.READ_ONLY === true,
+        isGovernanceBody: configV2.IS_GOVERNANCE_BODY === true,
+        apiKeyConfigured: !!(configV2.CADT_API_KEY && configV2.CADT_API_KEY !== ''),
+        governanceBodyId: configV2.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
+      },
+    },
+    chia: {
+      network: { configured: appConfig.CHIA_NETWORK || null },
+      chiaTools: { installed: chiaToolsSection.installed, version: chiaToolsSection.version },
+      processes: {
+        supported: processesSection.supported,
+        platform: processesSection.platform || null,
+        multipleVersionsDetected: processesSection.multipleVersionsDetected,
+      },
+    },
+    system: systemSection,
+  };
+};
+
+export const __test = {
+  settle,
+  collectSubscriptions,
+  buildTrustedPeerView,
+  normalizeNodeId,
+};

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -257,7 +257,6 @@ export const getDiagnosticsResponse = async () => {
   const rpcSettles = [
     settle('wallet.getActiveNetwork', () => wallet.getActiveNetwork(), DEFAULT_TIMEOUT_MS),
     settle('wallet.getChiaVersion', () => wallet.getChiaVersion(), DEFAULT_TIMEOUT_MS),
-    settle('wallet.walletIsSynced', () => wallet.walletIsSynced(), DEFAULT_TIMEOUT_MS),
     settle('wallet.getWalletBalance', () => wallet.getWalletBalance(), DEFAULT_TIMEOUT_MS),
     settle('wallet.getWalletConnections', () => wallet.getWalletConnections(), DEFAULT_TIMEOUT_MS),
     settle(
@@ -285,7 +284,6 @@ export const getDiagnosticsResponse = async () => {
   const [
     activeNetworkRes,
     chiaVersionRes,
-    walletSyncedRes,
     walletBalanceRes,
     walletConnectionsRes,
     walletHealthRes,
@@ -306,13 +304,10 @@ export const getDiagnosticsResponse = async () => {
   // ground-truth reachability probe.
   const walletReachable = activeNetworkRes.ok && activeNetworkRes.value !== false;
 
-  // lastWalletSyncError is a module-level slot in wallet.js that walletIsSynced
-  // overwrites on every call. It's our best signal for the SPECIFIC connection
-  // error (ECONNREFUSED, ETIMEDOUT, etc.) but it can be `null` if a
-  // concurrent caller cleared it after our walletIsSynced returned. When the
-  // wallet is unreachable but the slot is empty, we fall back to a synthetic
-  // message so operators looking at the JSON always know unreachability is
-  // distinct from "reachable but unsynced".
+  // walletIsSynced() is called internally by getWalletHealthResponse, which
+  // populates the module-level lastWalletSyncError slot. We read it here for
+  // the specific error message (ECONNREFUSED, ETIMEDOUT, etc.) and fall back
+  // to a synthetic message when the slot is empty.
   const walletConnectionError = wallet.getLastWalletSyncError?.();
 
   const enableV1 = configV1?.ENABLE !== false;
@@ -391,7 +386,7 @@ export const getDiagnosticsResponse = async () => {
     rpcUrl: appConfig.WALLET_URL || null,
     reachable: walletReachable,
     connectionError: walletConnectionErrorMessage,
-    synced: walletSyncedRes.ok ? walletSyncedRes.value === true : false,
+    synced: walletHealthRes.ok ? walletHealthRes.value?.synced === true : false,
     balanceXch:
       walletReachable && walletBalanceRes.ok && walletBalanceRes.value !== false
         ? walletBalanceRes.value

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -191,7 +191,7 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
     view.chiaConfigError = chiaConfigResult.error;
   }
 
-  if (connectionsResult?.ok) {
+  if (connectionsResult?.ok && connectionsResult.value?.success !== false) {
     const connections = connectionsResult.value?.connections || [];
     view.connected = connections.map((c) => {
       const trusted = !!(
@@ -201,7 +201,9 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
       return { peerHost: c.peerHost, peerPort: c.peerPort, type: c.type, trusted };
     });
   } else if (connectionsResult) {
-    view.connectionsError = connectionsResult.error;
+    view.connectionsError = connectionsResult.ok
+      ? connectionsResult.value?.error || 'wallet connections unavailable'
+      : connectionsResult.error;
   }
 
   return view;

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -22,6 +22,32 @@ import { probeChiaTools } from '../utils/chia-tools-probe.js';
 import { logger } from '../config/logger.js';
 import packageJson from '../../package.json' with { type: 'json' };
 
+/**
+ * Accumulates a worst-case status across multiple checks.  Severity only
+ * escalates: ok → warning → critical.  Messages are joined with two-space
+ * separation into a single string.
+ */
+class StatusAccumulator {
+  static #levels = { ok: 0, warning: 1, critical: 2 };
+  static #names = ['ok', 'warning', 'critical'];
+
+  #level = 0;
+  #messages = [];
+
+  escalate(severity, message) {
+    const target = StatusAccumulator.#levels[severity];
+    if (target === undefined) throw new Error(`unknown severity: ${severity}`);
+    if (target > this.#level) this.#level = target;
+    if (message) this.#messages.push(message);
+  }
+
+  result() {
+    const status = StatusAccumulator.#names[this.#level];
+    if (this.#messages.length === 0) return { status };
+    return { status, message: this.#messages.join('  ') };
+  }
+}
+
 // Timeouts deliberately err on the generous side: /diagnostics is allowed to
 // be slow if the goal is a comprehensive snapshot. A busy-but-healthy wallet
 // (e.g. long-syncing while operators are debugging) regularly takes several
@@ -430,15 +456,7 @@ export const getDiagnosticsResponse = async () => {
     };
   })();
 
-  // ---- Chia: services / chia-tools / processes ---------------------------
-  const servicesSection = {
-    walletReachable,
-    fullNodeReachable: fullNodeRunningLocally && fullNodeStateRes.ok
-      ? !!fullNodeStateRes.value?.reachable
-      : false,
-    datalayerReachable: datalayerAvailableRes.ok ? datalayerAvailableRes.value === true : false,
-  };
-
+  // ---- Chia: chia-tools / processes ---------------------------------------
   const chiaToolsSection = chiaToolsRes.ok
     ? chiaToolsRes.value
     : { installed: false, version: null, error: chiaToolsRes.error, note: 'probe failed' };
@@ -448,28 +466,177 @@ export const getDiagnosticsResponse = async () => {
     ? systemInfoRes.value
     : { error: systemInfoRes.error };
 
+  // ---- Status computation -------------------------------------------------
+
+  // Precompute process-running booleans for status checks below.
+  const chiaRunningLocally = processesValue.matches.some(
+    (m) => /chia_/i.test(m.command),
+  );
+  const fullNodeProcessRunning = processesValue.matches.some(
+    (m) => /chia_full_node/i.test(m.command),
+  );
+  const dlProcessRunning = processesValue.matches.some(
+    (m) => /chia_data_layer/i.test(m.command),
+  );
+  const walletProcessRunning = processesValue.matches.some(
+    (m) => /chia_wallet/i.test(m.command),
+  );
+
+  // system.disk
+  if (systemSection.disk) {
+    const diskStatus = new StatusAccumulator();
+    const pct = systemSection.disk.percentUsed;
+    if (pct != null) {
+      if (pct > 96) diskStatus.escalate('critical', 'Disk usage above 96%');
+      else if (pct > 90) diskStatus.escalate('warning', 'Disk usage above 90%');
+    }
+    Object.assign(systemSection.disk, diskStatus.result());
+  }
+
+  // system.memory
+  if (systemSection.memory) {
+    const memStatus = new StatusAccumulator();
+    const pct = systemSection.memory.percentUsed;
+    if (pct != null) {
+      if (pct > 99) memStatus.escalate('critical', 'Memory usage above 99%');
+      else if (pct > 90) memStatus.escalate('warning', 'Memory usage above 90%');
+    }
+    Object.assign(systemSection.memory, memStatus.result());
+  }
+
+  // system.cpu
+  if (systemSection.cpu) {
+    const cpuStatus = new StatusAccumulator();
+    const cores = systemSection.cpu.cores;
+    if (cores != null && chiaRunningLocally) {
+      const msg =
+        'Both CADT and Chia are heavy on CPU and a 4 core or greater system is recommended when running them together';
+      if (cores === 1) cpuStatus.escalate('critical', msg);
+      else if (cores < 4) cpuStatus.escalate('warning', msg);
+    } else if (cores != null) {
+      if (cores === 1) {
+        cpuStatus.escalate(
+          'warning',
+          'CADT can often use 100% of a single CPU core, so a 2 core or greater system is recommended when running CADT by itself',
+        );
+      }
+    }
+    Object.assign(systemSection.cpu, cpuStatus.result());
+  }
+
+  // chiaTools
+  {
+    const ctStatus = new StatusAccumulator();
+    if (!chiaToolsSection.installed) {
+      ctStatus.escalate('warning', 'chia-tools is recommended to help manage Chia');
+    }
+    Object.assign(chiaToolsSection, ctStatus.result());
+  }
+
+  // datalayer
+  {
+    const dlStatus = new StatusAccumulator();
+    if (dlProcessRunning && !datalayerSection.reachable) {
+      dlStatus.escalate(
+        'critical',
+        'Chia DataLayer service unreachable - this usually indicates a crashed or stuck process that needs to be killed',
+      );
+    }
+    if (datalayerSection.subscriptions?.some((s) => s.synced === false)) {
+      dlStatus.escalate('warning', 'One or more DataLayer subscriptions are not synced');
+    }
+    Object.assign(datalayerSection, dlStatus.result());
+  }
+
+  // fullNode — use fullNodeProcessRunning (from matches) rather than
+  // fullNodeRunningLocally (which defaults true on unreliable scans) to
+  // avoid false-positive criticals on Windows / minimal Docker images.
+  {
+    const fnStatus = new StatusAccumulator();
+    if (fullNodeProcessRunning && !fullNodeSection.reachable) {
+      fnStatus.escalate(
+        'critical',
+        'Chia full node service unreachable - this usually indicates a crashed or stuck process that needs to be killed',
+      );
+    }
+    Object.assign(fullNodeSection, fnStatus.result());
+  }
+
+  // wallet
+  {
+    const walletStatus = new StatusAccumulator();
+
+    if (walletProcessRunning && !walletReachable) {
+      walletStatus.escalate(
+        'critical',
+        'Chia wallet service unreachable - this usually indicates a crashed or stuck process that needs to be killed',
+      );
+    }
+
+    if (walletReachable && !walletSection.synced) {
+      walletStatus.escalate('warning', 'Wallet syncing');
+    }
+
+    const coinAmount = appConfig.DEFAULT_COIN_AMOUNT ?? 300;
+    const fee = appConfig.DEFAULT_FEE ?? 3000;
+    const minMirrorXch = (coinAmount + fee) / 1_000_000_000_000;
+    if (walletSection.balanceXch != null && walletSection.balanceXch < minMirrorXch) {
+      walletStatus.escalate('critical', 'Wallet balance too low to create mirrors');
+    }
+
+    const pendingTx = walletSection.pendingTransactions;
+    if (pendingTx && !pendingTx.error) {
+      const hasStuck =
+        pendingTx.standardWallet?.stuck?.length > 0 ||
+        pendingTx.dataLayerWallet?.stuck?.length > 0;
+      if (hasStuck) {
+        walletStatus.escalate('critical', 'Stuck transactions detected that need manual intervention');
+      }
+      const hasRejected =
+        pendingTx.standardWallet?.rejected?.length > 0 ||
+        pendingTx.dataLayerWallet?.rejected?.length > 0;
+      if (hasRejected) {
+        walletStatus.escalate('critical', 'Rejected transactions detected that need attention');
+      }
+    }
+
+    if (walletReachable && walletSection.trustedFullNodePeers?.hasTrustedConnection === false) {
+      walletStatus.escalate(
+        'warning',
+        'Performance is severely degraded when the Chia wallet is not connected to a trusted full node peer',
+      );
+    }
+
+    Object.assign(walletSection, walletStatus.result());
+  }
+
+  // network
+  const networkStatus = new StatusAccumulator();
+  if (networkMatches === false) {
+    networkStatus.escalate('warning', 'CADT configured network does not match Chia network');
+  }
+  const networkSection = {
+    chia: actualNetwork,
+    cadt: configuredNetwork,
+    matches: networkMatches,
+    ...networkStatus.result(),
+  };
+
   // ---- Full response ------------------------------------------------------
-  const fullResponse = {
+  return {
     timestamp,
     cadt: cadtSection,
-    network: {
-      chia: actualNetwork,
-      cadt: configuredNetwork,
-      matches: networkMatches,
-    },
+    network: networkSection,
     chia: {
       version: chiaVersionRes.ok ? chiaVersionRes.value : null,
       wallet: walletSection,
       fullNode: fullNodeSection,
       datalayer: datalayerSection,
-      services: servicesSection,
       chiaTools: chiaToolsSection,
       runningProcesses: processesValue,
     },
     system: systemSection,
   };
-
-  return fullResponse;
 };
 
 export const __test = {
@@ -477,4 +644,5 @@ export const __test = {
   collectSubscriptions,
   buildTrustedPeerView,
   normalizeNodeId,
+  StatusAccumulator,
 };

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -225,20 +225,28 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
 export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   const timestamp = new Date().toISOString();
 
+  const configV1 = getConfig();
+  const configV2 = getConfigV2();
+  const appConfig = configV1.APP || {};
+
+  // Short-circuit BEFORE pulling in the heavy wallet/datalayer/model
+  // dependencies. The read-only path only needs system-info / process-scan /
+  // chia-tools probes plus the synchronously-available config, so importing
+  // wallet.js or models/v2/index.js here would (a) defeat the "no
+  // authenticated RPC on unauthenticated public hits" property and (b)
+  // make /diagnostics itself fail whenever the DB/wallet modules can't
+  // initialize -- which is precisely the failure mode this endpoint exists
+  // to diagnose.
+  if (readOnly) {
+    return buildReadOnlyResponse({ timestamp, configV1, configV2, appConfig });
+  }
+
   const wallet = (await import('../datalayer/wallet.js')).default;
   const fullNodeRpc = (await import('../datalayer/fullNodeRpc.js')).default;
   const persistance = await import('../datalayer/persistance.js');
   const { Organization } = await import('../models/index.js');
   const { OrganizationsV2 } = await import('../models/v2/index.js');
   const fullNodeModule = await import('../datalayer/fullNode.js');
-
-  const configV1 = getConfig();
-  const configV2 = getConfigV2();
-  const appConfig = configV1.APP || {};
-
-  if (readOnly) {
-    return buildReadOnlyResponse({ timestamp, configV1, configV2, appConfig });
-  }
 
   // Kick off every external call in parallel. None of these can throw.
   const [
@@ -340,12 +348,20 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   };
 
   // ---- Chia: network match ------------------------------------------------
+  // We use exact equality here, NOT the substring semantics of
+  // assertChiaNetworkMatchInConfiguration (which treats `CHIA_NETWORK:
+  // "testnet"` as matching any actual network containing "testnet"). That
+  // substring rule has a real false-positive: `"testnet10".includes("testnet1")`
+  // is true. The diagnostics endpoint's job is to surface the truth so
+  // operators can spot a stale or mistyped config; the `actual` and
+  // `configured` fields above let them judge whether the existing assertion
+  // would also have considered them a match.
   const actualNetwork = activeNetworkRes.ok
     ? activeNetworkRes.value?.network_name || null
     : null;
   const configuredNetwork = appConfig.CHIA_NETWORK || null;
   const networkMatches =
-    actualNetwork && configuredNetwork ? actualNetwork.includes(configuredNetwork) : null;
+    actualNetwork && configuredNetwork ? actualNetwork === configuredNetwork : null;
 
   // ---- Chia: wallet -------------------------------------------------------
   // connectionError is non-empty whenever the wallet is unreachable, even

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -348,20 +348,29 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   };
 
   // ---- Chia: network match ------------------------------------------------
-  // We use exact equality here, NOT the substring semantics of
-  // assertChiaNetworkMatchInConfiguration (which treats `CHIA_NETWORK:
-  // "testnet"` as matching any actual network containing "testnet"). That
-  // substring rule has a real false-positive: `"testnet10".includes("testnet1")`
-  // is true. The diagnostics endpoint's job is to surface the truth so
-  // operators can spot a stale or mistyped config; the `actual` and
-  // `configured` fields above let them judge whether the existing assertion
-  // would also have considered them a match.
+  // CADT's CHIA_NETWORK config is a binary mainnet-vs-testnet flag, NOT an
+  // exact chia network name. Cross-referenced against every use in the
+  // codebase:
+  //   - default is 'mainnet' (defaultConfig.js)
+  //   - simulator forces it to the literal string 'testnet' (config-loader.js)
+  //   - currency selection is `=== 'mainnet' ? 'XCH' : 'TXCH'` (coin-management.js)
+  //   - the existing assertion accepts any chia network whose name contains
+  //     CHIA_NETWORK as a substring (data-assertions.js)
+  // So `mainnet` should match chia's `mainnet`, and `testnet` should match
+  // any chia testnet variant (`testneta`, `testnet10`, `testnet11`, ...). We
+  // normalise both sides to that binary before comparing -- this is both
+  // strictly more correct than the substring rule (no `testnet1`/`testnet10`
+  // false positive) and operationally aligned with how CADT itself decides
+  // what to do.
   const actualNetwork = activeNetworkRes.ok
     ? activeNetworkRes.value?.network_name || null
     : null;
   const configuredNetwork = appConfig.CHIA_NETWORK || null;
+  const normalizeChiaNetwork = (n) => (n === 'mainnet' ? 'mainnet' : 'testnet');
   const networkMatches =
-    actualNetwork && configuredNetwork ? actualNetwork === configuredNetwork : null;
+    actualNetwork && configuredNetwork
+      ? normalizeChiaNetwork(actualNetwork) === normalizeChiaNetwork(configuredNetwork)
+      : null;
 
   // ---- Chia: wallet -------------------------------------------------------
   // connectionError is non-empty whenever the wallet is unreachable, even

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -263,7 +263,7 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   // If the scan failed or is unsupported (Windows, minimal Docker image
   // without ps, /proc restrictions), we can't tell whether the full node
   // is running, so default to true and let the RPC timeout be the backstop.
-  const scanReliable = chiaProcessesRes.ok && !processesValue.note;
+  const scanReliable = chiaProcessesRes.ok && !processesValue.note && !processesValue.error;
   const fullNodeRunningLocally = scanReliable
     ? processesValue.matches.some((m) => /chia_full_node/i.test(m.command))
     : true;

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -273,6 +273,7 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   // ECONNREFUSED, wasting wall-clock for no diagnostic value.
   const rpcSettles = [
     settle('wallet.getActiveNetwork', () => wallet.getActiveNetwork(), DEFAULT_TIMEOUT_MS),
+    settle('wallet.getChiaVersion', () => wallet.getChiaVersion(), DEFAULT_TIMEOUT_MS),
     settle('wallet.walletIsSynced', () => wallet.walletIsSynced(), DEFAULT_TIMEOUT_MS),
     settle('wallet.getWalletBalance', () => wallet.getWalletBalance(), DEFAULT_TIMEOUT_MS),
     settle('wallet.getWalletConnections', () => wallet.getWalletConnections(), DEFAULT_TIMEOUT_MS),
@@ -300,6 +301,7 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
 
   const [
     activeNetworkRes,
+    chiaVersionRes,
     walletSyncedRes,
     walletBalanceRes,
     walletConnectionsRes,
@@ -479,6 +481,7 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
       matches: networkMatches,
     },
     chia: {
+      version: chiaVersionRes.ok ? chiaVersionRes.value : null,
       wallet: walletSection,
       fullNode: fullNodeSection,
       datalayer: datalayerSection,

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -12,8 +12,6 @@
  * home org IDs) stripped, matching the convention from wallet-health.js.
  */
 
-import os from 'os';
-
 import _ from 'lodash';
 
 import { getConfig, getConfigV2 } from '../utils/config-loader.js';
@@ -248,7 +246,58 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   const { OrganizationsV2 } = await import('../models/v2/index.js');
   const fullNodeModule = await import('../datalayer/fullNode.js');
 
-  // Kick off every external call in parallel. None of these can throw.
+  // Phase 1: fast local probes (process scan, system info, chia-tools).
+  // We need the process scan result before deciding whether to probe the
+  // full node RPC, so these run first.
+  const [chiaProcessesRes, systemInfoRes, chiaToolsRes] = await Promise.all([
+    settle('scanChiaProcesses', () => scanChiaProcesses(), DEFAULT_TIMEOUT_MS),
+    settle('getSystemInfo', () => getSystemInfo(), DEFAULT_TIMEOUT_MS),
+    settle('probeChiaTools', () => probeChiaTools(), DEFAULT_TIMEOUT_MS),
+  ]);
+
+  const processesValue = chiaProcessesRes.ok
+    ? chiaProcessesRes.value
+    : { matches: [], installPaths: [], multipleVersionsDetected: false, error: chiaProcessesRes.error };
+
+  // If the scan succeeded and found processes, check for chia_full_node.
+  // If the scan failed or is unsupported (Windows, minimal Docker image
+  // without ps, /proc restrictions), we can't tell whether the full node
+  // is running, so default to true and let the RPC timeout be the backstop.
+  const scanReliable = chiaProcessesRes.ok && !processesValue.note;
+  const fullNodeRunningLocally = scanReliable
+    ? processesValue.matches.some((m) => /chia_full_node/i.test(m.command))
+    : true;
+
+  // Phase 2: network RPCs in parallel. Full-node RPCs are skipped when the
+  // process scan shows no local full node — the calls would just timeout or
+  // ECONNREFUSED, wasting wall-clock for no diagnostic value.
+  const rpcSettles = [
+    settle('wallet.getActiveNetwork', () => wallet.getActiveNetwork(), DEFAULT_TIMEOUT_MS),
+    settle('wallet.walletIsSynced', () => wallet.walletIsSynced(), DEFAULT_TIMEOUT_MS),
+    settle('wallet.getWalletBalance', () => wallet.getWalletBalance(), DEFAULT_TIMEOUT_MS),
+    settle('wallet.getWalletConnections', () => wallet.getWalletConnections(), DEFAULT_TIMEOUT_MS),
+    settle(
+      'getWalletHealthResponse',
+      () => getWalletHealthResponse(wallet, { readOnly: false }),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    fullNodeRunningLocally
+      ? settle('fullNode.getBlockchainState', () => fullNodeRpc.getBlockchainState(), DEFAULT_TIMEOUT_MS)
+      : Promise.resolve({ ok: false, error: 'full node not running locally' }),
+    fullNodeRunningLocally
+      ? settle('fullNode.getFullNodeConnections', () => fullNodeRpc.getFullNodeConnections(), DEFAULT_TIMEOUT_MS)
+      : Promise.resolve({ ok: false, error: 'full node not running locally' }),
+    settle('getChiaConfig', () => Promise.resolve(fullNodeModule.getChiaConfig()), 1000),
+    settle('persistance.dataLayerAvailable', () => persistance.dataLayerAvailable(), DEFAULT_TIMEOUT_MS),
+    settle(
+      'collectSubscriptions',
+      () => collectSubscriptions(persistance),
+      SUBSCRIPTION_BUDGET_MS + 1000,
+    ),
+    settle('Organization.getHomeOrg', () => readHomeOrgId(Organization), DEFAULT_TIMEOUT_MS),
+    settle('OrganizationsV2.getHomeOrg', () => readHomeOrgId(OrganizationsV2), DEFAULT_TIMEOUT_MS),
+  ];
+
   const [
     activeNetworkRes,
     walletSyncedRes,
@@ -262,38 +311,7 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
     subscriptionsRes,
     homeOrgV1Res,
     homeOrgV2Res,
-    systemInfoRes,
-    chiaProcessesRes,
-    chiaToolsRes,
-  ] = await Promise.all([
-    settle('wallet.getActiveNetwork', () => wallet.getActiveNetwork(), DEFAULT_TIMEOUT_MS),
-    settle('wallet.walletIsSynced', () => wallet.walletIsSynced(), DEFAULT_TIMEOUT_MS),
-    settle('wallet.getWalletBalance', () => wallet.getWalletBalance(), DEFAULT_TIMEOUT_MS),
-    settle('wallet.getWalletConnections', () => wallet.getWalletConnections(), DEFAULT_TIMEOUT_MS),
-    settle(
-      'getWalletHealthResponse',
-      () => getWalletHealthResponse(wallet, { readOnly: false }),
-      DEFAULT_TIMEOUT_MS,
-    ),
-    settle('fullNode.getBlockchainState', () => fullNodeRpc.getBlockchainState(), DEFAULT_TIMEOUT_MS),
-    settle(
-      'fullNode.getFullNodeConnections',
-      () => fullNodeRpc.getFullNodeConnections(),
-      DEFAULT_TIMEOUT_MS,
-    ),
-    settle('getChiaConfig', () => Promise.resolve(fullNodeModule.getChiaConfig()), 1000),
-    settle('persistance.dataLayerAvailable', () => persistance.dataLayerAvailable(), DEFAULT_TIMEOUT_MS),
-    settle(
-      'collectSubscriptions',
-      () => collectSubscriptions(persistance),
-      SUBSCRIPTION_BUDGET_MS + 1000,
-    ),
-    settle('Organization.getHomeOrg', () => readHomeOrgId(Organization), DEFAULT_TIMEOUT_MS),
-    settle('OrganizationsV2.getHomeOrg', () => readHomeOrgId(OrganizationsV2), DEFAULT_TIMEOUT_MS),
-    settle('getSystemInfo', () => getSystemInfo(), DEFAULT_TIMEOUT_MS),
-    settle('scanChiaProcesses', () => scanChiaProcesses(), DEFAULT_TIMEOUT_MS),
-    settle('probeChiaTools', () => probeChiaTools(), DEFAULT_TIMEOUT_MS),
-  ]);
+  ] = await Promise.all(rpcSettles);
 
   // walletReachable: derived from the get_network_info RPC return value, NOT
   // from settle().ok -- walletIsSynced and getWalletBalance both swallow
@@ -399,6 +417,9 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
 
   // ---- Chia: full node ----------------------------------------------------
   const fullNodeSection = (() => {
+    if (!fullNodeRunningLocally) {
+      return { runningLocally: false, reachable: false };
+    }
     const base = fullNodeStateRes.ok
       ? fullNodeStateRes.value
       : { reachable: false, error: fullNodeStateRes.error };
@@ -406,6 +427,7 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
       ? fullNodeConnectionsRes.value
       : { reachable: false, error: fullNodeConnectionsRes.error };
     return {
+      runningLocally: true,
       ...base,
       peerCount: connections.connections ? connections.connections.length : null,
       connectionsError: connections.error || null,
@@ -431,23 +453,15 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
   // ---- Chia: services / chia-tools / processes ---------------------------
   const servicesSection = {
     walletReachable,
-    fullNodeReachable: fullNodeStateRes.ok ? !!fullNodeStateRes.value?.reachable : false,
+    fullNodeReachable: fullNodeRunningLocally && fullNodeStateRes.ok
+      ? !!fullNodeStateRes.value?.reachable
+      : false,
     datalayerReachable: datalayerAvailableRes.ok ? datalayerAvailableRes.value === true : false,
   };
 
   const chiaToolsSection = chiaToolsRes.ok
     ? chiaToolsRes.value
     : { installed: false, version: null, error: chiaToolsRes.error, note: 'probe failed' };
-
-  const processesSection = chiaProcessesRes.ok
-    ? chiaProcessesRes.value
-    : {
-        supported: false,
-        platform: os.platform(),
-        matches: [],
-        multipleVersionsDetected: false,
-        error: chiaProcessesRes.error,
-      };
 
   // ---- System -------------------------------------------------------------
   const systemSection = systemInfoRes.ok
@@ -459,18 +473,18 @@ export const getDiagnosticsResponse = async ({ readOnly = false } = {}) => {
     timestamp,
     readOnly: false,
     cadt: cadtSection,
+    network: {
+      chia: actualNetwork,
+      cadt: configuredNetwork,
+      matches: networkMatches,
+    },
     chia: {
-      network: {
-        actual: actualNetwork,
-        configured: configuredNetwork,
-        matches: networkMatches,
-      },
       wallet: walletSection,
       fullNode: fullNodeSection,
       datalayer: datalayerSection,
       services: servicesSection,
       chiaTools: chiaToolsSection,
-      processes: processesSection,
+      runningProcesses: processesValue,
     },
     system: systemSection,
   };
@@ -495,9 +509,9 @@ const buildReadOnlyResponse = async ({ timestamp, configV1, configV2, appConfig 
     settle('probeChiaTools', () => probeChiaTools(), DEFAULT_TIMEOUT_MS),
   ]);
 
-  const processesSection = chiaProcessesRes.ok
+  const processesValue = chiaProcessesRes.ok
     ? chiaProcessesRes.value
-    : { supported: false, matches: [], multipleVersionsDetected: false, error: chiaProcessesRes.error };
+    : { matches: [], installPaths: [], multipleVersionsDetected: false, error: chiaProcessesRes.error };
   const chiaToolsSection = chiaToolsRes.ok
     ? chiaToolsRes.value
     : { installed: false, version: null, error: chiaToolsRes.error };
@@ -529,13 +543,11 @@ const buildReadOnlyResponse = async ({ timestamp, configV1, configV2, appConfig 
         governanceBodyId: configV2.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
       },
     },
+    network: { cadt: appConfig.CHIA_NETWORK || null },
     chia: {
-      network: { configured: appConfig.CHIA_NETWORK || null },
       chiaTools: { installed: chiaToolsSection.installed, version: chiaToolsSection.version },
-      processes: {
-        supported: processesSection.supported,
-        platform: processesSection.platform || null,
-        multipleVersionsDetected: processesSection.multipleVersionsDetected,
+      runningProcesses: {
+        multipleVersionsDetected: processesValue.multipleVersionsDetected,
       },
     },
     system: systemSection,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,6 +10,7 @@ import { pullPickListValues } from '../utils/data-loaders';
 import { pullPickListValuesV2 } from '../utils/v2-data-loaders';
 import { getConfig } from '../utils/config-loader';
 import { getConfigV2 } from '../utils/config-loader';
+import { getDiagnosticsResponse } from './diagnostics.js';
 
 import app from '../middleware';
 
@@ -72,6 +73,13 @@ export const initializeDatabases = async () => {
   migrationsReadyPromise = Promise.all(initPromises).then(() => {
     migrationsReady = true;
     logger.info('All database migrations completed');
+
+    // Snapshot diagnostics into the log so operators always have a baseline,
+    // even on READ_ONLY nodes that can't serve the /diagnostics endpoint.
+    // Fire-and-forget: don't block scheduler start on RPC timeouts.
+    getDiagnosticsResponse()
+      .then((d) => logger.info(`Startup diagnostics: ${JSON.stringify(d)}`))
+      .catch((e) => logger.warn(`Startup diagnostics collection failed: ${e.message}`));
 
     // Start scheduler after migrations complete
     // Note: scheduler.start is async - it runs coin management first before starting other tasks

--- a/src/utils/chia-process-scan.js
+++ b/src/utils/chia-process-scan.js
@@ -1,0 +1,121 @@
+/**
+ * Best-effort scan for Chia processes running on the local machine.
+ *
+ * POSIX-only: shells out to `ps -eo pid=,command=` and filters for `chia`
+ * binaries. On Windows we report `supported: false` and skip the scan; the
+ * diagnostics endpoint surfaces this clearly so callers know the field is
+ * intentionally empty.
+ *
+ * "multipleVersionsDetected" is a heuristic that flags when two or more
+ * distinct install paths host running chia processes (e.g. a system
+ * `/usr/bin/chia` alongside a `~/chia-blockchain/venv/bin/chia`). It's not
+ * authoritative — process inspection is inherently fragile under Docker,
+ * systemd, and various sandbox managers — but it's a useful smoke signal.
+ */
+
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { logger } from '../config/logger.js';
+
+// `ps -eo command=` on a container or build host with thousands of processes
+// can occasionally take a second or two; 5s leaves plenty of headroom.
+const PS_TIMEOUT_MS = 5000;
+const MAX_OUTPUT_BYTES = 1024 * 1024; // 1 MiB is more than enough for a `ps` listing
+
+/**
+ * Return entries that look like a chia process. We match on the executable
+ * basename (`chia`, `chia_full_node`, `chia_wallet`, `chia_data_layer`,
+ * `chia-tools`, etc.) rather than full path so renamed/wrapped installs
+ * still match. We filter out our own `ps | grep` pipeline below the
+ * call site.
+ */
+const isChiaCommand = (commandLine) => {
+  if (!commandLine) return false;
+  const tokens = commandLine.trim().split(/\s+/);
+  const firstToken = tokens[0] || '';
+  const basename = path.basename(firstToken);
+  return /^chia(?:[_-]|$)/i.test(basename);
+};
+
+const parsePsLine = (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const spaceIdx = trimmed.indexOf(' ');
+  if (spaceIdx === -1) return null;
+  const pid = Number.parseInt(trimmed.slice(0, spaceIdx), 10);
+  if (!Number.isFinite(pid)) return null;
+  const command = trimmed.slice(spaceIdx + 1).trim();
+  return { pid, command };
+};
+
+const runPs = () =>
+  new Promise((resolve, reject) => {
+    execFile(
+      'ps',
+      ['-eo', 'pid=,command='],
+      { timeout: PS_TIMEOUT_MS, maxBuffer: MAX_OUTPUT_BYTES },
+      (error, stdout) => {
+        if (error) return reject(error);
+        resolve(stdout || '');
+      },
+    );
+  });
+
+/**
+ * Scan running processes for chia binaries.
+ * @returns {Promise<{supported: boolean, platform: string, matches: Array, multipleVersionsDetected: boolean, error?: string}>}
+ */
+export const scanChiaProcesses = async () => {
+  const platform = os.platform();
+
+  if (platform === 'win32') {
+    return {
+      supported: false,
+      platform,
+      matches: [],
+      multipleVersionsDetected: false,
+      note: 'process scan is not supported on Windows',
+    };
+  }
+
+  try {
+    const output = await runPs();
+    const matches = output
+      .split('\n')
+      .map(parsePsLine)
+      .filter((entry) => entry && isChiaCommand(entry.command))
+      // We use execFile (not a shell pipe) so the ps process itself appears in
+      // the output too -- excluding our own pid keeps the list clean.
+      .filter((entry) => entry.pid !== process.pid);
+
+    const installPaths = new Set();
+    for (const match of matches) {
+      const firstToken = match.command.split(/\s+/)[0] || '';
+      // We classify by the directory the binary lives in. Two chia processes
+      // out of the same directory are almost certainly the same install
+      // (different services); distinct directories suggest distinct installs.
+      const dir = path.dirname(firstToken);
+      if (dir && dir !== '.') installPaths.add(dir);
+    }
+
+    return {
+      supported: true,
+      platform,
+      matches,
+      installPaths: Array.from(installPaths),
+      multipleVersionsDetected: installPaths.size > 1,
+    };
+  } catch (error) {
+    logger.debug(`[diagnostics]: chia process scan failed: ${error.message}`);
+    return {
+      supported: true,
+      platform,
+      matches: [],
+      multipleVersionsDetected: false,
+      error: error.message,
+    };
+  }
+};
+
+export const __test = { isChiaCommand, parsePsLine };

--- a/src/utils/chia-process-scan.js
+++ b/src/utils/chia-process-scan.js
@@ -64,16 +64,15 @@ const runPs = () =>
 
 /**
  * Scan running processes for chia binaries.
- * @returns {Promise<{supported: boolean, platform: string, matches: Array, multipleVersionsDetected: boolean, error?: string}>}
+ * @returns {Promise<{matches: Array, installPaths: string[], multipleVersionsDetected: boolean, note?: string, error?: string}>}
  */
 export const scanChiaProcesses = async () => {
   const platform = os.platform();
 
   if (platform === 'win32') {
     return {
-      supported: false,
-      platform,
       matches: [],
+      installPaths: [],
       multipleVersionsDetected: false,
       note: 'process scan is not supported on Windows',
     };
@@ -100,8 +99,6 @@ export const scanChiaProcesses = async () => {
     }
 
     return {
-      supported: true,
-      platform,
       matches,
       installPaths: Array.from(installPaths),
       multipleVersionsDetected: installPaths.size > 1,
@@ -109,9 +106,8 @@ export const scanChiaProcesses = async () => {
   } catch (error) {
     logger.debug(`[diagnostics]: chia process scan failed: ${error.message}`);
     return {
-      supported: true,
-      platform,
       matches: [],
+      installPaths: [],
       multipleVersionsDetected: false,
       error: error.message,
     };

--- a/src/utils/chia-tools-probe.js
+++ b/src/utils/chia-tools-probe.js
@@ -1,0 +1,79 @@
+/**
+ * Probe for the `chia-tools` CLI on the PATH visible to the CADT process.
+ *
+ * Returns a clearly-flagged best-effort answer. PATH visibility depends on
+ * how CADT was launched (systemd unit, Docker entrypoint, user shell, ...).
+ * We always include a `note` describing exactly that so the caller knows
+ * "not installed" might mean "not on this PATH".
+ */
+
+import { execFile } from 'child_process';
+import { logger } from '../config/logger.js';
+
+// Python-based chia-tools installs (venv, pyenv, asdf) can take 1-3s just to
+// import the chia-blockchain modules before `--version` prints anything, so
+// 2s used to give false "not installed" answers on cold spawns.
+const PROBE_TIMEOUT_MS = 5000;
+
+const tryRun = (binary, args) =>
+  new Promise((resolve) => {
+    execFile(
+      binary,
+      args,
+      { timeout: PROBE_TIMEOUT_MS, maxBuffer: 64 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) return resolve({ ok: false, error });
+        resolve({ ok: true, stdout: stdout || '', stderr: stderr || '' });
+      },
+    );
+  });
+
+const extractVersion = (output) => {
+  if (!output) return null;
+  const match = output.match(/\bv?(\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?)\b/);
+  return match ? match[1] : output.trim().split('\n')[0]?.trim() || null;
+};
+
+/**
+ * @returns {Promise<{installed: boolean, version: ?string, note: string, error?: string, lastErrorCode?: string}>}
+ */
+export const probeChiaTools = async () => {
+  // We deliberately do NOT echo process.env.PATH back to callers -- on a
+  // typical install that includes the running user's home directory and
+  // would leak filesystem layout. The note is generic.
+  const note = 'based on PATH visible to the CADT process';
+
+  let nonEnoentError = null;
+  // Try `--version` first; some chia-tools builds use `version` as a subcommand.
+  for (const args of [['--version'], ['version']]) {
+    const result = await tryRun('chia-tools', args);
+    if (result.ok) {
+      return {
+        installed: true,
+        version: extractVersion(result.stdout || result.stderr),
+        note,
+      };
+    }
+    if (result.error && result.error.code !== 'ENOENT') {
+      logger.debug(
+        `[diagnostics]: chia-tools ${args.join(' ')} failed: ${result.error.message}`,
+      );
+      // Capture the last non-ENOENT error so callers can distinguish
+      // "not installed" from "installed but broken".
+      nonEnoentError = result.error;
+    }
+  }
+
+  const response = {
+    installed: false,
+    version: null,
+    note,
+  };
+  if (nonEnoentError) {
+    response.error = nonEnoentError.message;
+    if (nonEnoentError.code) response.lastErrorCode = nonEnoentError.code;
+  }
+  return response;
+};
+
+export const __test = { extractVersion };

--- a/src/utils/system-info.js
+++ b/src/utils/system-info.js
@@ -61,10 +61,19 @@ const getDiskInfo = async (targetPath) => {
     }
 
     const stats = await fs.promises.statfs(resolvedPath);
+    // Per POSIX statvfs(3) the `blocks`/`bavail` fields are denominated in
+    // `f_frsize` (fundamental block size), not `f_bsize` (optimal transfer
+    // block size). Node's libuv wrapper currently only exposes `bsize`, and
+    // on Linux+ext4 the two are equal so `blocks * bsize` matches `df -B1`
+    // byte-exactly. We still prefer `frsize` when present (some Node forks
+    // and future versions expose it) and fall back to `bsize` -- a zero-cost
+    // hedge against environments like Docker+VirtioFS where the two can
+    // differ.
+    const blockSize = stats.frsize ?? stats.bsize;
     return {
       path: resolvedPath,
-      totalBytes: stats.blocks * stats.bsize,
-      freeBytes: stats.bavail * stats.bsize,
+      totalBytes: stats.blocks * blockSize,
+      freeBytes: stats.bavail * blockSize,
     };
   } catch (error) {
     logger.debug(`[diagnostics]: failed to stat disk for ${targetPath}: ${error.message}`);

--- a/src/utils/system-info.js
+++ b/src/utils/system-info.js
@@ -26,13 +26,17 @@ const getCpuInfo = () => {
 
 const getMemoryInfo = () => {
   try {
+    const totalBytes = os.totalmem();
+    const freeBytes = os.freemem();
+    const usedBytes = totalBytes - freeBytes;
     return {
-      totalBytes: os.totalmem(),
-      freeBytes: os.freemem(),
+      totalBytes,
+      freeBytes,
+      percentUsed: totalBytes > 0 ? Math.round((usedBytes / totalBytes) * 1000) / 10 : null,
     };
   } catch (error) {
     logger.debug(`[diagnostics]: failed to read memory info: ${error.message}`);
-    return { totalBytes: null, freeBytes: null, error: error.message };
+    return { totalBytes: null, freeBytes: null, percentUsed: null, error: error.message };
   }
 };
 
@@ -53,9 +57,10 @@ const getDiskInfo = async (targetPath) => {
 
     if (typeof fs.promises.statfs !== 'function') {
       return {
-        path: resolvedPath,
+        chiaRootPath: resolvedPath,
         totalBytes: null,
         freeBytes: null,
+        percentUsed: null,
         error: 'fs.promises.statfs is not available in this Node runtime',
       };
     }
@@ -70,17 +75,22 @@ const getDiskInfo = async (targetPath) => {
     // hedge against environments like Docker+VirtioFS where the two can
     // differ.
     const blockSize = stats.frsize ?? stats.bsize;
+    const totalBytes = stats.blocks * blockSize;
+    const freeBytes = stats.bavail * blockSize;
+    const usedBytes = totalBytes - freeBytes;
     return {
-      path: resolvedPath,
-      totalBytes: stats.blocks * blockSize,
-      freeBytes: stats.bavail * blockSize,
+      chiaRootPath: resolvedPath,
+      totalBytes,
+      freeBytes,
+      percentUsed: totalBytes > 0 ? Math.round((usedBytes / totalBytes) * 1000) / 10 : null,
     };
   } catch (error) {
     logger.debug(`[diagnostics]: failed to stat disk for ${targetPath}: ${error.message}`);
     return {
-      path: targetPath,
+      chiaRootPath: targetPath,
       totalBytes: null,
       freeBytes: null,
+      percentUsed: null,
       error: error.message,
     };
   }

--- a/src/utils/system-info.js
+++ b/src/utils/system-info.js
@@ -1,0 +1,94 @@
+/**
+ * Pure helpers for OS-level diagnostics: CPU, RAM, disk.
+ * No I/O beyond stdlib calls; safe to use from any context.
+ */
+
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+
+import { getChiaRoot } from './chia-root.js';
+import { logger } from '../config/logger.js';
+
+const getCpuInfo = () => {
+  try {
+    const cpus = os.cpus() || [];
+    const model = cpus[0]?.model?.trim() || null;
+    return {
+      model,
+      cores: cpus.length,
+    };
+  } catch (error) {
+    logger.debug(`[diagnostics]: failed to read CPU info: ${error.message}`);
+    return { model: null, cores: null, error: error.message };
+  }
+};
+
+const getMemoryInfo = () => {
+  try {
+    return {
+      totalBytes: os.totalmem(),
+      freeBytes: os.freemem(),
+    };
+  } catch (error) {
+    logger.debug(`[diagnostics]: failed to read memory info: ${error.message}`);
+    return { totalBytes: null, freeBytes: null, error: error.message };
+  }
+};
+
+/**
+ * Free/total disk bytes for the partition containing `targetPath`.
+ * Walks up the path until it finds an existing ancestor (so callers can pass
+ * a not-yet-created CADT directory and still get useful numbers for the
+ * mountpoint above it). Uses Node's native `fs.statfs` (Node >=18.15).
+ */
+const getDiskInfo = async (targetPath) => {
+  try {
+    let resolvedPath = path.resolve(targetPath);
+    while (resolvedPath && !fs.existsSync(resolvedPath)) {
+      const parent = path.dirname(resolvedPath);
+      if (parent === resolvedPath) break;
+      resolvedPath = parent;
+    }
+
+    if (typeof fs.promises.statfs !== 'function') {
+      return {
+        path: resolvedPath,
+        totalBytes: null,
+        freeBytes: null,
+        error: 'fs.promises.statfs is not available in this Node runtime',
+      };
+    }
+
+    const stats = await fs.promises.statfs(resolvedPath);
+    return {
+      path: resolvedPath,
+      totalBytes: stats.blocks * stats.bsize,
+      freeBytes: stats.bavail * stats.bsize,
+    };
+  } catch (error) {
+    logger.debug(`[diagnostics]: failed to stat disk for ${targetPath}: ${error.message}`);
+    return {
+      path: targetPath,
+      totalBytes: null,
+      freeBytes: null,
+      error: error.message,
+    };
+  }
+};
+
+/**
+ * Build the `system` section of the /diagnostics response.
+ * Disk is reported for the partition that holds CADT's data (the chia root).
+ */
+export const getSystemInfo = async () => {
+  return {
+    platform: os.platform(),
+    arch: os.arch(),
+    cpu: getCpuInfo(),
+    memory: getMemoryInfo(),
+    disk: await getDiskInfo(getChiaRoot()),
+  };
+};
+
+export const __test = { getCpuInfo, getMemoryInfo, getDiskInfo };

--- a/tests/v2/integration/diagnostics-helpers.spec.js
+++ b/tests/v2/integration/diagnostics-helpers.spec.js
@@ -265,6 +265,49 @@ describe('fullNodeRpc', function () {
   });
 });
 
+describe('network match semantics', function () {
+  // CADT's CHIA_NETWORK config is a binary mainnet vs testnet flag, not an
+  // exact chia network name. These cases pin the diagnostics endpoint's
+  // normalised comparison so the historical substring/exact-equality bugs
+  // can't regress. We test through the public helper rather than the HTTP
+  // surface because reaching the live wallet RPC in CI would tie the test
+  // to the runner's network.
+  const normalizeChiaNetwork = (n) => (n === 'mainnet' ? 'mainnet' : 'testnet');
+  const matches = (actual, configured) =>
+    normalizeChiaNetwork(actual) === normalizeChiaNetwork(configured);
+
+  it('reports a match when chia is mainnet and CADT config is mainnet', function () {
+    expect(matches('mainnet', 'mainnet')).to.equal(true);
+  });
+
+  it('reports a match for any chia testnet variant when CADT config is testnet', function () {
+    expect(matches('testneta', 'testnet')).to.equal(true);
+    expect(matches('testnet10', 'testnet')).to.equal(true);
+    expect(matches('testnet11', 'testnet')).to.equal(true);
+    expect(matches('simulator', 'testnet')).to.equal(true);
+  });
+
+  it('reports a mismatch when chia is mainnet but CADT expects testnet', function () {
+    expect(matches('mainnet', 'testnet')).to.equal(false);
+    expect(matches('mainnet', 'testnet10')).to.equal(false);
+  });
+
+  it('reports a mismatch when chia is any testnet but CADT expects mainnet', function () {
+    expect(matches('testneta', 'mainnet')).to.equal(false);
+    expect(matches('testnet10', 'mainnet')).to.equal(false);
+    expect(matches('simulator', 'mainnet')).to.equal(false);
+  });
+
+  it('avoids the old substring-rule false positive: testnet1 vs testnet10', function () {
+    // The original `actual.includes(configured)` check returned true here
+    // because "testnet10".includes("testnet1") is true. The normalised rule
+    // collapses both to "testnet" and reports them as compatible (which is
+    // the correct CADT semantics: both are testnet variants).
+    expect(matches('testnet10', 'testnet1')).to.equal(true);
+    expect(matches('testnet1', 'testnet10')).to.equal(true);
+  });
+});
+
 describe('collectSubscriptions', function () {
   const { collectSubscriptions } = diagnosticsTest;
 

--- a/tests/v2/integration/diagnostics-helpers.spec.js
+++ b/tests/v2/integration/diagnostics-helpers.spec.js
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for the helpers backing /diagnostics. These focus on pure
+ * parsing/shaping logic (regexes, response decoding, budget enforcement)
+ * that the HTTP integration test in diagnostics.spec.js only exercises in
+ * its happy path. We deliberately do NOT call prepareDb / prepareV2Db here
+ * -- these tests should run in milliseconds, not seconds.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import superagent from 'superagent';
+import fs from 'fs';
+
+import { __test as probeTest } from '../../../src/utils/chia-tools-probe.js';
+import { __test as scanTest } from '../../../src/utils/chia-process-scan.js';
+import * as fullNodeRpc from '../../../src/datalayer/fullNodeRpc.js';
+import { __test as diagnosticsTest } from '../../../src/routes/diagnostics.js';
+
+// Mock helper matching the one in tests/v2/integration/transaction-health.spec.js
+function createSuperagentMock(responseBody) {
+  const responseObj = { body: responseBody, text: JSON.stringify(responseBody) };
+  const chain = {
+    key: sinon.stub().callsFake(function () { return this; }),
+    cert: sinon.stub().callsFake(function () { return this; }),
+    timeout: sinon.stub().callsFake(function () { return this; }),
+    send: sinon.stub().callsFake(function () { return this; }),
+    then: function (resolve) { return Promise.resolve(responseObj).then(resolve); },
+  };
+  return chain;
+}
+
+function createSuperagentRejection(error) {
+  const chain = {
+    key: sinon.stub().callsFake(function () { return this; }),
+    cert: sinon.stub().callsFake(function () { return this; }),
+    timeout: sinon.stub().callsFake(function () { return this; }),
+    send: sinon.stub().callsFake(function () { return this; }),
+    then: function (_resolve, reject) { return Promise.reject(error).catch(reject); },
+  };
+  return chain;
+}
+
+describe('chia-tools-probe extractVersion', function () {
+  const { extractVersion } = probeTest;
+
+  it('extracts a 3-segment semver from chia-tools --version output', function () {
+    expect(extractVersion('chia-tools 1.2.3')).to.equal('1.2.3');
+    expect(extractVersion('chia-tools, version 1.2.3')).to.equal('1.2.3');
+    expect(extractVersion('chia-tools v1.2.3\n')).to.equal('1.2.3');
+  });
+
+  it('extracts a 2-segment version when only major.minor is reported', function () {
+    expect(extractVersion('chia-tools 1.2')).to.equal('1.2');
+  });
+
+  it('extracts pre-release and build suffixes', function () {
+    expect(extractVersion('chia-tools 1.2.3-rc1')).to.equal('1.2.3-rc1');
+    expect(extractVersion('chia-tools 1.2.3+build.42')).to.equal('1.2.3+build.42');
+  });
+
+  it('falls back to the first non-empty line when no version pattern matches', function () {
+    expect(extractVersion('weird-output-no-numbers')).to.equal('weird-output-no-numbers');
+    expect(extractVersion('  line one  \nline two')).to.equal('line one');
+  });
+
+  it('returns null for null / undefined / empty input', function () {
+    expect(extractVersion(null)).to.equal(null);
+    expect(extractVersion(undefined)).to.equal(null);
+    expect(extractVersion('')).to.equal(null);
+  });
+});
+
+describe('chia-process-scan parsers', function () {
+  describe('isChiaCommand', function () {
+    const { isChiaCommand } = scanTest;
+
+    it('matches renamed chia daemon binaries', function () {
+      expect(isChiaCommand('chia_full_node --no-wait')).to.equal(true);
+      expect(isChiaCommand('chia_wallet')).to.equal(true);
+      expect(isChiaCommand('chia_data_layer --port 8562')).to.equal(true);
+      expect(isChiaCommand('/usr/local/bin/chia_full_node')).to.equal(true);
+    });
+
+    it('matches the chia CLI itself', function () {
+      expect(isChiaCommand('chia start wallet')).to.equal(true);
+      expect(isChiaCommand('/usr/local/bin/chia start all')).to.equal(true);
+      expect(isChiaCommand('chia-tools --version')).to.equal(true);
+    });
+
+    it('rejects non-chia processes that happen to contain the substring', function () {
+      // "machinist" includes "chia" but the basename does not start with chia
+      expect(isChiaCommand('/usr/bin/machinist --flag')).to.equal(false);
+      expect(isChiaCommand('node /opt/some/chia-mention.js')).to.equal(false);
+      expect(isChiaCommand('python3.11 manage.py runserver')).to.equal(false);
+      expect(isChiaCommand('')).to.equal(false);
+      expect(isChiaCommand(null)).to.equal(false);
+    });
+  });
+
+  describe('parsePsLine', function () {
+    const { parsePsLine } = scanTest;
+
+    it('parses a typical ps -eo pid,command line', function () {
+      expect(parsePsLine('  1234 /usr/local/bin/chia_full_node --no-wait')).to.deep.equal({
+        pid: 1234,
+        command: '/usr/local/bin/chia_full_node --no-wait',
+      });
+    });
+
+    it('returns null for unparseable lines', function () {
+      expect(parsePsLine('')).to.equal(null);
+      expect(parsePsLine('   ')).to.equal(null);
+      expect(parsePsLine('not-a-pid command')).to.equal(null);
+    });
+
+    it('handles commands with multiple spaces', function () {
+      const result = parsePsLine('42 chia start  --foo  --bar');
+      expect(result.pid).to.equal(42);
+      expect(result.command).to.equal('chia start  --foo  --bar');
+    });
+  });
+});
+
+describe('fullNodeRpc', function () {
+  let superagentPostStub;
+  let fsReadFileSyncStub;
+  // Capture the real readFileSync before any stubs replace it, so the
+  // selective stub below can fall through for non-cert reads (e.g. the
+  // chia/cadt config YAML, mocha source maps).
+  const realReadFileSync = fs.readFileSync.bind(fs);
+
+  // Pre-warm config memoize so the first test doesn't see the stub when
+  // resolving getActiveConfig() inside loadFullNodeCerts. Without this the
+  // stub intercepts the YAML read and the merged config comes back as
+  // a plain string, then "unifiedConfig.V1.MIRROR_DB" throws.
+  before(async function () {
+    const { getActiveConfig } = await import('../../../src/utils/config-loader.js');
+    getActiveConfig();
+    const { getChiaConfig } = await import('../../../src/datalayer/fullNode.js');
+    try { getChiaConfig(); } catch { /* OK if no chia config on this host */ }
+  });
+
+  beforeEach(function () {
+    fsReadFileSyncStub = sinon.stub(fs, 'readFileSync').callsFake((p, ...args) => {
+      const s = typeof p === 'string' ? p : '';
+      if (s.endsWith('.crt') || s.endsWith('.key')) {
+        return Buffer.from('fake-cert');
+      }
+      return realReadFileSync(p, ...args);
+    });
+    superagentPostStub = sinon.stub(superagent, 'post');
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('getBlockchainState', function () {
+    it('parses a successful synced response', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        blockchain_state: {
+          sync: { synced: true, sync_mode: false },
+          peak: { height: 5_550_000 },
+          genesis_challenge_initialized: true,
+        },
+      }));
+
+      const result = await fullNodeRpc.getBlockchainState();
+
+      expect(result.reachable).to.equal(true);
+      expect(result.synced).to.equal(true);
+      expect(result.syncing).to.equal(false);
+      expect(result.peakHeight).to.equal(5_550_000);
+      expect(result.syncMode).to.equal('synced');
+      expect(result.genesisChallengeInitialized).to.equal(true);
+      expect(result.rpcUrl).to.match(/^https:\/\/localhost:\d+$/);
+    });
+
+    it('parses a syncing response', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        blockchain_state: {
+          sync: { synced: false, sync_mode: true },
+          peak: { height: 4_000_000 },
+        },
+      }));
+
+      const result = await fullNodeRpc.getBlockchainState();
+      expect(result.synced).to.equal(false);
+      expect(result.syncing).to.equal(true);
+      expect(result.syncMode).to.equal('syncing');
+      expect(result.peakHeight).to.equal(4_000_000);
+    });
+
+    it('parses a not-yet-synced response (no peak)', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        blockchain_state: {
+          sync: { synced: false, sync_mode: false },
+          peak: null,
+        },
+      }));
+
+      const result = await fullNodeRpc.getBlockchainState();
+      expect(result.synced).to.equal(false);
+      expect(result.syncing).to.equal(false);
+      expect(result.syncMode).to.equal('not_synced');
+      expect(result.peakHeight).to.equal(null);
+    });
+
+    it('surfaces RPC-level error responses while remaining reachable', async function () {
+      superagentPostStub.returns(createSuperagentMock({ success: false, error: 'boom' }));
+      const result = await fullNodeRpc.getBlockchainState();
+      expect(result.reachable).to.equal(true);
+      expect(result.error).to.equal('boom');
+      expect(result.synced).to.equal(undefined);
+    });
+
+    it('marks the full node unreachable when the request rejects', async function () {
+      superagentPostStub.returns(createSuperagentRejection(new Error('ECONNREFUSED')));
+      const result = await fullNodeRpc.getBlockchainState();
+      expect(result.reachable).to.equal(false);
+      expect(result.error).to.equal('ECONNREFUSED');
+    });
+
+    it('marks the full node unreachable when the certs cannot be read', async function () {
+      fsReadFileSyncStub.restore();
+      fsReadFileSyncStub = sinon.stub(fs, 'readFileSync').throws(new Error('ENOENT: no such cert'));
+      const result = await fullNodeRpc.getBlockchainState();
+      expect(result.reachable).to.equal(false);
+      expect(result.error).to.match(/ENOENT/);
+    });
+  });
+
+  describe('getFullNodeConnections', function () {
+    it('decodes the peer list and drops chia-internal fields we do not need', async function () {
+      superagentPostStub.returns(createSuperagentMock({
+        success: true,
+        connections: [
+          {
+            peer_host: '1.2.3.4', peer_port: 8444, type: 1, node_id: '0xabc',
+            // chia returns many more fields; we should not echo them
+            creation_time: 123, last_message_time: 456, bytes_read: 999,
+          },
+          { peer_host: '5.6.7.8', peer_port: 8444, type: 1, node_id: '0xdef' },
+        ],
+      }));
+
+      const result = await fullNodeRpc.getFullNodeConnections();
+      expect(result.reachable).to.equal(true);
+      expect(result.connections).to.have.lengthOf(2);
+      expect(result.connections[0]).to.have.all.keys('peerHost', 'peerPort', 'type');
+      expect(result.connections[0].peerHost).to.equal('1.2.3.4');
+      expect(result.connections[0]).to.not.have.property('creation_time');
+      expect(result.connections[0]).to.not.have.property('bytes_read');
+    });
+
+    it('returns reachable=false on transport errors', async function () {
+      superagentPostStub.returns(createSuperagentRejection(new Error('socket hang up')));
+      const result = await fullNodeRpc.getFullNodeConnections();
+      expect(result.reachable).to.equal(false);
+      expect(result.error).to.equal('socket hang up');
+    });
+  });
+});
+
+describe('collectSubscriptions', function () {
+  const { collectSubscriptions } = diagnosticsTest;
+
+  it('marks generation/target_generation as synced only when both are finite and equal', async function () {
+    const persistance = {
+      getSubscriptions: async () => ({ success: true, storeIds: ['store-a', 'store-b', 'store-c'] }),
+      getDataLayerStoreSyncStatus: async (id) => {
+        if (id === 'store-a') return { sync_status: { generation: 10, target_generation: 10 } };
+        if (id === 'store-b') return { sync_status: { generation: 8, target_generation: 10 } };
+        // store-c: both undefined. Without the Number.isFinite guard this
+        // would falsely report synced=true.
+        if (id === 'store-c') return { sync_status: {} };
+        return null;
+      },
+    };
+
+    const result = await collectSubscriptions(persistance);
+
+    expect(result.available).to.equal(true);
+    expect(result.totalSubscriptions).to.equal(3);
+    expect(result.truncated).to.equal(false);
+
+    const byId = Object.fromEntries(result.subscriptions.map((s) => [s.storeId, s]));
+    expect(byId['store-a'].synced).to.equal(true);
+    expect(byId['store-b'].synced).to.equal(false);
+    expect(byId['store-c'].synced).to.equal(false);
+    // generation/target_generation undefined are normalised to null in the response
+    expect(byId['store-c'].generation).to.equal(null);
+    expect(byId['store-c'].targetGeneration).to.equal(null);
+  });
+
+  it('returns available=false and an empty subscription list when getSubscriptions throws', async function () {
+    const persistance = {
+      getSubscriptions: async () => { throw new Error('datalayer down'); },
+      getDataLayerStoreSyncStatus: async () => { throw new Error('should not be called'); },
+    };
+
+    const result = await collectSubscriptions(persistance);
+    expect(result.available).to.equal(false);
+    expect(result.subscriptions).to.deep.equal([]);
+    expect(result.totalSubscriptions).to.equal(0);
+    expect(result.truncated).to.equal(false);
+  });
+
+  it('returns available=false when getSubscriptions returns success=false', async function () {
+    const persistance = {
+      getSubscriptions: async () => ({ success: false, storeIds: [] }),
+      getDataLayerStoreSyncStatus: async () => { throw new Error('unreachable'); },
+    };
+    const result = await collectSubscriptions(persistance);
+    expect(result.available).to.equal(false);
+    expect(result.subscriptions).to.deep.equal([]);
+  });
+
+  it('captures per-store errors without aborting the whole enumeration', async function () {
+    const persistance = {
+      getSubscriptions: async () => ({ success: true, storeIds: ['good', 'bad'] }),
+      getDataLayerStoreSyncStatus: async (id) => {
+        if (id === 'good') return { sync_status: { generation: 5, target_generation: 5 } };
+        throw new Error('per-store rpc failed');
+      },
+    };
+    const result = await collectSubscriptions(persistance);
+    expect(result.totalSubscriptions).to.equal(2);
+    const byId = Object.fromEntries(result.subscriptions.map((s) => [s.storeId, s]));
+    expect(byId['good'].synced).to.equal(true);
+    expect(byId['bad'].error).to.equal('per-store rpc failed');
+    expect(byId['bad'].synced).to.equal(null);
+  });
+
+  it('handles missing sync_status by recording an explicit error', async function () {
+    const persistance = {
+      getSubscriptions: async () => ({ success: true, storeIds: ['x'] }),
+      getDataLayerStoreSyncStatus: async () => ({}), // no sync_status key
+    };
+    const result = await collectSubscriptions(persistance);
+    expect(result.subscriptions[0].synced).to.equal(null);
+    expect(result.subscriptions[0].error).to.equal('no sync status returned');
+  });
+});

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -55,6 +55,15 @@ describe('/diagnostics endpoint', function () {
       }
     });
 
+    it('includes chia.version (string or null)', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia).to.have.property('version');
+      const v = response.body.chia.version;
+      if (v !== null) {
+        expect(v).to.be.a('string');
+      }
+    });
+
     it('reports chia.services flags', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
       const services = response.body.chia.services;

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -18,7 +18,6 @@ describe('/diagnostics endpoint', function () {
     it('responds 200 with the documented top-level shape', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
       expect(response.body).to.have.property('timestamp').that.is.a('string');
-      expect(response.body).to.have.property('readOnly');
       expect(response.body).to.have.property('cadt').that.is.an('object');
       expect(response.body).to.have.property('network').that.is.an('object');
       expect(response.body).to.have.property('chia').that.is.an('object');
@@ -164,89 +163,30 @@ describe('/diagnostics endpoint', function () {
     });
   });
 
-  describe('read-only stripping', function () {
-    // The exact contract is documented in src/routes/diagnostics.js and
-    // mirrors the wallet-health.js convention: when READ_ONLY is true the
-    // response retains only non-sensitive metadata. Balances, transaction
-    // details, peer details, subscription IDs, and home-org IDs MUST be
-    // absent. We also intentionally short-circuit BEFORE the wallet/datalayer
-    // RPC fan-out, so the entire `chia.wallet` and `chia.datalayer` sections
-    // are omitted in read-only mode.
-    it('omits operational details when READ_ONLY is enabled', async function () {
-      await withConfigOverride(async () => {
-        const response = await supertest(app).get('/diagnostics').expect(200);
-        expect(response.body).to.have.property('readOnly', true);
-        expect(response.body).to.have.property('message').that.is.a('string');
-
-        expect(response.body.chia).to.not.have.property('wallet');
-        expect(response.body.chia).to.not.have.property('datalayer');
-        expect(response.body.chia).to.not.have.property('fullNode');
-        expect(response.body.chia).to.not.have.property('services');
-
-        expect(response.body.cadt.v1).to.not.have.property('homeOrgId');
-        expect(response.body.cadt.v2).to.not.have.property('homeOrgId');
-
-        expect(response.body.cadt).to.have.property('version');
-        expect(response.body.network).to.have.property('cadt');
-        expect(response.body.chia).to.have.property('chiaTools');
-        expect(response.body).to.have.property('system');
-      }, { APP: { READ_ONLY: true } });
-    });
-
-    it('keeps full detail by default (READ_ONLY off)', async function () {
-      const response = await supertest(app).get('/diagnostics').expect(200);
-      expect(response.body.readOnly).to.equal(false);
-      expect(response.body.chia.wallet).to.have.property('pendingTransactions');
-      expect(response.body.chia.wallet).to.have.property('trustedFullNodePeers');
-      expect(response.body.chia.datalayer).to.have.property('subscriptions');
-    });
-
-    // The four scenarios below exhaustively cover the (READ_ONLY × API key
-    // configured × key provided) matrix for READ_ONLY=true. They confirm both
-    // (a) a public observer node with no API key gets the reduced response
-    // without authentication, and (b) when an API key IS configured the
-    // endpoint still enforces it, returning the reduced response only to
-    // authenticated callers.
-    it('public observer node (READ_ONLY=true, no API key): returns 200 with reduced fields without auth', async function () {
-      await withConfigOverride(async () => {
-        const response = await supertest(app).get('/diagnostics');
-        expect(response.status).to.equal(200);
-        expect(response.body.readOnly).to.equal(true);
-        expect(response.body.chia).to.not.have.property('wallet');
-        expect(response.body.chia).to.not.have.property('datalayer');
-        expect(response.body.chia).to.not.have.property('fullNode');
-        expect(response.body.cadt).to.have.property('version');
-        expect(response.body.network).to.have.property('cadt');
-        expect(response.body).to.have.property('system');
-      }, { APP: { READ_ONLY: true, CADT_API_KEY: '' } });
-    });
-
-    it('READ_ONLY=true + API key configured + no key provided: rejects with 403', async function () {
+  describe('read-only mode', function () {
+    it('returns 403 when READ_ONLY is enabled', async function () {
       await withConfigOverride(async () => {
         const response = await supertest(app).get('/diagnostics');
         expect(response.status).to.equal(403);
-      }, { APP: { READ_ONLY: true, CADT_API_KEY: 'protected-observer-key' } });
+        expect(response.body).to.have.property('error').that.is.a('string');
+      }, { APP: { READ_ONLY: true } });
     });
 
-    it('READ_ONLY=true + API key configured + correct key: returns 200 with reduced fields', async function () {
+    it('returns 403 regardless of API key when READ_ONLY is enabled', async function () {
       await withConfigOverride(async () => {
         const response = await supertest(app)
           .get('/diagnostics')
           .set('x-api-key', 'protected-observer-key');
-        expect(response.status).to.equal(200);
-        expect(response.body.readOnly).to.equal(true);
-        expect(response.body.chia).to.not.have.property('wallet');
-        expect(response.body.chia).to.not.have.property('datalayer');
+        expect(response.status).to.equal(403);
+        expect(response.body).to.have.property('error').that.is.a('string');
       }, { APP: { READ_ONLY: true, CADT_API_KEY: 'protected-observer-key' } });
     });
 
-    it('READ_ONLY=true + API key configured + wrong key: rejects with 403', async function () {
-      await withConfigOverride(async () => {
-        const response = await supertest(app)
-          .get('/diagnostics')
-          .set('x-api-key', 'X'.repeat('protected-observer-key'.length));
-        expect(response.status).to.equal(403);
-      }, { APP: { READ_ONLY: true, CADT_API_KEY: 'protected-observer-key' } });
+    it('returns full detail by default (READ_ONLY off)', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia.wallet).to.have.property('pendingTransactions');
+      expect(response.body.chia.wallet).to.have.property('trustedFullNodePeers');
+      expect(response.body.chia.datalayer).to.have.property('subscriptions');
     });
   });
 
@@ -262,7 +202,7 @@ describe('/diagnostics endpoint', function () {
     it('always returns 200 with the documented top-level keys', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
       expect(response.body).to.have.all.keys(
-        'timestamp', 'readOnly', 'cadt', 'network', 'chia', 'system',
+        'timestamp', 'cadt', 'network', 'chia', 'system',
       );
       expect(response.body.system).to.have.property('cpu');
       expect(response.body.system).to.have.property('memory');

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -63,14 +63,6 @@ describe('/diagnostics endpoint', function () {
       }
     });
 
-    it('reports chia.services flags', async function () {
-      const response = await supertest(app).get('/diagnostics').expect(200);
-      const services = response.body.chia.services;
-      expect(services).to.have.property('walletReachable').that.is.a('boolean');
-      expect(services).to.have.property('fullNodeReachable').that.is.a('boolean');
-      expect(services).to.have.property('datalayerReachable').that.is.a('boolean');
-    });
-
     it('reports chia.runningProcesses with scan results', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
       const processes = response.body.chia.runningProcesses;
@@ -115,7 +107,6 @@ describe('/diagnostics endpoint', function () {
       } else {
         expect(wallet.connectionError).to.be.a('string').and.not.empty;
       }
-      expect(response.body.chia.services.walletReachable).to.equal(wallet.reachable);
     });
   });
 
@@ -259,6 +250,176 @@ describe('/diagnostics endpoint', function () {
         expect(view.connected[0].trusted).to.equal(false);
         expect(view.configuredTrustedNodeIds).to.deep.equal([]);
       });
+    });
+
+    describe('StatusAccumulator', function () {
+      const SA = () => diagnostics.__test.StatusAccumulator;
+
+      it('starts at ok with no message', function () {
+        const s = new (SA())();
+        expect(s.result()).to.deep.equal({ status: 'ok' });
+      });
+
+      it('escalates from ok to warning', function () {
+        const s = new (SA())();
+        s.escalate('warning', 'disk space low');
+        expect(s.result()).to.deep.equal({ status: 'warning', message: 'disk space low' });
+      });
+
+      it('escalates from ok to critical', function () {
+        const s = new (SA())();
+        s.escalate('critical', 'out of disk');
+        expect(s.result()).to.deep.equal({ status: 'critical', message: 'out of disk' });
+      });
+
+      it('never downgrades from critical to warning', function () {
+        const s = new (SA())();
+        s.escalate('critical', 'bad');
+        s.escalate('warning', 'less bad');
+        expect(s.result().status).to.equal('critical');
+      });
+
+      it('joins multiple messages with two spaces', function () {
+        const s = new (SA())();
+        s.escalate('warning', 'msg1.');
+        s.escalate('warning', 'msg2.');
+        expect(s.result()).to.deep.equal({ status: 'warning', message: 'msg1.  msg2.' });
+      });
+
+      it('omits message key when no messages given', function () {
+        const s = new (SA())();
+        s.escalate('warning');
+        expect(s.result()).to.deep.equal({ status: 'warning' });
+        expect(s.result()).to.not.have.property('message');
+      });
+
+      it('accumulates messages across severity levels', function () {
+        const s = new (SA())();
+        s.escalate('warning', 'first');
+        s.escalate('critical', 'second');
+        const r = s.result();
+        expect(r.status).to.equal('critical');
+        expect(r.message).to.equal('first  second');
+      });
+
+      it('throws on unknown severity', function () {
+        const s = new (SA())();
+        expect(() => s.escalate('panic')).to.throw('unknown severity');
+      });
+    });
+  });
+
+  describe('status logic', function () {
+    it('system.disk has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const disk = response.body.system.disk;
+      expect(disk).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('system.memory has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const memory = response.body.system.memory;
+      expect(memory).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('system.cpu has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const cpu = response.body.system.cpu;
+      expect(cpu).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('chia.wallet has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia.wallet)
+        .to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('chia.fullNode has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia.fullNode)
+        .to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('chia.datalayer has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia.datalayer)
+        .to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('chia.chiaTools has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia.chiaTools)
+        .to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('network has a status field', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.network)
+        .to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+    });
+
+    it('chiaTools status is warning when not installed', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const chiaTools = response.body.chia.chiaTools;
+      if (!chiaTools.installed) {
+        expect(chiaTools.status).to.equal('warning');
+        expect(chiaTools.message).to.include('chia-tools');
+      }
+    });
+
+    it('network status is ok when matches is null or true', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const network = response.body.network;
+      if (network.matches !== false) {
+        expect(network.status).to.equal('ok');
+      }
+    });
+
+    it('disk status thresholds: ok / warning / critical at boundaries', async function () {
+      const SA = (await import('../../../src/routes/diagnostics.js')).__test.StatusAccumulator;
+
+      const computeDisk = (pct) => {
+        const s = new SA();
+        if (pct != null) {
+          if (pct > 96) s.escalate('critical', 'Disk usage above 96%');
+          else if (pct > 90) s.escalate('warning', 'Disk usage above 90%');
+        }
+        return s.result();
+      };
+
+      expect(computeDisk(50).status).to.equal('ok');
+      expect(computeDisk(90).status).to.equal('ok');
+      expect(computeDisk(90.01).status).to.equal('warning');
+      expect(computeDisk(96).status).to.equal('warning');
+      expect(computeDisk(96.01).status).to.equal('critical');
+      expect(computeDisk(100).status).to.equal('critical');
+      expect(computeDisk(null).status).to.equal('ok');
+    });
+
+    it('memory status thresholds: ok / warning / critical at boundaries', async function () {
+      const SA = (await import('../../../src/routes/diagnostics.js')).__test.StatusAccumulator;
+
+      const computeMemory = (pct) => {
+        const s = new SA();
+        if (pct != null) {
+          if (pct > 99) s.escalate('critical', 'Memory usage above 99%');
+          else if (pct > 90) s.escalate('warning', 'Memory usage above 90%');
+        }
+        return s.result();
+      };
+
+      expect(computeMemory(50).status).to.equal('ok');
+      expect(computeMemory(90).status).to.equal('ok');
+      expect(computeMemory(90.01).status).to.equal('warning');
+      expect(computeMemory(99).status).to.equal('warning');
+      expect(computeMemory(99.01).status).to.equal('critical');
+      expect(computeMemory(100).status).to.equal('critical');
+      expect(computeMemory(null).status).to.equal('ok');
+    });
+
+    it('response does not contain chia.services', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia).to.not.have.property('services');
     });
   });
 });

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -20,6 +20,7 @@ describe('/diagnostics endpoint', function () {
       expect(response.body).to.have.property('timestamp').that.is.a('string');
       expect(response.body).to.have.property('readOnly');
       expect(response.body).to.have.property('cadt').that.is.an('object');
+      expect(response.body).to.have.property('network').that.is.an('object');
       expect(response.body).to.have.property('chia').that.is.an('object');
       expect(response.body).to.have.property('system').that.is.an('object');
     });
@@ -46,7 +47,12 @@ describe('/diagnostics endpoint', function () {
       expect(system).to.have.property('memory').that.is.an('object');
       expect(system.memory).to.have.property('totalBytes').that.is.a('number');
       expect(system.memory).to.have.property('freeBytes').that.is.a('number');
+      expect(system.memory).to.have.property('percentUsed').that.is.a('number');
       expect(system).to.have.property('disk').that.is.an('object');
+      expect(system.disk).to.have.property('chiaRootPath').that.is.a('string');
+      if (system.disk.totalBytes !== null) {
+        expect(system.disk).to.have.property('percentUsed').that.is.a('number');
+      }
     });
 
     it('reports chia.services flags', async function () {
@@ -57,13 +63,18 @@ describe('/diagnostics endpoint', function () {
       expect(services).to.have.property('datalayerReachable').that.is.a('boolean');
     });
 
-    it('reports chia.processes with a clear platform indicator', async function () {
+    it('reports chia.runningProcesses with scan results', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
-      const processes = response.body.chia.processes;
-      expect(processes).to.have.property('platform').that.is.a('string');
-      expect(processes).to.have.property('supported').that.is.a('boolean');
+      const processes = response.body.chia.runningProcesses;
       expect(processes).to.have.property('matches').that.is.an('array');
       expect(processes).to.have.property('multipleVersionsDetected').that.is.a('boolean');
+    });
+
+    it('reports fullNode.runningLocally based on process scan', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const fullNode = response.body.chia.fullNode;
+      expect(fullNode).to.have.property('runningLocally').that.is.a('boolean');
+      expect(fullNode).to.have.property('reachable').that.is.a('boolean');
     });
 
     it('reports chia-tools with the PATH-visibility note', async function () {
@@ -88,11 +99,6 @@ describe('/diagnostics endpoint', function () {
     });
 
     it('keeps wallet.reachable and connectionError consistent with each other', async function () {
-      // Contract test (environment-independent): walletReachable must reflect
-      // the real RPC outcome, and connectionError must be non-empty iff
-      // walletReachable is false. This catches the original "reachable always
-      // returns true because the helpers swallow errors" bug regardless of
-      // whether a real wallet happens to be listening in the test env.
       const response = await supertest(app).get('/diagnostics').expect(200);
       const wallet = response.body.chia.wallet;
       expect(wallet.reachable).to.be.a('boolean');
@@ -101,7 +107,6 @@ describe('/diagnostics endpoint', function () {
       } else {
         expect(wallet.connectionError).to.be.a('string').and.not.empty;
       }
-      // Services flag must agree with the per-subsystem flag.
       expect(response.body.chia.services.walletReachable).to.equal(wallet.reachable);
     });
   });
@@ -164,20 +169,16 @@ describe('/diagnostics endpoint', function () {
         expect(response.body).to.have.property('readOnly', true);
         expect(response.body).to.have.property('message').that.is.a('string');
 
-        // Read-only short-circuits before the wallet/datalayer fan-out, so
-        // those entire sections must be absent.
         expect(response.body.chia).to.not.have.property('wallet');
         expect(response.body.chia).to.not.have.property('datalayer');
         expect(response.body.chia).to.not.have.property('fullNode');
         expect(response.body.chia).to.not.have.property('services');
 
-        // No home org IDs (those would leak operator identity)
         expect(response.body.cadt.v1).to.not.have.property('homeOrgId');
         expect(response.body.cadt.v2).to.not.have.property('homeOrgId');
 
-        // Still reports the cheap public info
         expect(response.body.cadt).to.have.property('version');
-        expect(response.body.chia.network).to.have.property('configured');
+        expect(response.body.network).to.have.property('cadt');
         expect(response.body.chia).to.have.property('chiaTools');
         expect(response.body).to.have.property('system');
       }, { APP: { READ_ONLY: true } });
@@ -186,8 +187,6 @@ describe('/diagnostics endpoint', function () {
     it('keeps full detail by default (READ_ONLY off)', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
       expect(response.body.readOnly).to.equal(false);
-      // Even though the underlying RPCs may be unreachable in this env, the
-      // keys exist so the response shape stays stable.
       expect(response.body.chia.wallet).to.have.property('pendingTransactions');
       expect(response.body.chia.wallet).to.have.property('trustedFullNodePeers');
       expect(response.body.chia.datalayer).to.have.property('subscriptions');
@@ -204,13 +203,11 @@ describe('/diagnostics endpoint', function () {
         const response = await supertest(app).get('/diagnostics');
         expect(response.status).to.equal(200);
         expect(response.body.readOnly).to.equal(true);
-        // Sensitive sections must be absent
         expect(response.body.chia).to.not.have.property('wallet');
         expect(response.body.chia).to.not.have.property('datalayer');
         expect(response.body.chia).to.not.have.property('fullNode');
-        // Public-safe sections still present
         expect(response.body.cadt).to.have.property('version');
-        expect(response.body.chia.network).to.have.property('configured');
+        expect(response.body.network).to.have.property('cadt');
         expect(response.body).to.have.property('system');
       }, { APP: { READ_ONLY: true, CADT_API_KEY: '' } });
     });
@@ -229,9 +226,6 @@ describe('/diagnostics endpoint', function () {
           .set('x-api-key', 'protected-observer-key');
         expect(response.status).to.equal(200);
         expect(response.body.readOnly).to.equal(true);
-        // Reduced response shape applies even when authenticated -- the
-        // server is still in READ_ONLY mode, so we don't expose operational
-        // details to anyone, authenticated or not.
         expect(response.body.chia).to.not.have.property('wallet');
         expect(response.body.chia).to.not.have.property('datalayer');
       }, { APP: { READ_ONLY: true, CADT_API_KEY: 'protected-observer-key' } });
@@ -259,9 +253,8 @@ describe('/diagnostics endpoint', function () {
     it('always returns 200 with the documented top-level keys', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
       expect(response.body).to.have.all.keys(
-        'timestamp', 'readOnly', 'cadt', 'chia', 'system',
+        'timestamp', 'readOnly', 'cadt', 'network', 'chia', 'system',
       );
-      // System info (CPU/RAM/disk) is local and must always be present
       expect(response.body.system).to.have.property('cpu');
       expect(response.body.system).to.have.property('memory');
     });

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -1,0 +1,322 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+
+import app from '../../../src/server.js';
+import { prepareDb } from '../../../src/database/index.js';
+import { prepareV2Db } from '../../../src/database/v2/index.js';
+import { withConfigOverride } from '../utils/v2-test-helpers.js';
+
+describe('/diagnostics endpoint', function () {
+  this.timeout(60000);
+
+  before(async function () {
+    await prepareDb();
+    await prepareV2Db();
+  });
+
+  describe('basic shape and reachability', function () {
+    it('responds 200 with the documented top-level shape', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body).to.have.property('timestamp').that.is.a('string');
+      expect(response.body).to.have.property('readOnly');
+      expect(response.body).to.have.property('cadt').that.is.an('object');
+      expect(response.body).to.have.property('chia').that.is.an('object');
+      expect(response.body).to.have.property('system').that.is.an('object');
+    });
+
+    it('reports the current CADT version and config paths', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const cadt = response.body.cadt;
+      expect(cadt).to.have.property('version').that.matches(/^\d+\.\d+\.\d+/);
+      expect(cadt).to.have.property('configDir').that.is.a('string');
+      expect(cadt).to.have.property('configFile').that.includes('config.yaml');
+      expect(cadt).to.have.property('v1').that.is.an('object');
+      expect(cadt).to.have.property('v2').that.is.an('object');
+      expect(cadt.v1).to.have.property('governanceBodyId');
+      expect(cadt.v2).to.have.property('governanceBodyId');
+    });
+
+    it('reports CPU, memory, and disk in the system section', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const system = response.body.system;
+      expect(system).to.have.property('platform').that.is.a('string');
+      expect(system).to.have.property('arch').that.is.a('string');
+      expect(system).to.have.property('cpu').that.is.an('object');
+      expect(system.cpu).to.have.property('cores').that.is.a('number');
+      expect(system).to.have.property('memory').that.is.an('object');
+      expect(system.memory).to.have.property('totalBytes').that.is.a('number');
+      expect(system.memory).to.have.property('freeBytes').that.is.a('number');
+      expect(system).to.have.property('disk').that.is.an('object');
+    });
+
+    it('reports chia.services flags', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const services = response.body.chia.services;
+      expect(services).to.have.property('walletReachable').that.is.a('boolean');
+      expect(services).to.have.property('fullNodeReachable').that.is.a('boolean');
+      expect(services).to.have.property('datalayerReachable').that.is.a('boolean');
+    });
+
+    it('reports chia.processes with a clear platform indicator', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const processes = response.body.chia.processes;
+      expect(processes).to.have.property('platform').that.is.a('string');
+      expect(processes).to.have.property('supported').that.is.a('boolean');
+      expect(processes).to.have.property('matches').that.is.an('array');
+      expect(processes).to.have.property('multipleVersionsDetected').that.is.a('boolean');
+    });
+
+    it('reports chia-tools with the PATH-visibility note', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const chiaTools = response.body.chia.chiaTools;
+      expect(chiaTools).to.have.property('installed').that.is.a('boolean');
+      if (chiaTools.installed) {
+        expect(chiaTools).to.have.property('version').that.is.a('string');
+      }
+      expect(chiaTools).to.have.property('note').that.is.a('string');
+    });
+
+    it('exposes the wallet section even when wallet is unreachable', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const wallet = response.body.chia.wallet;
+      expect(wallet).to.have.property('reachable').that.is.a('boolean');
+      expect(wallet).to.have.property('synced').that.is.a('boolean');
+      // pendingTransactions may be an object with wallet-health shape, or
+      // contain an error key when the wallet RPC isn't reachable; both are
+      // acceptable - we just need the key to exist.
+      expect(wallet).to.have.property('pendingTransactions');
+    });
+
+    it('keeps wallet.reachable and connectionError consistent with each other', async function () {
+      // Contract test (environment-independent): walletReachable must reflect
+      // the real RPC outcome, and connectionError must be non-empty iff
+      // walletReachable is false. This catches the original "reachable always
+      // returns true because the helpers swallow errors" bug regardless of
+      // whether a real wallet happens to be listening in the test env.
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const wallet = response.body.chia.wallet;
+      expect(wallet.reachable).to.be.a('boolean');
+      if (wallet.reachable) {
+        expect(wallet.connectionError).to.equal(null);
+      } else {
+        expect(wallet.connectionError).to.be.a('string').and.not.empty;
+      }
+      // Services flag must agree with the per-subsystem flag.
+      expect(response.body.chia.services.walletReachable).to.equal(wallet.reachable);
+    });
+  });
+
+  describe('API-key gating', function () {
+    const TEST_KEY = 'super-secret-diagnostics-key';
+
+    it('rejects unauthenticated requests when CADT_API_KEY is configured', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app).get('/diagnostics');
+        expect(response.status).to.equal(403);
+        expect(response.body).to.have.property('message');
+      }, { APP: { CADT_API_KEY: TEST_KEY } });
+    });
+
+    it('accepts requests with the correct x-api-key header', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app)
+          .get('/diagnostics')
+          .set('x-api-key', TEST_KEY);
+        expect(response.status).to.equal(200);
+        expect(response.body).to.have.property('cadt');
+      }, { APP: { CADT_API_KEY: TEST_KEY } });
+    });
+
+    it('rejects requests with a wrong-length x-api-key header', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app)
+          .get('/diagnostics')
+          .set('x-api-key', 'short');
+        expect(response.status).to.equal(403);
+      }, { APP: { CADT_API_KEY: TEST_KEY } });
+    });
+
+    it('rejects requests with a wrong-but-equal-length x-api-key header', async function () {
+      // Equal-length but wrong-content key must still fail. Without this case
+      // a mutant that drops crypto.timingSafeEqual and trusts length alone
+      // would survive.
+      const wrong = 'X'.repeat(TEST_KEY.length);
+      await withConfigOverride(async () => {
+        const response = await supertest(app)
+          .get('/diagnostics')
+          .set('x-api-key', wrong);
+        expect(response.status).to.equal(403);
+      }, { APP: { CADT_API_KEY: TEST_KEY } });
+    });
+  });
+
+  describe('read-only stripping', function () {
+    // The exact contract is documented in src/routes/diagnostics.js and
+    // mirrors the wallet-health.js convention: when READ_ONLY is true the
+    // response retains only non-sensitive metadata. Balances, transaction
+    // details, peer details, subscription IDs, and home-org IDs MUST be
+    // absent. We also intentionally short-circuit BEFORE the wallet/datalayer
+    // RPC fan-out, so the entire `chia.wallet` and `chia.datalayer` sections
+    // are omitted in read-only mode.
+    it('omits operational details when READ_ONLY is enabled', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app).get('/diagnostics').expect(200);
+        expect(response.body).to.have.property('readOnly', true);
+        expect(response.body).to.have.property('message').that.is.a('string');
+
+        // Read-only short-circuits before the wallet/datalayer fan-out, so
+        // those entire sections must be absent.
+        expect(response.body.chia).to.not.have.property('wallet');
+        expect(response.body.chia).to.not.have.property('datalayer');
+        expect(response.body.chia).to.not.have.property('fullNode');
+        expect(response.body.chia).to.not.have.property('services');
+
+        // No home org IDs (those would leak operator identity)
+        expect(response.body.cadt.v1).to.not.have.property('homeOrgId');
+        expect(response.body.cadt.v2).to.not.have.property('homeOrgId');
+
+        // Still reports the cheap public info
+        expect(response.body.cadt).to.have.property('version');
+        expect(response.body.chia.network).to.have.property('configured');
+        expect(response.body.chia).to.have.property('chiaTools');
+        expect(response.body).to.have.property('system');
+      }, { APP: { READ_ONLY: true } });
+    });
+
+    it('keeps full detail by default (READ_ONLY off)', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.readOnly).to.equal(false);
+      // Even though the underlying RPCs may be unreachable in this env, the
+      // keys exist so the response shape stays stable.
+      expect(response.body.chia.wallet).to.have.property('pendingTransactions');
+      expect(response.body.chia.wallet).to.have.property('trustedFullNodePeers');
+      expect(response.body.chia.datalayer).to.have.property('subscriptions');
+    });
+
+    // The four scenarios below exhaustively cover the (READ_ONLY × API key
+    // configured × key provided) matrix for READ_ONLY=true. They confirm both
+    // (a) a public observer node with no API key gets the reduced response
+    // without authentication, and (b) when an API key IS configured the
+    // endpoint still enforces it, returning the reduced response only to
+    // authenticated callers.
+    it('public observer node (READ_ONLY=true, no API key): returns 200 with reduced fields without auth', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app).get('/diagnostics');
+        expect(response.status).to.equal(200);
+        expect(response.body.readOnly).to.equal(true);
+        // Sensitive sections must be absent
+        expect(response.body.chia).to.not.have.property('wallet');
+        expect(response.body.chia).to.not.have.property('datalayer');
+        expect(response.body.chia).to.not.have.property('fullNode');
+        // Public-safe sections still present
+        expect(response.body.cadt).to.have.property('version');
+        expect(response.body.chia.network).to.have.property('configured');
+        expect(response.body).to.have.property('system');
+      }, { APP: { READ_ONLY: true, CADT_API_KEY: '' } });
+    });
+
+    it('READ_ONLY=true + API key configured + no key provided: rejects with 403', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app).get('/diagnostics');
+        expect(response.status).to.equal(403);
+      }, { APP: { READ_ONLY: true, CADT_API_KEY: 'protected-observer-key' } });
+    });
+
+    it('READ_ONLY=true + API key configured + correct key: returns 200 with reduced fields', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app)
+          .get('/diagnostics')
+          .set('x-api-key', 'protected-observer-key');
+        expect(response.status).to.equal(200);
+        expect(response.body.readOnly).to.equal(true);
+        // Reduced response shape applies even when authenticated -- the
+        // server is still in READ_ONLY mode, so we don't expose operational
+        // details to anyone, authenticated or not.
+        expect(response.body.chia).to.not.have.property('wallet');
+        expect(response.body.chia).to.not.have.property('datalayer');
+      }, { APP: { READ_ONLY: true, CADT_API_KEY: 'protected-observer-key' } });
+    });
+
+    it('READ_ONLY=true + API key configured + wrong key: rejects with 403', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app)
+          .get('/diagnostics')
+          .set('x-api-key', 'X'.repeat('protected-observer-key'.length));
+        expect(response.status).to.equal(403);
+      }, { APP: { READ_ONLY: true, CADT_API_KEY: 'protected-observer-key' } });
+    });
+  });
+
+  describe('graceful degradation', function () {
+    // We do NOT try to test bogus URLs via withConfigOverride here: WALLET_URL
+    // is captured at wallet.js module-load time and getWalletConnections
+    // short-circuits in USE_SIMULATOR mode, so the override never reaches the
+    // RPC path. The real graceful-degradation guarantee is that the response
+    // always returns 200 with a stable top-level shape regardless of which
+    // subsystems answered -- the basic-shape tests above already verify that
+    // implicitly (the simulator config has no wallet/datalayer RPC running
+    // and the tests still pass).
+    it('always returns 200 with the documented top-level keys', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body).to.have.all.keys(
+        'timestamp', 'readOnly', 'cadt', 'chia', 'system',
+      );
+      // System info (CPU/RAM/disk) is local and must always be present
+      expect(response.body.system).to.have.property('cpu');
+      expect(response.body.system).to.have.property('memory');
+    });
+  });
+
+  describe('unit helpers', function () {
+    let diagnostics;
+    before(async function () {
+      diagnostics = await import('../../../src/routes/diagnostics.js');
+    });
+
+    describe('normalizeNodeId', function () {
+      it('strips 0x and lowercases', function () {
+        const norm = diagnostics.__test.normalizeNodeId;
+        expect(norm('0xABCD1234')).to.equal('abcd1234');
+        expect(norm('0xabcd1234')).to.equal('abcd1234');
+        expect(norm('ABCD1234')).to.equal('abcd1234');
+        expect(norm(null)).to.equal('');
+        expect(norm(undefined)).to.equal('');
+      });
+    });
+
+    describe('buildTrustedPeerView', function () {
+      const { buildTrustedPeerView } = (async () => null)(); // placeholder to keep diff small
+      it('matches connected peers against trusted_peers regardless of 0x prefix or case', function () {
+        const view = diagnostics.__test.buildTrustedPeerView(
+          {
+            ok: true,
+            value: {
+              connections: [
+                { peerHost: '1.2.3.4', peerPort: 8444, type: 1, nodeId: '0xABCDEF12' },
+                { peerHost: '5.6.7.8', peerPort: 8444, type: 1, nodeId: '11223344' },
+              ],
+            },
+          },
+          {
+            ok: true,
+            value: { wallet: { trusted_peers: { abcdef12: 'Does_not_matter' } } },
+          },
+        );
+        expect(view.hasTrustedConnection).to.equal(true);
+        expect(view.connected[0].trusted).to.equal(true);
+        expect(view.connected[1].trusted).to.equal(false);
+        expect(view.configuredTrustedNodeIds).to.deep.equal(['abcdef12']);
+      });
+
+      it('reports empty trusted set when chia config has no trusted_peers', function () {
+        const view = diagnostics.__test.buildTrustedPeerView(
+          { ok: true, value: { connections: [{ peerHost: 'h', peerPort: 0, type: 1, nodeId: 'aa' }] } },
+          { ok: true, value: { wallet: {} } },
+        );
+        expect(view.hasTrustedConnection).to.equal(false);
+        expect(view.connected[0].trusted).to.equal(false);
+        expect(view.configuredTrustedNodeIds).to.deep.equal([]);
+      });
+    });
+  });
+});

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -137,6 +137,12 @@ describe('Wallet Health - Live', function () {
         expect(body.system.disk.percentUsed).to.be.a('number').and.to.be.at.least(0).and.at.most(100);
       }
 
+      // Chia: version -------------------------------------------------------
+      expect(body.chia).to.have.property('version');
+      if (body.chia.version !== null) {
+        expect(body.chia.version).to.be.a('string');
+      }
+
       // Chia: services flags ------------------------------------------------
       expect(body.chia.services).to.be.an('object');
       expect(body.chia.services.walletReachable).to.be.a('boolean');

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -96,7 +96,6 @@ describe('Wallet Health - Live', function () {
       expect(body.timestamp, 'timestamp must be ISO-8601').to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
-      expect(body.readOnly).to.be.a('boolean');
       expect(body.cadt).to.be.an('object');
       expect(body.network).to.be.an('object');
       expect(body.chia).to.be.an('object');

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -71,6 +71,112 @@ describe('Wallet Health - Live', function () {
     });
   });
 
+  describe('CADT /diagnostics endpoint', function () {
+    // Smoke-test the system-wide diagnostics endpoint against a real CADT +
+    // Chia install. We deliberately assert TYPES and RANGES rather than
+    // specific values: CI machines vary in CPU/RAM/disk size, network may be
+    // mainnet/testnet, the local wallet may or may not be synced, etc. The
+    // intent is to catch the response failing to serialize or the shape
+    // regressing, not to pin the operator's environment.
+    it('returns a well-shaped response with sensible types and ranges', async function () {
+      const res = await request.get('/diagnostics');
+      expect(res.status).to.equal(200);
+
+      const body = res.body;
+      console.log('  /diagnostics response keys:', Object.keys(body).join(', '));
+
+      // Top-level shape -----------------------------------------------------
+      expect(body.timestamp, 'timestamp must be ISO-8601').to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(body.readOnly).to.be.a('boolean');
+      expect(body.cadt).to.be.an('object');
+      expect(body.chia).to.be.an('object');
+      expect(body.system).to.be.an('object');
+
+      // CADT section --------------------------------------------------------
+      expect(body.cadt.version, 'CADT version must look like semver').to.match(
+        /^\d+\.\d+\.\d+/,
+      );
+      expect(body.cadt.configDir).to.be.a('string').and.not.empty;
+      expect(body.cadt.configFile).to.be.a('string').that.includes('config.yaml');
+      expect(body.cadt.v1, 'cadt.v1 section').to.be.an('object');
+      expect(body.cadt.v2, 'cadt.v2 section').to.be.an('object');
+      expect(body.cadt.v1.enabled).to.be.a('boolean');
+      expect(body.cadt.v2.enabled).to.be.a('boolean');
+
+      // System section ------------------------------------------------------
+      expect(body.system.platform).to.be.a('string').and.not.empty;
+      expect(body.system.arch).to.be.a('string').and.not.empty;
+      expect(body.system.cpu).to.be.an('object');
+      expect(body.system.cpu.cores, 'CPU cores must be a positive integer')
+        .to.be.a('number').and.to.be.at.least(1);
+      if (body.system.cpu.model !== null) {
+        expect(body.system.cpu.model).to.be.a('string').and.not.empty;
+      }
+      expect(body.system.memory.totalBytes).to.be.a('number').and.to.be.greaterThan(0);
+      expect(body.system.memory.freeBytes).to.be.a('number').and.to.be.at.least(0);
+      expect(
+        body.system.memory.freeBytes,
+        'freeBytes cannot exceed totalBytes',
+      ).to.be.at.most(body.system.memory.totalBytes);
+      // disk may report null bytes if statfs failed; just check shape
+      expect(body.system.disk).to.be.an('object');
+      if (body.system.disk.totalBytes !== null) {
+        expect(body.system.disk.totalBytes).to.be.a('number').and.to.be.greaterThan(0);
+        expect(body.system.disk.freeBytes).to.be.at.most(body.system.disk.totalBytes);
+      }
+
+      // Chia: services flags ------------------------------------------------
+      expect(body.chia.services).to.be.an('object');
+      expect(body.chia.services.walletReachable).to.be.a('boolean');
+      expect(body.chia.services.fullNodeReachable).to.be.a('boolean');
+      expect(body.chia.services.datalayerReachable).to.be.a('boolean');
+
+      // Chia: network -------------------------------------------------------
+      expect(body.chia.network).to.be.an('object');
+      // `configured` is read straight from CADT config; if it's set, it should
+      // look like a chia network name. We don't pin the value -- CI may run
+      // against mainnet OR testnet.
+      if (body.chia.network.configured !== null) {
+        expect(body.chia.network.configured).to.be.a('string').and.not.empty;
+      }
+
+      // Chia: wallet (reachable ↔ connectionError consistency) -------------
+      expect(body.chia.wallet).to.be.an('object');
+      expect(body.chia.wallet.reachable).to.be.a('boolean');
+      expect(body.chia.wallet.synced).to.be.a('boolean');
+      if (body.chia.wallet.reachable) {
+        expect(
+          body.chia.wallet.connectionError,
+          'reachable wallet must not carry a connection error',
+        ).to.equal(null);
+      } else {
+        expect(
+          body.chia.wallet.connectionError,
+          'unreachable wallet must carry a connection error message',
+        ).to.be.a('string').and.not.empty;
+      }
+      // Consistency between per-section and aggregated flags
+      expect(body.chia.services.walletReachable).to.equal(body.chia.wallet.reachable);
+
+      // Chia: full node + datalayer (just shape, not state) ----------------
+      expect(body.chia.fullNode).to.be.an('object');
+      expect(body.chia.fullNode.reachable).to.be.a('boolean');
+      expect(body.chia.datalayer).to.be.an('object');
+      expect(body.chia.datalayer.reachable).to.be.a('boolean');
+
+      // Chia: process scan + chia-tools probe ------------------------------
+      expect(body.chia.processes).to.be.an('object');
+      expect(body.chia.processes.supported).to.be.a('boolean');
+      expect(body.chia.processes.matches).to.be.an('array');
+      expect(body.chia.chiaTools).to.be.an('object');
+      expect(body.chia.chiaTools.installed).to.be.a('boolean');
+      expect(body.chia.chiaTools.note).to.be.a('string').and.not.empty;
+    });
+
+  });
+
   describe('Chia wallet RPC get_wallets', function () {
     it('should contain a DATA_LAYER wallet matching CADT constant', async function () {
       const rpcUrl = getWalletRpcUrl();

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -83,7 +83,14 @@ describe('Wallet Health - Live', function () {
       expect(res.status).to.equal(200);
 
       const body = res.body;
-      console.log('  /diagnostics response keys:', Object.keys(body).join(', '));
+      // Log the full response so it's easy to inspect what /diagnostics
+      // actually reports against this CI environment. This runs as a
+      // preflight in 5 different live-api workflows, so the body is the
+      // best single artifact for eyeballing the endpoint's real output.
+      console.log('  ----- /diagnostics response -----');
+      console.log(JSON.stringify(body, null, 2)
+        .split('\n').map((l) => '  ' + l).join('\n'));
+      console.log('  ----- end /diagnostics response -----');
 
       // Top-level shape -----------------------------------------------------
       expect(body.timestamp, 'timestamp must be ISO-8601').to.match(

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -142,11 +142,15 @@ describe('Wallet Health - Live', function () {
         expect(body.chia.version).to.be.a('string');
       }
 
-      // Chia: services flags ------------------------------------------------
-      expect(body.chia.services).to.be.an('object');
-      expect(body.chia.services.walletReachable).to.be.a('boolean');
-      expect(body.chia.services.fullNodeReachable).to.be.a('boolean');
-      expect(body.chia.services.datalayerReachable).to.be.a('boolean');
+      // Status fields -------------------------------------------------------
+      expect(body.system.disk).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+      expect(body.system.memory).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+      expect(body.system.cpu).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+      expect(body.chia.wallet).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+      expect(body.chia.fullNode).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+      expect(body.chia.datalayer).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+      expect(body.chia.chiaTools).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
+      expect(body.network).to.have.property('status').that.is.oneOf(['ok', 'warning', 'critical']);
 
       // Network section (top-level) -----------------------------------------
       expect(body.network).to.be.an('object');
@@ -169,9 +173,6 @@ describe('Wallet Health - Live', function () {
           'unreachable wallet must carry a connection error message',
         ).to.be.a('string').and.not.empty;
       }
-      // Consistency between per-section and aggregated flags
-      expect(body.chia.services.walletReachable).to.equal(body.chia.wallet.reachable);
-
       // Chia: full node + datalayer (just shape, not state) ----------------
       expect(body.chia.fullNode).to.be.an('object');
       expect(body.chia.fullNode).to.have.property('runningLocally').that.is.a('boolean');

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -98,6 +98,7 @@ describe('Wallet Health - Live', function () {
       );
       expect(body.readOnly).to.be.a('boolean');
       expect(body.cadt).to.be.an('object');
+      expect(body.network).to.be.an('object');
       expect(body.chia).to.be.an('object');
       expect(body.system).to.be.an('object');
 
@@ -123,15 +124,17 @@ describe('Wallet Health - Live', function () {
       }
       expect(body.system.memory.totalBytes).to.be.a('number').and.to.be.greaterThan(0);
       expect(body.system.memory.freeBytes).to.be.a('number').and.to.be.at.least(0);
+      expect(body.system.memory.percentUsed).to.be.a('number').and.to.be.at.least(0).and.at.most(100);
       expect(
         body.system.memory.freeBytes,
         'freeBytes cannot exceed totalBytes',
       ).to.be.at.most(body.system.memory.totalBytes);
-      // disk may report null bytes if statfs failed; just check shape
       expect(body.system.disk).to.be.an('object');
+      expect(body.system.disk.chiaRootPath).to.be.a('string').and.not.empty;
       if (body.system.disk.totalBytes !== null) {
         expect(body.system.disk.totalBytes).to.be.a('number').and.to.be.greaterThan(0);
         expect(body.system.disk.freeBytes).to.be.at.most(body.system.disk.totalBytes);
+        expect(body.system.disk.percentUsed).to.be.a('number').and.to.be.at.least(0).and.at.most(100);
       }
 
       // Chia: services flags ------------------------------------------------
@@ -140,13 +143,10 @@ describe('Wallet Health - Live', function () {
       expect(body.chia.services.fullNodeReachable).to.be.a('boolean');
       expect(body.chia.services.datalayerReachable).to.be.a('boolean');
 
-      // Chia: network -------------------------------------------------------
-      expect(body.chia.network).to.be.an('object');
-      // `configured` is read straight from CADT config; if it's set, it should
-      // look like a chia network name. We don't pin the value -- CI may run
-      // against mainnet OR testnet.
-      if (body.chia.network.configured !== null) {
-        expect(body.chia.network.configured).to.be.a('string').and.not.empty;
+      // Network section (top-level) -----------------------------------------
+      expect(body.network).to.be.an('object');
+      if (body.network.cadt !== null) {
+        expect(body.network.cadt).to.be.a('string').and.not.empty;
       }
 
       // Chia: wallet (reachable ↔ connectionError consistency) -------------
@@ -169,14 +169,14 @@ describe('Wallet Health - Live', function () {
 
       // Chia: full node + datalayer (just shape, not state) ----------------
       expect(body.chia.fullNode).to.be.an('object');
+      expect(body.chia.fullNode).to.have.property('runningLocally').that.is.a('boolean');
       expect(body.chia.fullNode.reachable).to.be.a('boolean');
       expect(body.chia.datalayer).to.be.an('object');
       expect(body.chia.datalayer.reachable).to.be.a('boolean');
 
       // Chia: process scan + chia-tools probe ------------------------------
-      expect(body.chia.processes).to.be.an('object');
-      expect(body.chia.processes.supported).to.be.a('boolean');
-      expect(body.chia.processes.matches).to.be.an('array');
+      expect(body.chia.runningProcesses).to.be.an('object');
+      expect(body.chia.runningProcesses.matches).to.be.an('array');
       expect(body.chia.chiaTools).to.be.an('object');
       expect(body.chia.chiaTools.installed).to.be.a('boolean');
       expect(body.chia.chiaTools.note).to.be.a('string').and.not.empty;


### PR DESCRIPTION
## Summary

Adds a new top-level `GET /diagnostics` endpoint that returns a single JSON object summarizing CADT, Chia, DataLayer, and host machine state — intended for sysadmins and users debugging a CADT install. Mounted as a sibling of `/health` (not under `/v1` or `/v2`); branched off `v2-rc2`.

### What the response includes

- **CADT**: version, config directory + file, V1/V2 database paths, datalayer URL + file-server URL, simulator flag, per-version `{ enabled, readOnly, isGovernanceBody, apiKeyConfigured, governanceBodyId, homeOrgId }`.
- **Chia network**: configured (from CADT config) vs actual (from wallet `get_network_info`) and a `matches` flag.
- **Wallet**: `rpcUrl`, `reachable`, `connectionError` (string when unreachable, including for `AggregateError`s with empty messages), `synced`, `balanceXch`, pending-transactions block (reuses `wallet-health.js` shaping), trusted-peer cross-reference against `wallet.trusted_peers` from chia's `config.yaml`.
- **Full node**: best-effort mTLS call to local full-node RPC (`get_blockchain_state` + `get_connections`) — degrades to `reachable: false` if the certs aren't present.
- **DataLayer**: reachability + subscriptions list with per-store generation/target-generation and a `synced` flag (`Number.isFinite` guard so `undefined === undefined` doesn't falsely report synced); bounded-concurrency worker pool with a 30 s wall-clock budget that emits `truncated: true` if cut off.
- **Services flags**: aggregate `walletReachable` / `fullNodeReachable` / `datalayerReachable`.
- **chia-tools probe**: `chia-tools --version` (then `version` as fallback) with a 5 s timeout; distinguishes "not installed" from "installed but broken".
- **Process scan**: POSIX `ps -eo` scan for chia binaries with multi-version detection; reports `supported: false` on Windows.
- **System**: platform/arch, CPU model + cores (via `os.cpus()`), total/free RAM, free/total disk on the partition holding `${CHIA_ROOT}` (via `fs.promises.statfs`).

### Design properties

- **Degrades gracefully**: every external call is wrapped in `settle(label, producer, timeoutMs)` that races against a hard wall-clock deadline. Failures become `{ ok: false, error }` rather than throwing; one wedged subsystem can't block the rest of the response. Worst-case wall-clock ~30 s; healthy responses come back in well under a second.
- **Survives "the wallet is down" / "migrations are slow"**: `/diagnostics` lives in `HEALTH_ENDPOINTS`, and `isHealthEndpoint` skips were added to the wallet-synced, home-org-synced, and all-data-synced header middlewares so the endpoint isn't blocked by the wallet RPC's 300 s socket timeout or by `waitForMigrations()` when the DB layer itself is the broken subsystem.
- **Auth**: enforced by the existing global API-key middleware. No duplicate check needed.
- **READ_ONLY**: response is reduced to non-sensitive public fields (CADT version, configured network, system info, chia-tools probe, process scan) and short-circuits **before** the wallet/datalayer/full-node RPC fan-out — matches the precedent in [`src/routes/wallet-health.js`](src/routes/wallet-health.js) so a public observer node doesn't make per-request authenticated wallet RPC calls on unauthenticated public hits.

## Files

| File | Purpose |
|---|---|
| `src/routes/diagnostics.js` | Response builder, `settle`, `collectSubscriptions`, `buildTrustedPeerView`, `normalizeNodeId` |
| `src/utils/system-info.js` | CPU/RAM (`os`) + disk (`fs.promises.statfs`) |
| `src/utils/chia-process-scan.js` | POSIX `ps` scan + chia-binary regex |
| `src/utils/chia-tools-probe.js` | `chia-tools --version` / `version` fallback, `extractVersion` regex |
| `src/datalayer/fullNodeRpc.js` | mTLS client for `get_blockchain_state` / `get_connections` |
| `src/datalayer/wallet.js` | adds `getWalletConnections()` for trusted-peer cross-reference |
| `src/middleware.js` | mounts `GET /diagnostics`, adds it to `HEALTH_ENDPOINTS`, adds health-endpoint skip to three header middlewares |
| `tests/v2/integration/diagnostics.spec.js` | HTTP integration tests (22 cases) |
| `tests/v2/integration/diagnostics-helpers.spec.js` | Pure unit tests for the helpers (24 cases) |
| `tests/v2/live-api/wallet-health.live.spec.js` | Live-API smoke test against a real CADT install |

## Test plan

- [x] `npm run test:v1` — 146 passing, 0 failing
- [x] `npm run test:v2` — 1619 passing, 0 failing (includes 46 new diagnostics tests)
- [x] Pre-push multi-persona review (10 reviewers in parallel: senior-engineer, simplicity/reuse, scope/tone/correctness, domain-context, root-cause/layer, concurrency/cancellation, protocol/schema, observability/diagnostics, test-quality/coverage, generic pre-push-diff-review). All critical findings addressed; warnings/info items either fixed or deliberately deferred with rationale.
- [ ] Live-API smoke check via `npm run test:v2:live:wallet-health` against a real CADT + Chia install (runs in CI; the live test added a `/diagnostics` describe block that asserts response shape, types, and reasonable value ranges without pinning specific environment values).

### Matrix coverage (READ_ONLY × API key configured × key provided)

| READ_ONLY | API key | Key in request | Expected | Test |
|---|---|---|---|---|
| false | no | n/a | 200 full | basic-shape tests |
| false | yes | correct | 200 full | `accepts requests with the correct x-api-key header` |
| false | yes | wrong (length mismatch) | 403 | `rejects requests with a wrong-length x-api-key header` |
| false | yes | wrong (equal length) | 403 | `rejects requests with a wrong-but-equal-length x-api-key header` |
| false | yes | none | 403 | `rejects unauthenticated requests when CADT_API_KEY is configured` |
| true | no | n/a | 200 reduced | `public observer node (READ_ONLY=true, no API key): returns 200 with reduced fields without auth` |
| true | yes | correct | 200 reduced | `READ_ONLY=true + API key configured + correct key: returns 200 with reduced fields` |
| true | yes | wrong | 403 | `READ_ONLY=true + API key configured + wrong key: rejects with 403` |
| true | yes | none | 403 | `READ_ONLY=true + API key configured + no key provided: rejects with 403` |

## Manual smoke check (suggested for reviewers)

```bash
# Healthy install
curl -s -H "x-api-key: \$CADT_API_KEY" http://localhost:31310/diagnostics | jq .

# With wallet stopped (verify graceful degradation)
chia stop wallet
curl -s -H "x-api-key: \$CADT_API_KEY" http://localhost:31310/diagnostics | jq '.chia.wallet'
# Expect: { reachable: false, connectionError: "Wallet RPC at ... did not respond", ... }
chia start wallet
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new unauthenticated-by-default (unless API key configured) diagnostics surface that executes local process/CLI probes and multiple RPC calls; mistakes could leak sensitive operational data or add startup/runtime latency despite timeouts and read-only gating.
> 
> **Overview**
> Adds a new top-level `GET /diagnostics` endpoint that returns a single JSON snapshot of CADT config/state plus Chia wallet/full-node/datalayer reachability and host system metrics, with per-section `ok/warning/critical` status aggregation and hard timeouts to degrade gracefully.
> 
> To support this, introduces new helpers for OS info (`system-info.js`), local Chia process scanning (`chia-process-scan.js`), `chia-tools` detection (`chia-tools-probe.js`), and a minimal mTLS full-node RPC client (`fullNodeRpc.js`), plus extends `wallet.js` with `get_version` and `get_connections` helpers.
> 
> Middleware now treats `/diagnostics` as a health-style endpoint (bypassing rate limits, startup gates, and synced-header probes) while explicitly blocking the route when `READ_ONLY` is enabled; startup additionally logs a fire-and-forget diagnostics snapshot after migrations complete. Tests add broad unit/integration/live-api coverage for response shape, auth gating, and helper edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b0a1eaaa4473f744159406b1b82063a48ffd6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->