### PR TITLE
feat(API): reject writes when disk space drops below 512 MiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ CADT and Chia system usage will depend on many factors, including how busy the b
 
 ARM and x86 systems are supported.  While Windows, MacOS, and all versions of Linux are supported, Ubuntu Linux is the recommended operating system as it is used most in testing and our internal hosting.
 
+#### Disk space guard
+
+CADT defensively rejects write requests when the filesystem holding the V1/V2 SQLite databases drops below a low-space threshold, so a full disk cannot corrupt the database mid-transaction. Operators should monitor for this and free space (or expand the volume) before it triggers.
+
+* When free space falls below **1 GiB** (2³⁰ bytes), CADT logs a warning. Writes are still served.
+* When free space falls below **512 MiB** (2²⁰ × 512 bytes), CADT rejects `POST`, `PUT`, and `PATCH` requests with HTTP `507 Insufficient Storage` and logs an error. `GET` reads and `DELETE` requests are still served so operators can free space without restarting the service. Note that a very large `DELETE` (e.g., a cascading delete that touches many rows) writes to the SQLite WAL during the transaction; if the disk is critically low even an allowed `DELETE` may run out of space before the next checkpoint, so prefer freeing files outside the database first.
+* Log lines are emitted only on **severity transitions** (`ok` → `warn`, `warn` → `block`, recovery to `ok`, etc.) — not on every observation — so monitoring scrapes against `/health` cannot drown out the alert when free space first drops below a threshold.
+* Current status is exposed under the `diskSpace` field on the `/health`, `/v1/health`, and `/v2/health` endpoints for monitoring. The field is `null` until the first probe completes, otherwise an object with `severity` (`ok` / `warn` / `block` / `unknown`), `freeBytes` (the lowest free-space figure observed across the V1/V2 data directories, or `null` when every probe failed), and the `blockBytes` / `warnBytes` thresholds. The 507 response body itself only contains `{message, error: "INSUFFICIENT_DISK_SPACE", success: false}` — exact byte counts are reserved for `/health` so anonymous callers (the disk-space gate runs before the `CADT_API_KEY` check) cannot enumerate operational state.
+
 ### Linux
 
 A binary file that can run on all Linux distributions on x86 hardware can be found for each tagged release named `cadt-linux-x64-<version>.zip`.  This zip file will extract to the `cadt-linux-64` directory by default, where the `cadt` file can be executed to run the API.

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -23,9 +23,8 @@ import { sendReadOnlyError } from './utils/read-only-response.js';
 import { getRateLimitRetryAfterSeconds } from './utils/rate-limit.js';
 import {
   checkDiskSpace,
-  peekDiskSpaceStatus,
-  refreshDiskSpaceStatus,
   logDiskSpaceStatus,
+  buildHealthDiskSpacePayload,
   buildInsufficientDiskSpaceError,
   isWriteRejectedByDiskGuard,
 } from './utils/disk-space.js';
@@ -544,34 +543,14 @@ app.use(async function (req, res, next) {
 });
 
 app.get('/health', (req, res) => {
-  // Surface disk-space status so monitoring can alert before writes get
-  // blocked. Use the non-blocking peek (cached value only) and kick off
-  // an async refresh in the background — synchronously awaiting statfs
-  // here can cause k8s liveness probes (default 1 s timeout) to fail
-  // when the filesystem is slow or wedged, which is exactly when /health
-  // most needs to stay responsive.
-  let diskSpace = null;
-  try {
-    const status = peekDiskSpaceStatus();
-    if (status) {
-      diskSpace = {
-        severity: status.severity,
-        freeBytes: status.freeBytes,
-        blockBytes: status.blockBytes,
-        warnBytes: status.warnBytes,
-      };
-      // Drive the debounced log from /health too so a mostly-idle CADT
-      // (no writes in flight) still surfaces warn/block transitions.
-      logDiskSpaceStatus(status);
-    }
-    refreshDiskSpaceStatus();
-  } catch (err) {
-    logger.debug(`disk-space-guard: /health peek failed: ${err.message}`);
-  }
+  // Non-blocking: build the cached disk-space projection (helper handles
+  // peek + transition log + async refresh + safe-fail). Synchronously
+  // awaiting statfs here would risk timing out k8s liveness probes when
+  // the filesystem is slow.
   res.status(200).json({
     message: 'OK',
     timestamp: new Date().toISOString(),
-    diskSpace,
+    diskSpace: buildHealthDiskSpacePayload(),
   });
 });
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -21,6 +21,14 @@ import { OrganizationsV2 } from './models/v2/index.js';
 import { logger } from './config/logger.js';
 import { sendReadOnlyError } from './utils/read-only-response.js';
 import { getRateLimitRetryAfterSeconds } from './utils/rate-limit.js';
+import {
+  checkDiskSpace,
+  peekDiskSpaceStatus,
+  refreshDiskSpaceStatus,
+  logDiskSpaceStatus,
+  buildInsufficientDiskSpaceError,
+  isWriteRejectedByDiskGuard,
+} from './utils/disk-space.js';
 
 const { USE_SIMULATOR } = getConfig().APP;
 
@@ -181,6 +189,35 @@ app.use(async function (req, res, next) {
     }
     if (READ_ONLY && isReadOnlyMethodBlocked(req.method)) {
       return sendReadOnlyError(res);
+    }
+
+    // Defensive disk-space guard. SQLite (the V1/V2 backing store) returns
+    // SQLITE_FULL mid-transaction when the underlying filesystem runs out
+    // of space, which can corrupt the WAL and leave the DB inconsistent.
+    // Reject POST/PUT/PATCH below the hardcoded BLOCK_BYTES threshold
+    // (see src/utils/disk-space.js) so reads stay available and operators
+    // can free space via DELETE without restarting. Runs after READ_ONLY
+    // (configuration wins over transient state) but before the wallet/
+    // datalayer RPC checks below so we don't pay an RPC cost on a request
+    // we already know we can't persist.
+    if (isWriteRejectedByDiskGuard(req.method)) {
+      let diskStatus = null;
+      try {
+        diskStatus = await checkDiskSpace();
+        logDiskSpaceStatus(diskStatus);
+      } catch (diskErr) {
+        // Fail open: a bug in the guard itself must not take down writes.
+        // computeStatus() swallows per-directory statfs errors and the
+        // dir-resolution helpers don't throw, so reaching this branch
+        // means something unexpected happened (e.g., getChiaRoot blew up
+        // because os.homedir() failed under a misconfigured PID-1).
+        logger.error(
+          `disk-space-guard: unexpected check failure: ${diskErr.message}`,
+        );
+      }
+      if (diskStatus && diskStatus.severity === 'block') {
+        return res.status(507).json(buildInsufficientDiskSpaceError());
+      }
     }
 
     await assertChiaNetworkMatchInConfiguration();
@@ -507,9 +544,34 @@ app.use(async function (req, res, next) {
 });
 
 app.get('/health', (req, res) => {
+  // Surface disk-space status so monitoring can alert before writes get
+  // blocked. Use the non-blocking peek (cached value only) and kick off
+  // an async refresh in the background — synchronously awaiting statfs
+  // here can cause k8s liveness probes (default 1 s timeout) to fail
+  // when the filesystem is slow or wedged, which is exactly when /health
+  // most needs to stay responsive.
+  let diskSpace = null;
+  try {
+    const status = peekDiskSpaceStatus();
+    if (status) {
+      diskSpace = {
+        severity: status.severity,
+        freeBytes: status.freeBytes,
+        blockBytes: status.blockBytes,
+        warnBytes: status.warnBytes,
+      };
+      // Drive the debounced log from /health too so a mostly-idle CADT
+      // (no writes in flight) still surfaces warn/block transitions.
+      logDiskSpaceStatus(status);
+    }
+    refreshDiskSpaceStatus();
+  } catch (err) {
+    logger.debug(`disk-space-guard: /health peek failed: ${err.message}`);
+  }
   res.status(200).json({
     message: 'OK',
     timestamp: new Date().toISOString(),
+    diskSpace,
   });
 });
 

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -3,12 +3,7 @@
 import express from 'express';
 import { getWalletHealthResponse } from '../wallet-health.js';
 import { getConfig } from '../../utils/config-loader';
-import {
-  peekDiskSpaceStatus,
-  refreshDiskSpaceStatus,
-  logDiskSpaceStatus,
-} from '../../utils/disk-space.js';
-import { logger } from '../../config/logger.js';
+import { buildHealthDiskSpacePayload } from '../../utils/disk-space.js';
 const V1Router = express.Router();
 
 import {
@@ -25,30 +20,12 @@ import {
 } from './resources';
 
 V1Router.get('/health', (req, res) => {
-  // Non-blocking: use cached disk-space status only and trigger an async
-  // refresh. Synchronously awaiting statfs would risk timing out k8s
-  // liveness probes when the filesystem is slow. See bare /health in
-  // src/middleware.js for full rationale.
-  let diskSpace = null;
-  try {
-    const status = peekDiskSpaceStatus();
-    if (status) {
-      diskSpace = {
-        severity: status.severity,
-        freeBytes: status.freeBytes,
-        blockBytes: status.blockBytes,
-        warnBytes: status.warnBytes,
-      };
-      logDiskSpaceStatus(status);
-    }
-    refreshDiskSpaceStatus();
-  } catch (err) {
-    logger.debug(`disk-space-guard: /v1/health peek failed: ${err.message}`);
-  }
+  // Non-blocking: see bare /health in src/middleware.js. The shared
+  // helper handles peek + transition log + async refresh.
   res.status(200).json({
     message: 'V1 API is running',
     timestamp: new Date().toISOString(),
-    diskSpace,
+    diskSpace: buildHealthDiskSpacePayload(),
   });
 });
 

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -3,6 +3,12 @@
 import express from 'express';
 import { getWalletHealthResponse } from '../wallet-health.js';
 import { getConfig } from '../../utils/config-loader';
+import {
+  peekDiskSpaceStatus,
+  refreshDiskSpaceStatus,
+  logDiskSpaceStatus,
+} from '../../utils/disk-space.js';
+import { logger } from '../../config/logger.js';
 const V1Router = express.Router();
 
 import {
@@ -19,9 +25,30 @@ import {
 } from './resources';
 
 V1Router.get('/health', (req, res) => {
+  // Non-blocking: use cached disk-space status only and trigger an async
+  // refresh. Synchronously awaiting statfs would risk timing out k8s
+  // liveness probes when the filesystem is slow. See bare /health in
+  // src/middleware.js for full rationale.
+  let diskSpace = null;
+  try {
+    const status = peekDiskSpaceStatus();
+    if (status) {
+      diskSpace = {
+        severity: status.severity,
+        freeBytes: status.freeBytes,
+        blockBytes: status.blockBytes,
+        warnBytes: status.warnBytes,
+      };
+      logDiskSpaceStatus(status);
+    }
+    refreshDiskSpaceStatus();
+  } catch (err) {
+    logger.debug(`disk-space-guard: /v1/health peek failed: ${err.message}`);
+  }
   res.status(200).json({
     message: 'V1 API is running',
     timestamp: new Date().toISOString(),
+    diskSpace,
   });
 });
 

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -28,40 +28,17 @@ import { OrganizationsV2Router } from './resources/organizations-v2.js';
 import { AuditV2Router } from './resources/audit-v2.js';
 import { OfferV2Router } from './resources/offer-v2.js';
 import { FilestoreV2Router } from './resources/filestore-v2.js';
-import {
-  peekDiskSpaceStatus,
-  refreshDiskSpaceStatus,
-  logDiskSpaceStatus,
-} from '../../utils/disk-space.js';
-import { logger } from '../../config/logger.js';
+import { buildHealthDiskSpacePayload } from '../../utils/disk-space.js';
 
 const V2Router = express.Router();
 
 V2Router.get('/health', (req, res) => {
-  // Non-blocking: use cached disk-space status only and trigger an async
-  // refresh. Synchronously awaiting statfs would risk timing out k8s
-  // liveness probes when the filesystem is slow. See bare /health in
-  // src/middleware.js for full rationale.
-  let diskSpace = null;
-  try {
-    const status = peekDiskSpaceStatus();
-    if (status) {
-      diskSpace = {
-        severity: status.severity,
-        freeBytes: status.freeBytes,
-        blockBytes: status.blockBytes,
-        warnBytes: status.warnBytes,
-      };
-      logDiskSpaceStatus(status);
-    }
-    refreshDiskSpaceStatus();
-  } catch (err) {
-    logger.debug(`disk-space-guard: /v2/health peek failed: ${err.message}`);
-  }
+  // Non-blocking: see bare /health in src/middleware.js. The shared
+  // helper handles peek + transition log + async refresh.
   res.status(200).json({
     message: 'V2 API is running',
     timestamp: new Date().toISOString(),
-    diskSpace,
+    diskSpace: buildHealthDiskSpacePayload(),
   });
 });
 

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -28,13 +28,40 @@ import { OrganizationsV2Router } from './resources/organizations-v2.js';
 import { AuditV2Router } from './resources/audit-v2.js';
 import { OfferV2Router } from './resources/offer-v2.js';
 import { FilestoreV2Router } from './resources/filestore-v2.js';
+import {
+  peekDiskSpaceStatus,
+  refreshDiskSpaceStatus,
+  logDiskSpaceStatus,
+} from '../../utils/disk-space.js';
+import { logger } from '../../config/logger.js';
 
 const V2Router = express.Router();
 
 V2Router.get('/health', (req, res) => {
+  // Non-blocking: use cached disk-space status only and trigger an async
+  // refresh. Synchronously awaiting statfs would risk timing out k8s
+  // liveness probes when the filesystem is slow. See bare /health in
+  // src/middleware.js for full rationale.
+  let diskSpace = null;
+  try {
+    const status = peekDiskSpaceStatus();
+    if (status) {
+      diskSpace = {
+        severity: status.severity,
+        freeBytes: status.freeBytes,
+        blockBytes: status.blockBytes,
+        warnBytes: status.warnBytes,
+      };
+      logDiskSpaceStatus(status);
+    }
+    refreshDiskSpaceStatus();
+  } catch (err) {
+    logger.debug(`disk-space-guard: /v2/health peek failed: ${err.message}`);
+  }
   res.status(200).json({
     message: 'V2 API is running',
     timestamp: new Date().toISOString(),
+    diskSpace,
   });
 });
 

--- a/src/utils/disk-space.js
+++ b/src/utils/disk-space.js
@@ -154,36 +154,31 @@ const computeStatus = async () => {
   });
 };
 
-/**
- * Non-blocking peek at the current disk-space status. Returns the cached
- * value if one exists, otherwise null. Never triggers a statfs.
- *
- * Used by /health endpoints so liveness probes never block on a slow
- * filesystem (statfs can hang for seconds on NFS/EBS hiccups, and k8s'
- * default livenessProbe.timeoutSeconds is 1 s — a full statfs round trip
- * can trigger spurious pod restarts precisely when operators most need
- * /health to respond).
- *
- * The cache is kept fresh by checkDiskSpace() calls from the write-path
- * middleware (every 30 s of write traffic) and by the periodic refresh
- * driven from refreshDiskSpaceStatus() below. As a fallback, /health
- * handlers should also kick off an async refresh (and ignore the
- * promise) so a quiet, mostly-idle instance still gets timely updates.
- */
-export const peekDiskSpaceStatus = () => {
+// Non-blocking peek at the current disk-space status. Returns the cached
+// value if one exists, otherwise null. Never triggers a statfs.
+//
+// Used by buildHealthDiskSpacePayload so /health probes never block on
+// a slow filesystem (statfs can hang for seconds on NFS/EBS hiccups,
+// and k8s' default livenessProbe.timeoutSeconds is 1 s -- a full statfs
+// round trip can trigger spurious pod restarts precisely when /health
+// most needs to respond).
+//
+// The cache is kept fresh by checkDiskSpace() calls from the write-path
+// middleware and by the fire-and-forget refresh kicked off from
+// buildHealthDiskSpacePayload, so a quiet, mostly-idle instance still
+// sees timely updates.
+const peekDiskSpaceStatus = () => {
   if (testOverride !== null) {
     return testOverride;
   }
   return cachedStatus;
 };
 
-/**
- * Fire-and-forget refresh of the cached disk-space status. Used by
- * /health and similar non-blocking callers that want the cache to stay
- * warm without paying statfs latency on the request path. Failures are
- * swallowed (computeStatus already logs them).
- */
-export const refreshDiskSpaceStatus = () => {
+// Fire-and-forget refresh of the cached disk-space status. Used by
+// buildHealthDiskSpacePayload to keep the cache warm without paying
+// statfs latency on the request path. Failures are swallowed
+// (computeStatus already logs them).
+const refreshDiskSpaceStatus = () => {
   // Reuse the same in-flight de-dup as checkDiskSpace so callers don't
   // accidentally schedule overlapping statfs calls.
   void checkDiskSpace().catch(() => {});
@@ -278,6 +273,51 @@ export const logDiskSpaceStatus = (status) => {
       break;
   }
   lastLoggedSeverity = status.severity;
+};
+
+// Fields exposed on /health endpoints. Centralising the projection here
+// keeps /health, /v1/health, and /v2/health byte-for-byte consistent;
+// adding a new field (e.g. `error`, `path`) only requires a change in
+// this list, not in three handlers.
+const HEALTH_DISK_SPACE_FIELDS = Object.freeze([
+  'severity',
+  'freeBytes',
+  'blockBytes',
+  'warnBytes',
+]);
+
+/**
+ * Build the standard `diskSpace` payload for /health-style endpoints
+ * and drive the same side effects every health handler should perform:
+ *   - debounced transition log line (so a mostly-idle instance still
+ *     surfaces warn/block transitions even with no writes in flight)
+ *   - fire-and-forget cache refresh (so the next probe sees up-to-date
+ *     numbers without this request paying statfs latency)
+ *
+ * Returns the projection object (or null if the cache hasn't been
+ * populated yet). Never throws - any internal failure is swallowed
+ * after a debug log so /health itself stays 200.
+ *
+ * Callers must NOT pass the returned object back to a caller that
+ * could mutate it; the live cache reference is frozen so attempts to
+ * mutate the projection's shared keys are silent no-ops anyway, but a
+ * fresh object is returned here for safety.
+ */
+export const buildHealthDiskSpacePayload = () => {
+  try {
+    const status = peekDiskSpaceStatus();
+    refreshDiskSpaceStatus();
+    if (!status) return null;
+    logDiskSpaceStatus(status);
+    const payload = {};
+    for (const field of HEALTH_DISK_SPACE_FIELDS) {
+      payload[field] = status[field] ?? null;
+    }
+    return payload;
+  } catch (err) {
+    logger.debug(`disk-space-guard: health payload failed: ${err.message}`);
+    return null;
+  }
 };
 
 /**

--- a/src/utils/disk-space.js
+++ b/src/utils/disk-space.js
@@ -1,0 +1,335 @@
+'use strict';
+
+import fs from 'fs';
+import path from 'path';
+
+import { getChiaRoot } from './chia-root.js';
+import { logger } from '../config/logger.js';
+
+const BYTES_PER_MB = 1024 * 1024;
+
+// Hardcoded thresholds (intentionally not user-configurable).
+//
+// Sized for the existing 100 MB filestore upload limit + typical SQLite
+// WAL growth during batch operations. Lowering BLOCK_BYTES risks
+// SQLITE_FULL mid-transaction (which can corrupt the WAL); raising it
+// wastes disk for no operational benefit. WARN_BYTES gives operators
+// advance notice before writes are blocked.
+//
+// Exported so tests (and any future callers like /health) can reference
+// the same source of truth instead of duplicating the literals.
+export const BLOCK_BYTES = 512 * BYTES_PER_MB;
+export const WARN_BYTES = 1024 * BYTES_PER_MB;
+
+// Cache statfs results to avoid hammering the filesystem on every
+// request. 30 s is a comfortable trade-off: short enough that operators
+// see the severity flip soon after they free or fill the disk, long
+// enough that even a request flood adds at most one statfs per 30 s.
+const CHECK_INTERVAL_MS = 30_000;
+
+let cachedStatus = null;
+let cachedAt = 0;
+let inflight = null;
+
+// Transition-based logging: emit a log line ONLY when severity changes
+// (e.g. ok→warn, warn→block, block→ok, anything→unknown). Earlier
+// revisions used a time-windowed debounce, but that interacted badly
+// with k8s-style /health scrapes: a 5 s scrape interval keeps the
+// debounce timestamps fresh, which silenced the operator-facing error
+// log the first time a real write hit the block threshold. Tracking
+// the previously-logged severity instead of a timestamp is immune to
+// scrape rate.
+let lastLoggedSeverity = null;
+
+// Test-only override: when set, checkDiskSpace returns this value verbatim
+// and the underlying statfs is skipped entirely. null = real behaviour.
+let testOverride = null;
+
+// Helper that won't throw if existsSync rejects (rare - EACCES on the
+// path itself, weird FUSE filesystems, etc.). Used by getDirsToCheck so
+// the dir resolution never makes computeStatus reject.
+const safeExists = (p) => {
+  try {
+    return fs.existsSync(p);
+  } catch {
+    return false;
+  }
+};
+
+// CADT writes to ${CHIA_ROOT}/cadt/v{1,2}/. Both usually live on the
+// same partition, but checking both keeps us correct if someone mounts
+// them separately. Returns absolute, already-existing parent dirs - we
+// don't try to mkdir here because the data dir owners are responsible
+// for creation and we don't want to mask a permissions problem.
+const getDirsToCheck = () => {
+  const chiaRoot = getChiaRoot();
+  const candidates = [
+    path.join(chiaRoot, 'cadt', 'v1'),
+    path.join(chiaRoot, 'cadt', 'v2'),
+  ];
+  const existing = candidates.filter(safeExists);
+  // Fallback: if neither v1 nor v2 dir exists yet (very early startup),
+  // statfs the cadt root or the chia root itself. statfs only needs the
+  // path to resolve to *some* file in the filesystem, so this keeps us
+  // returning a sensible "free bytes" number from the very first request.
+  if (existing.length === 0) {
+    const cadtRoot = path.join(chiaRoot, 'cadt');
+    if (safeExists(cadtRoot)) return [cadtRoot];
+    if (safeExists(chiaRoot)) return [chiaRoot];
+    return [path.parse(chiaRoot).root];
+  }
+  return existing;
+};
+
+// Mirrors the math used by src/utils/system-info.js so /health and
+// /diagnostics agree on the same disk's free-byte count. Per POSIX
+// statvfs(3), `bavail` is denominated in `frsize` (fundamental block
+// size), not `bsize` (optimal transfer block size). Node's libuv
+// wrapper currently only exposes `bsize`, and on Linux+ext4 the two
+// are equal, but on Docker+VirtioFS or future Node versions that
+// expose `frsize` they can differ - hence the `?? bsize` fallback.
+const statfsBytes = async (dir) => {
+  const stat = await fs.promises.statfs(dir);
+  const blockSize = stat.frsize ?? stat.bsize;
+  // bavail is "free blocks for unprivileged users" - what user-space
+  // writes actually see. Some filesystems reserve 5% for root, so
+  // bfree (raw free blocks) would over-report by that margin.
+  return stat.bavail * blockSize;
+};
+
+const computeStatus = async () => {
+  const dirs = getDirsToCheck();
+
+  let worstFreeBytes = Number.POSITIVE_INFINITY;
+  let worstPath = dirs[0];
+  let statfsError = null;
+
+  for (const dir of dirs) {
+    try {
+      const free = await statfsBytes(dir);
+      if (free < worstFreeBytes) {
+        worstFreeBytes = free;
+        worstPath = dir;
+      }
+    } catch (err) {
+      // Don't let a transient statfs failure block writes - that would
+      // fail closed in a way operators can't recover from without code
+      // changes. Record the error, treat the directory as if it had
+      // plenty of space, and surface the problem in /health and logs.
+      statfsError = err;
+      logger.debug(
+        `disk-space-guard: statfs(${dir}) failed: ${err.message}; skipping this path`,
+      );
+    }
+  }
+
+  if (!Number.isFinite(worstFreeBytes)) {
+    // All statfs calls failed. Fail open (allow writes) so a buggy or
+    // un-statfs-able filesystem doesn't take CADT down. The "unknown"
+    // log line is emitted by logDiskSpaceStatus on the transition, not
+    // here, so a steady-state EACCES on the data dir doesn't spam logs.
+    return Object.freeze({
+      severity: 'unknown',
+      freeBytes: null,
+      blockBytes: BLOCK_BYTES,
+      warnBytes: WARN_BYTES,
+      path: worstPath,
+      error: statfsError?.message || null,
+    });
+  }
+
+  let severity = 'ok';
+  if (worstFreeBytes < BLOCK_BYTES) severity = 'block';
+  else if (worstFreeBytes < WARN_BYTES) severity = 'warn';
+
+  // Freeze the cached object so callers can't mutate the live cache by
+  // accident (peekDiskSpaceStatus returns the same reference).
+  return Object.freeze({
+    severity,
+    freeBytes: worstFreeBytes,
+    blockBytes: BLOCK_BYTES,
+    warnBytes: WARN_BYTES,
+    path: worstPath,
+    error: null,
+  });
+};
+
+/**
+ * Non-blocking peek at the current disk-space status. Returns the cached
+ * value if one exists, otherwise null. Never triggers a statfs.
+ *
+ * Used by /health endpoints so liveness probes never block on a slow
+ * filesystem (statfs can hang for seconds on NFS/EBS hiccups, and k8s'
+ * default livenessProbe.timeoutSeconds is 1 s — a full statfs round trip
+ * can trigger spurious pod restarts precisely when operators most need
+ * /health to respond).
+ *
+ * The cache is kept fresh by checkDiskSpace() calls from the write-path
+ * middleware (every 30 s of write traffic) and by the periodic refresh
+ * driven from refreshDiskSpaceStatus() below. As a fallback, /health
+ * handlers should also kick off an async refresh (and ignore the
+ * promise) so a quiet, mostly-idle instance still gets timely updates.
+ */
+export const peekDiskSpaceStatus = () => {
+  if (testOverride !== null) {
+    return testOverride;
+  }
+  return cachedStatus;
+};
+
+/**
+ * Fire-and-forget refresh of the cached disk-space status. Used by
+ * /health and similar non-blocking callers that want the cache to stay
+ * warm without paying statfs latency on the request path. Failures are
+ * swallowed (computeStatus already logs them).
+ */
+export const refreshDiskSpaceStatus = () => {
+  // Reuse the same in-flight de-dup as checkDiskSpace so callers don't
+  // accidentally schedule overlapping statfs calls.
+  void checkDiskSpace().catch(() => {});
+};
+
+/**
+ * Returns the current disk-space status, using a cached value when
+ * available (refreshed every CHECK_INTERVAL_MS - 30 s).
+ *
+ * Shape: { severity, freeBytes, blockBytes, warnBytes, path, error }
+ *   severity: 'ok' | 'warn' | 'block' | 'unknown'
+ *   freeBytes: bytes available to unprivileged users on the tightest
+ *              data directory (null when statfs failed everywhere)
+ *
+ * Concurrent callers within the same refresh window share the in-flight
+ * promise so we only statfs once per refresh interval no matter how
+ * many requests arrive simultaneously.
+ */
+export const checkDiskSpace = async () => {
+  if (testOverride !== null) {
+    return testOverride;
+  }
+
+  const now = Date.now();
+  if (cachedStatus && now - cachedAt < CHECK_INTERVAL_MS) {
+    return cachedStatus;
+  }
+  if (inflight) {
+    return inflight;
+  }
+  inflight = computeStatus()
+    .then((status) => {
+      cachedStatus = status;
+      cachedAt = Date.now();
+      return status;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+};
+
+/**
+ * Emit a log line on every severity transition (e.g. ok→warn,
+ * warn→block, block→ok, anything→unknown). Idempotent within a
+ * severity: repeat calls with the same severity are no-ops, so callers
+ * can drive this from any path (write middleware, /health scrapes,
+ * periodic tasks) without flooding the log.
+ *
+ * Operators get a clear "we crossed into trouble" alert and a matching
+ * "we recovered" alert without a time-windowed debounce that scrape
+ * traffic could refresh.
+ */
+export const logDiskSpaceStatus = (status) => {
+  if (!status) return;
+  if (status.severity === lastLoggedSeverity) return;
+
+  const free =
+    status.freeBytes == null
+      ? 'unknown'
+      : `${(status.freeBytes / BYTES_PER_MB).toFixed(1)} MiB`;
+  const block = `${(status.blockBytes / BYTES_PER_MB).toFixed(0)} MiB`;
+  const warn = `${(status.warnBytes / BYTES_PER_MB).toFixed(0)} MiB`;
+  const previous = lastLoggedSeverity ?? 'unset';
+
+  switch (status.severity) {
+    case 'block':
+      logger.error(
+        `disk-space-guard: severity transitioned ${previous} -> block. Free space ${free} on ${status.path} is below BLOCK threshold (${block}); rejecting POST/PUT/PATCH writes (GET reads and DELETE still allowed).`,
+      );
+      break;
+    case 'warn':
+      logger.warn(
+        `disk-space-guard: severity transitioned ${previous} -> warn. Free space ${free} on ${status.path} is below WARN threshold (${warn}); free disk space before reaching the BLOCK threshold (${block}).`,
+      );
+      break;
+    case 'unknown':
+      logger.warn(
+        `disk-space-guard: severity transitioned ${previous} -> unknown. Could not statfs ${status.path}${status.error ? ` (${status.error})` : ''}; failing open and allowing writes.`,
+      );
+      break;
+    case 'ok':
+      // Only announce recovery; suppress the initial "ok" on first
+      // observation to avoid a noisy log line on every cold start.
+      if (lastLoggedSeverity !== null) {
+        logger.info(
+          `disk-space-guard: severity transitioned ${previous} -> ok. Free space ${free} on ${status.path}.`,
+        );
+      }
+      break;
+    default:
+      break;
+  }
+  lastLoggedSeverity = status.severity;
+};
+
+/**
+ * Build the 507 Insufficient Storage response body. Shape mirrors
+ * READ_ONLY_ERROR in src/utils/read-only-response.js so clients can
+ * branch on `error` uniformly. Intentionally does NOT include
+ * freeBytes/thresholdBytes - the disk-space middleware runs before the
+ * API-key check, so this body is reachable by anonymous callers and we
+ * don't want to leak operational state. Authenticated operators can see
+ * the full numeric status on /health, /v1/health, and /v2/health.
+ */
+export const buildInsufficientDiskSpaceError = () => ({
+  message: 'Server is low on disk space; write operations are temporarily disabled',
+  error: 'INSUFFICIENT_DISK_SPACE',
+  success: false,
+});
+
+// Test-only. DO NOT call from production code. Pass null to restore
+// real statfs-backed behaviour.
+export const __setDiskSpaceForTests = (status) => {
+  testOverride = status;
+  cachedStatus = null;
+  cachedAt = 0;
+  inflight = null;
+};
+
+// Test-only. Reset the last-logged severity so transition-log
+// assertions don't leak between specs running in the same mocha
+// session. Kept under the previous name so older specs don't break.
+export const __resetDiskSpaceLogDebounceForTests = () => {
+  lastLoggedSeverity = null;
+};
+
+// Test-only. Force the next checkDiskSpace() call to re-statfs even if
+// it's still within the cache window.
+export const __invalidateDiskSpaceCacheForTests = () => {
+  cachedStatus = null;
+  cachedAt = 0;
+  inflight = null;
+};
+
+// Exposed for /health and any future callers that want to format MB.
+export const BYTES_PER_MEGABYTE = BYTES_PER_MB;
+
+// Methods that should be rejected when severity === 'block'. DELETE is
+// intentionally omitted so operators can free space without restarting.
+// Note: a pathological large CASCADE DELETE can still trigger SQLITE_FULL
+// because DELETE writes deleted pages into the WAL before checkpoint
+// reclaims space. The 512 MiB BLOCK threshold is sized to keep typical
+// DELETEs safe; a full operator escape hatch (skip the guard entirely)
+// would require a config flag we have intentionally avoided here.
+const BLOCKED_METHODS = Object.freeze(['POST', 'PUT', 'PATCH']);
+
+export const isWriteRejectedByDiskGuard = (method) =>
+  BLOCKED_METHODS.includes(String(method || '').toUpperCase());

--- a/src/utils/disk-space.js
+++ b/src/utils/disk-space.js
@@ -319,9 +319,6 @@ export const __invalidateDiskSpaceCacheForTests = () => {
   inflight = null;
 };
 
-// Exposed for /health and any future callers that want to format MB.
-export const BYTES_PER_MEGABYTE = BYTES_PER_MB;
-
 // Methods that should be rejected when severity === 'block'. DELETE is
 // intentionally omitted so operators can free space without restarting.
 // Note: a pathological large CASCADE DELETE can still trigger SQLITE_FULL

--- a/tests/v2/integration/disk-space-guard.spec.js
+++ b/tests/v2/integration/disk-space-guard.spec.js
@@ -1,0 +1,208 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+import app from '../../../src/server.js';
+import { prepareDb } from '../../../src/database/index.js';
+import { prepareV2Db } from '../../../src/database/v2/index.js';
+import { createV2TestHomeOrg } from '../utils/v2-test-helpers.js';
+import { createTestHomeOrg } from '../../test-fixtures/index.js';
+import {
+  __setDiskSpaceForTests,
+  __resetDiskSpaceLogDebounceForTests,
+  __invalidateDiskSpaceCacheForTests,
+  buildInsufficientDiskSpaceError,
+  BLOCK_BYTES,
+  WARN_BYTES,
+} from '../../../src/utils/disk-space.js';
+
+const MB = 1024 * 1024;
+
+const setDiskSeverity = (severity, overrides = {}) => {
+  const free = (() => {
+    switch (severity) {
+      case 'block':
+        return 100 * MB;
+      case 'warn':
+        return 800 * MB;
+      case 'unknown':
+        return null;
+      default:
+        return 50 * 1024 * MB; // 50 GB
+    }
+  })();
+  __setDiskSpaceForTests({
+    severity,
+    freeBytes: free,
+    blockBytes: BLOCK_BYTES,
+    warnBytes: WARN_BYTES,
+    path: '/fake/data/dir',
+    error: severity === 'unknown' ? 'EACCES: fake' : null,
+    ...overrides,
+  });
+};
+
+describe('Disk-space guard enforcement', function () {
+  this.timeout(30000);
+
+  before(async function () {
+    await prepareDb();
+    await prepareV2Db();
+    await createTestHomeOrg();
+    await createV2TestHomeOrg();
+  });
+
+  beforeEach(function () {
+    __resetDiskSpaceLogDebounceForTests();
+    __invalidateDiskSpaceCacheForTests();
+  });
+
+  afterEach(function () {
+    __setDiskSpaceForTests(null);
+  });
+
+  describe('when severity is "block"', function () {
+    beforeEach(function () {
+      setDiskSeverity('block');
+    });
+
+    it('rejects V2 POST writes with 507 INSUFFICIENT_DISK_SPACE', async function () {
+      const response = await supertest(app).post('/v2/governance').send({});
+      expect(response.status).to.equal(507);
+      expect(response.body.error).to.equal('INSUFFICIENT_DISK_SPACE');
+      expect(response.body.success).to.equal(false);
+      expect(response.body.message).to.match(/low on disk space/i);
+      // Body intentionally does not include freeBytes/thresholdBytes
+      // (see comment on buildInsufficientDiskSpaceError) - the guard
+      // runs before the API-key check and we don't want to leak
+      // operational state to anonymous callers. /health exposes the
+      // numeric values.
+      expect(response.body).to.not.have.property('freeBytes');
+      expect(response.body).to.not.have.property('thresholdBytes');
+    });
+
+    it('rejects V2 PUT writes with 507 INSUFFICIENT_DISK_SPACE', async function () {
+      const response = await supertest(app)
+        .put('/v2/organizations/subscribe')
+        .send({ orgUid: 'test-org' });
+      expect(response.status).to.equal(507);
+      expect(response.body.error).to.equal('INSUFFICIENT_DISK_SPACE');
+    });
+
+    it('rejects V1 POST writes with 507 INSUFFICIENT_DISK_SPACE (same gate as V2)', async function () {
+      // Belt-and-suspenders: the guard sits in shared middleware and
+      // gates on req.method, not URL prefix. Verify V1 routes are
+      // covered too so a future routing change can't silently bypass.
+      const response = await supertest(app).post('/v1/projects').send({});
+      expect(response.status).to.equal(507);
+      expect(response.body.error).to.equal('INSUFFICIENT_DISK_SPACE');
+    });
+
+    it('allows DELETE so operators can free space', async function () {
+      // We don't care whether the underlying resource exists; the
+      // assertion is that we did NOT short-circuit with 507. The
+      // controller may return 404 or 400 for "no such org" - anything
+      // other than 507 satisfies "the guard let it through".
+      const response = await supertest(app).delete(
+        '/v1/organizations/nonexistent-org',
+      );
+      expect(response.status).to.not.equal(507);
+    });
+
+    it('allows GET reads', async function () {
+      const response = await supertest(app).get('/v2/organizations');
+      expect(response.status).to.not.equal(507);
+    });
+
+    it('allows /health and reports severity', async function () {
+      const response = await supertest(app).get('/health');
+      expect(response.status).to.equal(200);
+      expect(response.body.diskSpace).to.include({ severity: 'block' });
+      expect(response.body.diskSpace.freeBytes).to.equal(100 * MB);
+      expect(response.body.diskSpace.blockBytes).to.equal(BLOCK_BYTES);
+    });
+
+    it('allows /v1/health and /v2/health with disk status', async function () {
+      const v1 = await supertest(app).get('/v1/health');
+      const v2 = await supertest(app).get('/v2/health');
+      expect(v1.status).to.equal(200);
+      expect(v2.status).to.equal(200);
+      expect(v1.body.diskSpace.severity).to.equal('block');
+      expect(v2.body.diskSpace.severity).to.equal('block');
+    });
+  });
+
+  describe('when severity is "warn"', function () {
+    beforeEach(function () {
+      setDiskSeverity('warn');
+    });
+
+    it('still permits POST writes (does not return 507) and reports warn on /health', async function () {
+      const response = await supertest(app).post('/v2/governance').send({});
+      // Whatever the controller decides (validation error, etc.) is fine;
+      // the guard must not have short-circuited with 507.
+      expect(response.status).to.not.equal(507);
+
+      // Tighten the assertion: confirm the seeded warn status was actually
+      // consumed by the guard (otherwise the "not 507" check above would
+      // pass for any controller-level 4xx, including bugs that bypass the
+      // guard entirely).
+      const health = await supertest(app).get('/health');
+      expect(health.body.diskSpace.severity).to.equal('warn');
+      expect(health.body.diskSpace.freeBytes).to.equal(800 * MB);
+    });
+
+    it('exposes warn severity on /health', async function () {
+      const response = await supertest(app).get('/health');
+      expect(response.body.diskSpace.severity).to.equal('warn');
+    });
+  });
+
+  describe('when severity is "ok"', function () {
+    beforeEach(function () {
+      setDiskSeverity('ok');
+    });
+
+    it('permits all methods', async function () {
+      const postResponse = await supertest(app).post('/v2/governance').send({});
+      expect(postResponse.status).to.not.equal(507);
+
+      const getResponse = await supertest(app).get('/v2/organizations');
+      expect(getResponse.status).to.not.equal(507);
+    });
+
+    it('reports ok severity on /health', async function () {
+      const response = await supertest(app).get('/health');
+      expect(response.body.diskSpace.severity).to.equal('ok');
+    });
+  });
+
+  describe('when severity is "unknown" (statfs failed)', function () {
+    beforeEach(function () {
+      setDiskSeverity('unknown');
+    });
+
+    it('fails open: writes are NOT rejected so a buggy filesystem cannot take CADT offline', async function () {
+      const response = await supertest(app).post('/v2/governance').send({});
+      expect(response.status).to.not.equal(507);
+    });
+
+    it('surfaces unknown severity on /health for monitoring', async function () {
+      const response = await supertest(app).get('/health');
+      expect(response.body.diskSpace.severity).to.equal('unknown');
+      expect(response.body.diskSpace.freeBytes).to.equal(null);
+    });
+  });
+
+  describe('error body shape', function () {
+    it('buildInsufficientDiskSpaceError matches the canonical READ_ONLY shape and leaks no state', function () {
+      const body = buildInsufficientDiskSpaceError();
+      expect(body).to.have.property('message');
+      expect(body).to.have.property('error', 'INSUFFICIENT_DISK_SPACE');
+      expect(body).to.have.property('success', false);
+      // Numeric fields are intentionally excluded - see the comment on
+      // buildInsufficientDiskSpaceError. /health remains the channel
+      // for the actual numbers.
+      expect(body).to.not.have.property('freeBytes');
+      expect(body).to.not.have.property('thresholdBytes');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a defensive disk-space guard so a full disk cannot corrupt the SQLite WAL mid-transaction. CADT now periodically inspects free space on the V1/V2 data directories and:

- **Rejects `POST`/`PUT`/`PATCH`** with HTTP `507 Insufficient Storage` when free space drops below **512 MiB**.
- **Logs a warning** when free space drops below **1 GiB** (advance notice before writes are blocked).
- **Always permits** `GET`/`HEAD`/`OPTIONS` reads and `DELETE` so operators can free space without restarting.

Status (`severity` / `freeBytes` / thresholds) is exposed under `diskSpace` on `/health`, `/v1/health`, and `/v2/health` for monitoring.

Thresholds are intentionally hardcoded — sized for the existing 100 MB filestore upload limit + typical SQLite WAL growth during batch operations.

## Notable design decisions

- **Non-blocking `/health`**: handlers use a cached-only peek and trigger an async refresh in the background. A synchronous `statfs` round-trip can stall on slow/wedged filesystems and trip k8s default `livenessProbe.timeoutSeconds: 1` precisely when `/health` most needs to respond.
- **Transition-based logging**: log lines fire on severity changes (`ok`→`warn`, `warn`→`block`, recovery, etc.), not on every observation. Earlier time-windowed debounce was vulnerable to `/health` scrape traffic refreshing the timestamp and silencing the operator-facing block alert when a real write first hit the threshold.
- **Same byte math as `/diagnostics`**: mirrors `frsize ?? bsize` from `src/utils/system-info.js` so `/health` and `/diagnostics` agree on free space.
- **Slim 507 body**: the disk-space gate runs before the API-key check (consistent with READ_ONLY enforcement). The 507 body is `{message, error, success}` only — exact byte counts live on `/health` so anonymous callers cannot enumerate operational state.
- **DELETE caveat**: documented in the README. A pathological cascade DELETE writes pages to the WAL during the transaction; if disk is already critically low even an allowed DELETE may run out before the next checkpoint. Operators are advised to free files outside the database first.

## Test plan

- [x] `npm run test:v2 -- 'tests/v2/integration/disk-space-guard.spec.js'` — 14 specs covering block / warn / ok / unknown across V1 and V2 routes
- [x] `npm run test:v2 -- 'tests/v2/integration/read-only-enforcement.spec.js'` — verifies READ_ONLY still wins over disk-space (configuration over transient state)
- [x] `npm run test:v1 -- 'tests/integration/project.spec.js'` — V1 write smoke; no regression
- [x] `npm run test:v2 -- 'tests/v2/integration/file-upload-limits.spec.js'` — multer error handling unchanged
- [x] `npx eslint` — no new lint errors introduced (only the 12 pre-existing warnings remain)
- [x] `node --check` clean on all modified files
- [x] Two adversarial code-review passes via `pre-push-diff-review` skill, all warning-level findings addressed

## Files changed

| File | Change |
|---|---|
| `src/utils/disk-space.js` | new — cached `statfs` helper, transition-based logging, frozen status objects |
| `src/middleware.js` | new disk-space gate inside the Common assertions block (after READ_ONLY) |
| `src/routes/v1/index.js` | `/v1/health` reports cached `diskSpace` non-blocking |
| `src/routes/v2/index.js` | `/v2/health` reports cached `diskSpace` non-blocking |
| `README.md` | new "Disk space guard" subsection under System Requirements |
| `tests/v2/integration/disk-space-guard.spec.js` | new — 14 specs |

## Related

Targets `v2-rc2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new middleware that can reject write requests with HTTP 507 based on filesystem free space, impacting availability/behavior of POST/PUT/PATCH across V1/V2. Risk is mitigated by caching, fail-open behavior on probe errors, and integration tests, but still affects core request handling.
> 
> **Overview**
> **Adds a defensive disk-space guard to protect SQLite from running out of space mid-transaction.** When free space on the V1/V2 data directories drops below a hardcoded threshold, CADT now rejects `POST`/`PUT`/`PATCH` with HTTP `507` (while still allowing `GET` and `DELETE`).
> 
> `/health`, `/v1/health`, and `/v2/health` now include a `diskSpace` field sourced from a cached `statfs` probe with transition-based logging, and the behavior is documented in `README.md` and covered by new integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f254838c11db3ec6fb1c1ced90ccf36af05d9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->