### PR TITLE
feat(V2): block deletes when local inbound references remain

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -1890,7 +1890,7 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustMethodologyId`.
 
-**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `project_methodology` records reference this methodology, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `project_methodology` records reference this methodology, the request returns `409 Conflict` until those references are removed. References from any synced registry count the same.
 
 Request
 ```shell
@@ -1910,16 +1910,10 @@ Response (409 — references exist)
 ```json
 {
   "success": false,
-  "message": "Cannot delete methodology: referenced by 2 project-methodology links",
-  "references": [{ "table": "project_methodology", "count": 2 }],
-  "hint": "Remove all references first, or use ?force=true to delete anyway"
+  "message": "Cannot delete methodology: it is still referenced by 2 project-methodology links. Remove those references before deleting this methodology.",
+  "error": "Referenced records must be removed before deletion",
+  "references": [{ "table": "project_methodology", "count": 2 }]
 }
-```
-
-Force delete (bypass guard)
-```shell
-curl --location --request DELETE 'localhost:31310/v2/methodology/9b9bb857-c71b-4649-b805-a289db27dc1c?force=true' \
---header 'Content-Type: application/json'
 ```
 
 ---
@@ -2076,7 +2070,7 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustProgramId`.
 
-**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `project` records reference this program via `cadTrustProgramId`, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `project` records reference this program via `cadTrustProgramId`, the request returns `409 Conflict` until those references are removed.
 
 Request
 ```shell
@@ -2096,16 +2090,10 @@ Response (409 — references exist)
 ```json
 {
   "success": false,
-  "message": "Cannot delete program: referenced by 3 projects",
-  "references": [{ "table": "project", "count": 3 }],
-  "hint": "Remove all references first, or use ?force=true to delete anyway"
+  "message": "Cannot delete program: it is still referenced by 3 projects. Remove those references before deleting this program.",
+  "error": "Referenced records must be removed before deletion",
+  "references": [{ "table": "project", "count": 3 }]
 }
-```
-
-Force delete (bypass guard)
-```shell
-curl --location --request DELETE 'localhost:31310/v2/program/51ca9638-22b0-4e14-ae7a-c09d23b37b58?force=true' \
---header 'Content-Type: application/json'
 ```
 
 ---
@@ -4671,7 +4659,7 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustStakeholderId`.
 
-**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `stakeholder_projects` records reference this stakeholder, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `stakeholder_projects` records reference this stakeholder, the request returns `409 Conflict` until those references are removed.
 
 Request
 ```shell
@@ -4691,16 +4679,10 @@ Response (409 — references exist)
 ```json
 {
   "success": false,
-  "message": "Cannot delete stakeholder: referenced by 1 stakeholder-project links",
-  "references": [{ "table": "stakeholder_projects", "count": 1 }],
-  "hint": "Remove all references first, or use ?force=true to delete anyway"
+  "message": "Cannot delete stakeholder: it is still referenced by 1 stakeholder-project links. Remove those references before deleting this stakeholder.",
+  "error": "Referenced records must be removed before deletion",
+  "references": [{ "table": "stakeholder_projects", "count": 1 }]
 }
-```
-
-Force delete (bypass guard)
-```shell
-curl --location --request DELETE 'localhost:31310/v2/stakeholder/e880047e-cdf4-45bb-a9df-e706fa427713?force=true' \
---header 'Content-Type: application/json'
 ```
 
 ---
@@ -4999,7 +4981,7 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustLabelId`.
 
-**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `unit_label` records reference this label, the request returns `409 Conflict`. Pass `?force=true` to bypass the guard and stage the delete anyway.
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `unit_label` records reference this label, the request returns `409 Conflict` until those references are removed.
 
 Request
 ```shell
@@ -5019,16 +5001,10 @@ Response (409 — references exist)
 ```json
 {
   "success": false,
-  "message": "Cannot delete label: referenced by 4 unit-label links",
-  "references": [{ "table": "unit_label", "count": 4 }],
-  "hint": "Remove all references first, or use ?force=true to delete anyway"
+  "message": "Cannot delete label: it is still referenced by 4 unit-label links. Remove those references before deleting this label.",
+  "error": "Referenced records must be removed before deletion",
+  "references": [{ "table": "unit_label", "count": 4 }]
 }
-```
-
-Force delete (bypass guard)
-```shell
-curl --location --request DELETE 'localhost:31310/v2/label/dcacd68e-1cfb-4f06-9798-efa0aacda42c?force=true' \
---header 'Content-Type: application/json'
 ```
 
 ---

--- a/src/controllers/v2/label-v2.controller.js
+++ b/src/controllers/v2/label-v2.controller.js
@@ -272,12 +272,9 @@ export const deleteLabelV2 = async (req, res) => {
       });
     }
 
-    const force = req.query.force === 'true';
-    if (!force) {
-      const refResult = await checkReferences('label', id);
-      if (refResult.hasReferences) {
-        return res.status(409).json(buildReferenceConflictBody('label', refResult));
-      }
+    const refResult = await checkReferences('label', id);
+    if (refResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('label', refResult));
     }
 
     await StagingV2.create({

--- a/src/controllers/v2/location-v2.controller.js
+++ b/src/controllers/v2/location-v2.controller.js
@@ -12,6 +12,7 @@ import {
 import { resolveOrgUid } from '../../utils/owner-utils.js';
 import { paginationParams, optionallyPaginatedResponse } from '../../utils/helpers.js';
 import { loggerV2 } from '../../config/logger.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 
 // Generic CRUD controller factory for LocationV2
 const createLocationController = (Model, ModelMirror, schema) => {
@@ -259,6 +260,11 @@ const createLocationController = (Model, ModelMirror, schema) => {
             message: 'Location not found',
             success: false,
           });
+        }
+
+        const refResult = await checkReferences('location', id);
+        if (refResult.hasReferences) {
+          return res.status(409).json(buildReferenceConflictBody('location', refResult));
         }
 
         // Generate UUID for staging

--- a/src/controllers/v2/methodology-v2.controller.js
+++ b/src/controllers/v2/methodology-v2.controller.js
@@ -276,12 +276,9 @@ export const destroy = async (req, res) => {
       });
     }
 
-    const force = req.query.force === 'true';
-    if (!force) {
-      const refResult = await checkReferences('methodology', id);
-      if (refResult.hasReferences) {
-        return res.status(409).json(buildReferenceConflictBody('methodology', refResult));
-      }
+    const refResult = await checkReferences('methodology', id);
+    if (refResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('methodology', refResult));
     }
 
     await StagingV2.create({

--- a/src/controllers/v2/program-v2.controller.js
+++ b/src/controllers/v2/program-v2.controller.js
@@ -265,12 +265,9 @@ export const destroy = async (req, res) => {
       });
     }
 
-    const force = req.query.force === 'true';
-    if (!force) {
-      const refResult = await checkReferences('program', id);
-      if (refResult.hasReferences) {
-        return res.status(409).json(buildReferenceConflictBody('program', refResult));
-      }
+    const refResult = await checkReferences('program', id);
+    if (refResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('program', refResult));
     }
 
     await StagingV2.create({

--- a/src/controllers/v2/project-methodology-v2.controller.js
+++ b/src/controllers/v2/project-methodology-v2.controller.js
@@ -14,6 +14,7 @@ import {
 import { resolveOrgUid } from '../../utils/owner-utils.js';
 import { paginationParams, optionallyPaginatedResponse } from '../../utils/helpers.js';
 import { loggerV2 } from '../../config/logger.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 
 export const createProjectMethodologyV2 = async (req, res) => {
   try {
@@ -366,6 +367,13 @@ export const deleteProjectMethodologyV2 = async (req, res) => {
         message: 'Project-Methodology relationship not found',
         success: false,
       });
+    }
+
+    const refResult = await checkReferences('project_methodology', cadTrustProjectMethodologyId);
+    if (refResult.hasReferences) {
+      return res.status(409).json(
+        buildReferenceConflictBody('project-methodology relationship', refResult),
+      );
     }
 
     // Stage the delete

--- a/src/controllers/v2/project-v2.controller.js
+++ b/src/controllers/v2/project-v2.controller.js
@@ -35,8 +35,31 @@ import { loggerV2 } from '../../config/logger.js';
 import { projectV2Schema } from '../../validations/v2/project-v2.validations.js';
 import { formatModelAssociationName } from '../../utils/model-utils.js';
 import { resolveOrgUid } from '../../utils/owner-utils.js';
-import { stageProjectChildDeletes } from '../../utils/v2-cascade-delete.js';
+import { getProjectCascadeUnits, stageProjectChildDeletes } from '../../utils/v2-cascade-delete.js';
 import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
+
+const checkProjectCascadeUnitReferences = async (projectId) => {
+  const units = await getProjectCascadeUnits(projectId);
+  const referencesByTable = new Map();
+
+  for (const unit of units) {
+    const unitRefResult = await checkReferences('unit', unit.cadTrustUnitId);
+    for (const reference of unitRefResult.references) {
+      const existing = referencesByTable.get(reference.table);
+      if (existing) {
+        existing.count += reference.count;
+      } else {
+        referencesByTable.set(reference.table, { ...reference });
+      }
+    }
+  }
+
+  const references = [...referencesByTable.values()];
+  return {
+    hasReferences: references.length > 0,
+    references,
+  };
+};
 
 export const create = async (req, res) => {
   try {
@@ -823,6 +846,11 @@ export const destroy = async (req, res) => {
     const refResult = await checkReferences('project', id);
     if (refResult.hasReferences) {
       return res.status(409).json(buildReferenceConflictBody('project', refResult));
+    }
+
+    const cascadeRefResult = await checkProjectCascadeUnitReferences(id);
+    if (cascadeRefResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('project', cascadeRefResult));
     }
 
     const releaseTransactionMutex =

--- a/src/controllers/v2/project-v2.controller.js
+++ b/src/controllers/v2/project-v2.controller.js
@@ -36,6 +36,7 @@ import { projectV2Schema } from '../../validations/v2/project-v2.validations.js'
 import { formatModelAssociationName } from '../../utils/model-utils.js';
 import { resolveOrgUid } from '../../utils/owner-utils.js';
 import { stageProjectChildDeletes } from '../../utils/v2-cascade-delete.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 
 export const create = async (req, res) => {
   try {
@@ -817,6 +818,11 @@ export const destroy = async (req, res) => {
         message: 'Project not found',
         success: false,
       });
+    }
+
+    const refResult = await checkReferences('project', id);
+    if (refResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('project', refResult));
     }
 
     const releaseTransactionMutex =

--- a/src/controllers/v2/project-v2.controller.js
+++ b/src/controllers/v2/project-v2.controller.js
@@ -36,29 +36,11 @@ import { projectV2Schema } from '../../validations/v2/project-v2.validations.js'
 import { formatModelAssociationName } from '../../utils/model-utils.js';
 import { resolveOrgUid } from '../../utils/owner-utils.js';
 import { getProjectCascadeUnits, stageProjectChildDeletes } from '../../utils/v2-cascade-delete.js';
-import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
+import { checkReferences, buildReferenceConflictBody, checkUnitReferencesForIds } from '../../utils/v2-reference-guards.js';
 
 const checkProjectCascadeUnitReferences = async (projectId) => {
   const units = await getProjectCascadeUnits(projectId);
-  const referencesByTable = new Map();
-
-  for (const unit of units) {
-    const unitRefResult = await checkReferences('unit', unit.cadTrustUnitId);
-    for (const reference of unitRefResult.references) {
-      const existing = referencesByTable.get(reference.table);
-      if (existing) {
-        existing.count += reference.count;
-      } else {
-        referencesByTable.set(reference.table, { ...reference });
-      }
-    }
-  }
-
-  const references = [...referencesByTable.values()];
-  return {
-    hasReferences: references.length > 0,
-    references,
-  };
+  return checkUnitReferencesForIds(units.map((unit) => unit.cadTrustUnitId));
 };
 
 export const create = async (req, res) => {

--- a/src/controllers/v2/stakeholder-v2.controller.js
+++ b/src/controllers/v2/stakeholder-v2.controller.js
@@ -263,12 +263,9 @@ export const deleteStakeholderV2 = async (req, res) => {
       });
     }
 
-    const force = req.query.force === 'true';
-    if (!force) {
-      const refResult = await checkReferences('stakeholder', id);
-      if (refResult.hasReferences) {
-        return res.status(409).json(buildReferenceConflictBody('stakeholder', refResult));
-      }
+    const refResult = await checkReferences('stakeholder', id);
+    if (refResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('stakeholder', refResult));
     }
 
     await StagingV2.create({

--- a/src/controllers/v2/unit-v2.controller.js
+++ b/src/controllers/v2/unit-v2.controller.js
@@ -31,6 +31,7 @@ import { unitV2Schema } from '../../validations/v2/unit-v2.validations.js';
 import { genericSortColumnRegex } from '../../utils/string-utils.js';
 import { resolveOrgUid } from '../../utils/owner-utils.js';
 import { stageUnitChildDeletes } from '../../utils/v2-cascade-delete.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 
 // Regex patterns for query parsing
 const genericFilterRegex = /^(\w+):(.+):(\w+)$/;
@@ -798,6 +799,11 @@ export const destroy = async (req, res) => {
         message: 'Unit not found',
         success: false,
       });
+    }
+
+    const refResult = await checkReferences('unit', id);
+    if (refResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('unit', refResult));
     }
 
     const releaseTransactionMutex =

--- a/src/controllers/v2/validation-v2.controller.js
+++ b/src/controllers/v2/validation-v2.controller.js
@@ -21,6 +21,7 @@ import { resolveOrgUid } from '../../utils/owner-utils.js';
 
 import { loggerV2 } from '../../config/logger.js';
 import { validationV2Schema } from '../../validations/v2/validation-v2.validations.js';
+import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-reference-guards.js';
 
 export const create = async (req, res) => {
   try {
@@ -311,6 +312,11 @@ export const destroy = async (req, res) => {
         message: 'Validation not found',
         success: false,
       });
+    }
+
+    const refResult = await checkReferences('validation', id);
+    if (refResult.hasReferences) {
+      return res.status(409).json(buildReferenceConflictBody('validation', refResult));
     }
 
     // Stage the delete

--- a/src/utils/v2-cascade-delete.js
+++ b/src/utils/v2-cascade-delete.js
@@ -188,6 +188,44 @@ export const stageUnitChildDeletes = async (unitId, options = {}) => {
   return rows.length;
 };
 
+export const getProjectCascadeUnits = async (projectId, options = {}) => {
+  const { transaction } = options;
+
+  const verifications = await VerificationV2.findAll({
+    where: { cadTrustProjectId: projectId },
+    raw: true,
+    transaction,
+  });
+
+  const verificationIds = verifications
+    .map((verification) => verification.cadTrustVerificationId)
+    .filter(Boolean);
+
+  if (verificationIds.length === 0) {
+    return [];
+  }
+
+  const issuances = await IssuanceV2.findAll({
+    where: { cadTrustVerificationId: verificationIds },
+    raw: true,
+    transaction,
+  });
+
+  const issuanceIds = issuances
+    .map((issuance) => issuance.cadTrustIssuanceId)
+    .filter(Boolean);
+
+  if (issuanceIds.length === 0) {
+    return [];
+  }
+
+  return UnitV2.findAll({
+    where: { cadTrustIssuanceId: issuanceIds },
+    raw: true,
+    transaction,
+  });
+};
+
 export const stageProjectChildDeletes = async (projectId, options = {}) => {
   const { transaction } = options;
   const rows = [];
@@ -230,30 +268,20 @@ export const stageProjectChildDeletes = async (projectId, options = {}) => {
     });
     pushRowsForRecords(rows, issuances, 'issuance', 'cad_trust_issuance_id');
 
-    const issuanceIds = issuances
-      .map((issuance) => issuance.cadTrustIssuanceId)
+    const units = await getProjectCascadeUnits(projectId, { transaction });
+    pushRowsForRecords(rows, units, 'unit', 'cad_trust_unit_id');
+
+    const unitIds = units
+      .map((unit) => unit.cadTrustUnitId)
       .filter(Boolean);
 
-    if (issuanceIds.length > 0) {
-      const units = await UnitV2.findAll({
-        where: { cadTrustIssuanceId: issuanceIds },
+    if (unitIds.length > 0) {
+      const unitLabels = await UnitLabelV2.findAll({
+        where: { cadTrustUnitId: unitIds },
         raw: true,
         transaction,
       });
-      pushRowsForRecords(rows, units, 'unit', 'cad_trust_unit_id');
-
-      const unitIds = units
-        .map((unit) => unit.cadTrustUnitId)
-        .filter(Boolean);
-
-      if (unitIds.length > 0) {
-        const unitLabels = await UnitLabelV2.findAll({
-          where: { cadTrustUnitId: unitIds },
-          raw: true,
-          transaction,
-        });
-        pushRowsForRecords(rows, unitLabels, 'unit_label', 'cad_trust_unit_label_id');
-      }
+      pushRowsForRecords(rows, unitLabels, 'unit_label', 'cad_trust_unit_label_id');
     }
   }
 

--- a/src/utils/v2-cascade-delete.js
+++ b/src/utils/v2-cascade-delete.js
@@ -40,8 +40,8 @@
  *
  * These records intentionally do NOT cascade. The correct approaches (in order
  * of priority) are:
- *   - Tier 2: Block delete with 409 if local references exist (or allow with
- *             ?force=true after showing impact)
+ *   - Tier 2: Block delete with 409 if any local references exist (committed or staged
+ *             INSERT/UPDATE); clients must remove references first
  *   - Tier 3: Soft delete / deprecation (the only truly safe distributed
  *             systems answer — tombstones over hard deletes)
  *   - Tier 4: Orphan cleanup endpoint for records with zero local references

--- a/src/utils/v2-cascade-delete.js
+++ b/src/utils/v2-cascade-delete.js
@@ -219,6 +219,16 @@ export const getProjectCascadeUnits = async (projectId, options = {}) => {
     return [];
   }
 
+  return getUnitsForIssuances(issuanceIds, { transaction });
+};
+
+const getUnitsForIssuances = async (issuanceIds, options = {}) => {
+  const { transaction } = options;
+
+  if (issuanceIds.length === 0) {
+    return [];
+  }
+
   return UnitV2.findAll({
     where: { cadTrustIssuanceId: issuanceIds },
     raw: true,
@@ -268,7 +278,11 @@ export const stageProjectChildDeletes = async (projectId, options = {}) => {
     });
     pushRowsForRecords(rows, issuances, 'issuance', 'cad_trust_issuance_id');
 
-    const units = await getProjectCascadeUnits(projectId, { transaction });
+    const issuanceIds = issuances
+      .map((issuance) => issuance.cadTrustIssuanceId)
+      .filter(Boolean);
+
+    const units = await getUnitsForIssuances(issuanceIds, { transaction });
     pushRowsForRecords(rows, units, 'unit', 'cad_trust_unit_id');
 
     const unitIds = units

--- a/src/utils/v2-reference-guards.js
+++ b/src/utils/v2-reference-guards.js
@@ -3,12 +3,11 @@
 /**
  * V2 Delete Reference Guards
  *
- * Prevents deletion of shared/standalone records (methodology, stakeholder,
- * program, label) when local references still exist. Returns reference counts
- * so the caller can decide whether to proceed with ?force=true.
+ * Blocks deletion when any local record (committed or staged INSERT/UPDATE)
+ * still references the target. References from any org/registry in the synced
+ * database count the same.
  *
- * See v2-cascade-delete.js for the full design rationale on why these records
- * must not be silently deleted.
+ * See v2-cascade-delete.js for cascade vs shared-record design rationale.
  */
 
 import {
@@ -17,10 +16,29 @@ import {
   UnitLabelV2,
   ProjectV2,
   StagingV2,
+  IssuanceV2,
+  VerificationV2,
+  AefT5AuthorizedEntitiesV2,
+  AefT2AuthorizationsV2,
+  AefT3ActionsV2,
+  AefT4HoldingsV2,
 } from '../models/v2/index.js';
 import { Op } from 'sequelize';
 import { toSnakeCase } from './v2-camel-to-snake.js';
 
+const REFERENCE_ERROR_CODE = 'Referenced records must be removed before deletion';
+
+/**
+ * @typedef {object} ReferenceDefinition
+ * @property {import('sequelize').Model} model
+ * @property {string} fkField - Sequelize attribute (camelCase)
+ * @property {string} table - staging / DB table name (snake_case)
+ * @property {string} label - human-readable plural for messages
+ * @property {(recordId: string) => object} [buildWhere] - optional custom where clause
+ * @property {(record: object, recordId: string) => boolean} [stagedMatch] - staged row match
+ */
+
+/** @type {Record<string, ReferenceDefinition[]>} */
 const REFERENCE_MAP = {
   methodology: [
     {
@@ -54,9 +72,75 @@ const REFERENCE_MAP = {
       label: 'unit-label links',
     },
   ],
+  project_methodology: [
+    {
+      model: IssuanceV2,
+      fkField: 'cadTrustProjectMethodologyId',
+      table: 'issuance',
+      label: 'issuance records',
+    },
+  ],
+  location: [
+    {
+      model: IssuanceV2,
+      fkField: 'cadTrustLocationId',
+      table: 'issuance',
+      label: 'issuance records',
+    },
+  ],
+  validation: [
+    {
+      model: VerificationV2,
+      fkField: 'cadTrustValidationId',
+      table: 'verification',
+      label: 'verifications',
+    },
+  ],
+  project: [
+    {
+      model: ProjectV2,
+      fkField: 'cadTrustReferenceProjectId',
+      table: 'project',
+      label: 'projects referencing this project',
+      buildWhere: (recordId) => ({
+        cadTrustReferenceProjectId: recordId,
+        cadTrustProjectId: { [Op.ne]: recordId },
+      }),
+      stagedMatch: (record, recordId) => (
+        record?.cad_trust_reference_project_id === recordId
+        && record?.cad_trust_project_id !== recordId
+      ),
+    },
+  ],
+  unit: [
+    {
+      model: AefT5AuthorizedEntitiesV2,
+      fkField: 'cadTrustUnitId',
+      table: 'aef_t5_authorized_entities',
+      label: 'AEF-T5 authorized entity records',
+    },
+    {
+      model: AefT2AuthorizationsV2,
+      fkField: 'cadTrustUnitId',
+      table: 'aef_t2_authorizations',
+      label: 'AEF-T2 authorization records',
+    },
+    {
+      model: AefT3ActionsV2,
+      fkField: 'cadTrustUnitId',
+      table: 'aef_t3_actions',
+      label: 'AEF-T3 action records',
+    },
+    {
+      model: AefT4HoldingsV2,
+      fkField: 'cadTrustUnitId',
+      table: 'aef_t4_holdings',
+      label: 'AEF-T4 holding records',
+    },
+  ],
 };
 
-const countStagedReferences = async (table, snakeFkField, recordId) => {
+const countStagedReferences = async (table, snakeFkField, recordId, matchPredicate = null) => {
   const stagedRows = await StagingV2.findAll({
     where: {
       table,
@@ -73,12 +157,15 @@ const countStagedReferences = async (table, snakeFkField, recordId) => {
       const parsedData = JSON.parse(stagedRow.data);
       const records = Array.isArray(parsedData) ? parsedData : [parsedData];
       for (const record of records) {
-        if (record?.[snakeFkField] === recordId) {
+        if (matchPredicate) {
+          if (matchPredicate(record)) {
+            count += 1;
+          }
+        } else if (record?.[snakeFkField] === recordId) {
           count += 1;
         }
       }
     } catch {
-      // Ignore malformed staging rows here; staging validation catches these separately.
       continue;
     }
   }
@@ -86,9 +173,10 @@ const countStagedReferences = async (table, snakeFkField, recordId) => {
 };
 
 /**
- * Check whether any local records reference the given shared record.
+ * Check whether any local records reference the given record (committed + staged).
  *
- * @param {string} table   – one of 'methodology', 'stakeholder', 'program', 'label'
+ * @param {string} table – logical key: methodology, stakeholder, program, label,
+ *   project_methodology, location, validation, project, unit
  * @param {string} recordId – PK of the record being deleted
  * @returns {{ hasReferences: boolean, references: Array<{table: string, count: number, label: string}> }}
  */
@@ -100,11 +188,17 @@ export const checkReferences = async (table, recordId) => {
 
   const references = [];
 
-  for (const { model, fkField, table: refTable, label } of definitions) {
-    const mainCount = await model.count({ where: { [fkField]: recordId } });
-    const stagedCount = await countStagedReferences(refTable, toSnakeCase(fkField), recordId);
-    const totalCount = mainCount + stagedCount;
+  for (const def of definitions) {
+    const { model, fkField, table: refTable, label, buildWhere, stagedMatch } = def;
+    const where = buildWhere ? buildWhere(recordId) : { [fkField]: recordId };
+    const mainCount = await model.count({ where });
 
+    const snakeFk = toSnakeCase(fkField);
+    const stagedCount = stagedMatch
+      ? await countStagedReferences(refTable, snakeFk, recordId, (record) => stagedMatch(record, recordId))
+      : await countStagedReferences(refTable, snakeFk, recordId);
+
+    const totalCount = mainCount + stagedCount;
     if (totalCount > 0) {
       references.push({ table: refTable, count: totalCount, label });
     }
@@ -125,10 +219,13 @@ export const checkReferences = async (table, recordId) => {
  */
 export const buildReferenceConflictBody = (entityName, refResult) => {
   const parts = refResult.references.map((r) => `${r.count} ${r.label}`);
+  const refSummary = parts.join(', ');
   return {
     success: false,
-    message: `Cannot delete ${entityName}: referenced by ${parts.join(', ')}`,
+    message: `Cannot delete ${entityName}: it is still referenced by ${refSummary}. Remove those references before deleting this ${entityName}.`,
+    error: REFERENCE_ERROR_CODE,
     references: refResult.references.map(({ table, count }) => ({ table, count })),
-    hint: 'Remove all references first, or use ?force=true to delete anyway',
   };
 };
+
+export const REFERENCE_GUARD_ERROR = REFERENCE_ERROR_CODE;

--- a/src/utils/v2-reference-guards.js
+++ b/src/utils/v2-reference-guards.js
@@ -227,5 +227,3 @@ export const buildReferenceConflictBody = (entityName, refResult) => {
     references: refResult.references.map(({ table, count }) => ({ table, count })),
   };
 };
-
-export const REFERENCE_GUARD_ERROR = REFERENCE_ERROR_CODE;

--- a/src/utils/v2-reference-guards.js
+++ b/src/utils/v2-reference-guards.js
@@ -197,6 +197,35 @@ const countStagedReferences = async (table, snakeFkField, recordId, matchPredica
   return count;
 };
 
+const countStagedReferencesForIds = async (table, snakeFkField, recordIds) => {
+  const recordIdSet = new Set(recordIds);
+  const stagedRows = await StagingV2.findAll({
+    where: {
+      table,
+      action: { [Op.in]: ['INSERT', 'UPDATE'] },
+      committed: false,
+      failed_commit: false,
+    },
+    raw: true,
+  });
+
+  let count = 0;
+  for (const stagedRow of stagedRows) {
+    try {
+      const parsedData = JSON.parse(stagedRow.data);
+      const records = Array.isArray(parsedData) ? parsedData : [parsedData];
+      for (const record of records) {
+        if (recordIdSet.has(record?.[snakeFkField])) {
+          count += 1;
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+  return count;
+};
+
 const findPendingStagedDeleteIds = async (table, primaryKeyField) => {
   const stagedRows = await StagingV2.findAll({
     where: {
@@ -258,6 +287,42 @@ export const checkReferences = async (table, recordId) => {
       ? await countStagedReferences(refTable, snakeFk, recordId, (record) => stagedMatch(record, recordId))
       : await countStagedReferences(refTable, snakeFk, recordId);
 
+    const totalCount = mainCount + stagedCount;
+    if (totalCount > 0) {
+      references.push({ table: refTable, count: totalCount, label });
+    }
+  }
+
+  return {
+    hasReferences: references.length > 0,
+    references,
+  };
+};
+
+export const checkUnitReferencesForIds = async (unitIds) => {
+  const recordIds = unitIds.filter(Boolean);
+  if (recordIds.length === 0) {
+    return { hasReferences: false, references: [] };
+  }
+
+  const definitions = REFERENCE_MAP.unit;
+  const references = [];
+
+  for (const def of definitions) {
+    const { model, fkField, table: refTable, label } = def;
+    const primaryKeyAttr = model.primaryKeyAttribute;
+    const primaryKeyField = getV2PrimaryKeyField(refTable) || toSnakeCase(primaryKeyAttr);
+    const pendingDeleteIds = await findPendingStagedDeleteIds(refTable, primaryKeyField);
+    const mainRecords = await model.findAll({
+      where: { [fkField]: { [Op.in]: recordIds } },
+      raw: true,
+    });
+    const mainCount = mainRecords.filter((row) => {
+      const rowId = row?.[primaryKeyAttr] ?? row?.[primaryKeyField];
+      return !pendingDeleteIds.has(rowId);
+    }).length;
+
+    const stagedCount = await countStagedReferencesForIds(refTable, toSnakeCase(fkField), recordIds);
     const totalCount = mainCount + stagedCount;
     if (totalCount > 0) {
       references.push({ table: refTable, count: totalCount, label });

--- a/src/utils/v2-reference-guards.js
+++ b/src/utils/v2-reference-guards.js
@@ -25,6 +25,7 @@ import {
 } from '../models/v2/index.js';
 import { Op } from 'sequelize';
 import { toSnakeCase } from './v2-camel-to-snake.js';
+import { getV2PrimaryKeyField } from './v2-primary-key-utils.js';
 
 const REFERENCE_ERROR_CODE = 'Referenced records must be removed before deletion';
 
@@ -172,6 +173,34 @@ const countStagedReferences = async (table, snakeFkField, recordId, matchPredica
   return count;
 };
 
+const findPendingStagedDeleteIds = async (table, primaryKeyField) => {
+  const stagedRows = await StagingV2.findAll({
+    where: {
+      table,
+      action: 'DELETE',
+      committed: false,
+      failed_commit: false,
+    },
+    raw: true,
+  });
+
+  const deletedIds = new Set();
+  for (const stagedRow of stagedRows) {
+    try {
+      const parsedData = JSON.parse(stagedRow.data);
+      const records = Array.isArray(parsedData) ? parsedData : [parsedData];
+      for (const record of records) {
+        if (record?.[primaryKeyField]) {
+          deletedIds.add(record[primaryKeyField]);
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+  return deletedIds;
+};
+
 /**
  * Check whether any local records reference the given record (committed + staged).
  *
@@ -191,7 +220,14 @@ export const checkReferences = async (table, recordId) => {
   for (const def of definitions) {
     const { model, fkField, table: refTable, label, buildWhere, stagedMatch } = def;
     const where = buildWhere ? buildWhere(recordId) : { [fkField]: recordId };
-    const mainCount = await model.count({ where });
+    const mainRecords = await model.findAll({ where, raw: true });
+    const primaryKeyAttr = model.primaryKeyAttribute;
+    const primaryKeyField = getV2PrimaryKeyField(refTable) || toSnakeCase(primaryKeyAttr);
+    const pendingDeleteIds = await findPendingStagedDeleteIds(refTable, primaryKeyField);
+    const mainCount = mainRecords.filter((row) => {
+      const rowId = row?.[primaryKeyAttr] ?? row?.[primaryKeyField];
+      return !pendingDeleteIds.has(rowId);
+    }).length;
 
     const snakeFk = toSnakeCase(fkField);
     const stagedCount = stagedMatch

--- a/src/utils/v2-reference-guards.js
+++ b/src/utils/v2-reference-guards.js
@@ -112,6 +112,30 @@ const REFERENCE_MAP = {
         && record?.cad_trust_project_id !== recordId
       ),
     },
+    {
+      model: AefT5AuthorizedEntitiesV2,
+      fkField: 'cadTrustProjectId',
+      table: 'aef_t5_authorized_entities',
+      label: 'AEF-T5 authorized entity records',
+    },
+    {
+      model: AefT2AuthorizationsV2,
+      fkField: 'cadTrustProjectId',
+      table: 'aef_t2_authorizations',
+      label: 'AEF-T2 authorization records',
+    },
+    {
+      model: AefT3ActionsV2,
+      fkField: 'cadTrustProjectId',
+      table: 'aef_t3_actions',
+      label: 'AEF-T3 action records',
+    },
+    {
+      model: AefT4HoldingsV2,
+      fkField: 'cadTrustProjectId',
+      table: 'aef_t4_holdings',
+      label: 'AEF-T4 holding records',
+    },
   ],
   unit: [
     {

--- a/tests/v2/integration/label-v2.spec.js
+++ b/tests/v2/integration/label-v2.spec.js
@@ -646,7 +646,7 @@ describe('Label V2 Endpoint Integration Tests', function () {
       expect(response.body.references).to.be.an('array').with.lengthOf(1);
       expect(response.body.references[0].table).to.equal('unit_label');
       expect(response.body.references[0].count).to.equal(1);
-      expect(response.body.hint).to.include('force=true');
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'label', action: 'DELETE' },
@@ -685,7 +685,7 @@ describe('Label V2 Endpoint Integration Tests', function () {
       expect(response.body.references[0].count).to.equal(1);
     });
 
-    it('should allow delete with ?force=true despite references', async function () {
+    it('should return 409 with ?force=true when references still exist', async function () {
       const label = await LabelV2.create({
         cadTrustLabelId: uuidv4(),
         labelName: 'Force Delete Label',
@@ -701,15 +701,15 @@ describe('Label V2 Endpoint Integration Tests', function () {
       const response = await supertest(app)
         .delete(`/v2/label/${label.cadTrustLabelId}`)
         .query({ force: 'true' })
-        .expect(200);
+        .expect(409);
 
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Label delete staged successfully');
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'label', action: 'DELETE' },
       });
-      expect(stagingRecord).to.exist;
+      expect(stagingRecord).to.be.null;
     });
   });
 });

--- a/tests/v2/integration/location-v2.spec.js
+++ b/tests/v2/integration/location-v2.spec.js
@@ -1,8 +1,14 @@
 import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
-import { resetV2DataTables, createV2TestHomeOrg, getV2HomeOrgId } from '../utils/v2-test-helpers.js';
-import { ProgramV2, ProjectV2, LocationV2 } from '../../../src/models/v2/index.js';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  resetV2DataTables,
+  createV2TestHomeOrg,
+  getV2HomeOrgId,
+  createV2TestProgramChain,
+} from '../utils/v2-test-helpers.js';
+import { ProgramV2, ProjectV2, LocationV2, IssuanceV2, StagingV2 } from '../../../src/models/v2/index.js';
 
 describe('V2 Location API - Basic CRUD Tests', function () {
   let testProgram;
@@ -437,6 +443,38 @@ describe('V2 Location API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body.message).to.equal('Location deleted successfully');
+    });
+
+    it('should return 409 when issuance references location', async function () {
+      const chain = await createV2TestProgramChain({ testId: `LOC-REF-${uuidv4().slice(0, 8)}` });
+      const location = await LocationV2.create({
+        cadTrustLocationId: uuidv4(),
+        locationCountry: 'DE',
+        locationRegion: 'BY',
+        cadTrustProjectId: chain.project.cadTrustProjectId,
+      });
+      await IssuanceV2.update(
+        { cadTrustLocationId: location.cadTrustLocationId },
+        { where: { cadTrustIssuanceId: chain.issuance.cadTrustIssuanceId } },
+      );
+
+      const response = await supertest(app)
+        .delete(`/v2/location/${location.cadTrustLocationId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(response.body.references).to.deep.include({ table: 'issuance', count: 1 });
+
+      const stagingDeletes = await StagingV2.findAll({
+        where: { table: 'location', action: 'DELETE' },
+        raw: true,
+      });
+      const forThisLocation = stagingDeletes.find((row) => {
+        const data = JSON.parse(row.data);
+        return data[0]?.cad_trust_location_id === location.cadTrustLocationId;
+      });
+      expect(forThisLocation).to.be.undefined;
     });
   });
 });

--- a/tests/v2/integration/methodology-v2.spec.js
+++ b/tests/v2/integration/methodology-v2.spec.js
@@ -476,6 +476,59 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
       expect(response.body.references[0].count).to.equal(1);
     });
 
+    it('should allow delete when committed references are already staged for deletion', async function () {
+      const methodology = await MethodologyV2.create({
+        cadTrustMethodologyId: uuidv4(),
+        methodologyCode: 'STAGED-DELETE-METHOD-001',
+        methodologyName: 'Methodology With Deleted Reference',
+      });
+
+      const program = await ProgramV2.create({
+        programName: 'Staged Delete Program',
+        programRegistry: 'Test Registry',
+        programRegistryActivityId: 'STAGED-DELETE-001',
+      });
+
+      const project = await ProjectV2.create({
+        cadTrustProjectId: uuidv4(),
+        orgUid: 'test-home-org-v2',
+        projectRegistryName: 'Test Registry',
+        projectId: 'STAGED-DELETE-PROJ-001',
+        projectName: 'Staged Delete Project',
+        cadTrustProgramId: program.cadTrustProgramId,
+      });
+
+      const projectMethodology = await ProjectMethodologyV2.create({
+        cadTrustProjectMethodologyId: uuidv4(),
+        cadTrustProjectId: project.cadTrustProjectId,
+        cadTrustMethodologyId: methodology.cadTrustMethodologyId,
+      });
+
+      await StagingV2.create({
+        uuid: uuidv4(),
+        table: 'project_methodology',
+        action: 'DELETE',
+        data: JSON.stringify([{
+          cad_trust_project_methodology_id: projectMethodology.cadTrustProjectMethodologyId,
+        }]),
+        committed: false,
+        failed_commit: false,
+        is_transfer: false,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/methodology/${methodology.cadTrustMethodologyId}`)
+        .expect(200);
+
+      expect(response.body.success).to.be.true;
+      expect(response.body.message).to.equal('Methodology delete staged successfully');
+
+      const stagingRecord = await StagingV2.findOne({
+        where: { table: 'methodology', action: 'DELETE' },
+      });
+      expect(stagingRecord).to.exist;
+    });
+
     it('should return 409 with ?force=true when references still exist', async function () {
       const methodology = await MethodologyV2.create({
         cadTrustMethodologyId: uuidv4(),

--- a/tests/v2/integration/methodology-v2.spec.js
+++ b/tests/v2/integration/methodology-v2.spec.js
@@ -437,7 +437,7 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
       expect(response.body.references).to.be.an('array').with.lengthOf(1);
       expect(response.body.references[0].table).to.equal('project_methodology');
       expect(response.body.references[0].count).to.equal(1);
-      expect(response.body.hint).to.include('force=true');
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'methodology', action: 'DELETE' },
@@ -476,7 +476,7 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
       expect(response.body.references[0].count).to.equal(1);
     });
 
-    it('should allow delete with ?force=true despite references', async function () {
+    it('should return 409 with ?force=true when references still exist', async function () {
       const methodology = await MethodologyV2.create({
         cadTrustMethodologyId: uuidv4(),
         methodologyCode: 'FORCE-METHOD-001',
@@ -507,15 +507,15 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
       const response = await supertest(app)
         .delete(`/v2/methodology/${methodology.cadTrustMethodologyId}`)
         .query({ force: 'true' })
-        .expect(200);
+        .expect(409);
 
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Methodology delete staged successfully');
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'methodology', action: 'DELETE' },
       });
-      expect(stagingRecord).to.exist;
+      expect(stagingRecord).to.be.null;
     });
   });
 });

--- a/tests/v2/integration/program-v2.spec.js
+++ b/tests/v2/integration/program-v2.spec.js
@@ -456,7 +456,7 @@ describe('V2 Program API - Basic CRUD Tests', function () {
       expect(response.body.references).to.be.an('array').with.lengthOf(1);
       expect(response.body.references[0].table).to.equal('project');
       expect(response.body.references[0].count).to.equal(1);
-      expect(response.body.hint).to.include('force=true');
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'program', action: 'DELETE' },
@@ -499,7 +499,7 @@ describe('V2 Program API - Basic CRUD Tests', function () {
       expect(response.body.references[0].count).to.equal(1);
     });
 
-    it('should allow delete with ?force=true despite references', async function () {
+    it('should return 409 with ?force=true when references still exist', async function () {
       const program = await ProgramV2.create({
         cadTrustProgramId: uuidv4(),
         programName: 'Force Delete Program',
@@ -519,15 +519,15 @@ describe('V2 Program API - Basic CRUD Tests', function () {
       const response = await supertest(app)
         .delete(`/v2/program/${program.cadTrustProgramId}`)
         .query({ force: 'true' })
-        .expect(200);
+        .expect(409);
 
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Program delete staged successfully');
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'program', action: 'DELETE' },
       });
-      expect(stagingRecord).to.exist;
+      expect(stagingRecord).to.be.null;
     });
   });
 });

--- a/tests/v2/integration/project-methodology-v2.spec.js
+++ b/tests/v2/integration/project-methodology-v2.spec.js
@@ -2,9 +2,18 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { ProjectMethodologyV2, ProjectV2, ProgramV2, MethodologyV2, StagingV2 } from '../../../src/models/v2/index.js';
+import {
+  ProjectMethodologyV2,
+  ProjectV2,
+  ProgramV2,
+  MethodologyV2,
+  StagingV2,
+  ValidationV2,
+  VerificationV2,
+  IssuanceV2,
+} from '../../../src/models/v2/index.js';
 import { v4 as uuidv4 } from 'uuid';
-import { createV2TestHomeOrg, getV2HomeOrgId } from '../utils/v2-test-helpers.js';
+import { createV2TestHomeOrg, getV2HomeOrgId, addUuidIfNeeded } from '../utils/v2-test-helpers.js';
 
 describe('Project-Methodology V2 Join Table Integration Tests', function () {
   this.timeout(300000); // 5 minute timeout for comprehensive tests
@@ -712,6 +721,51 @@ describe('Project-Methodology V2 Join Table Integration Tests', function () {
         cadTrustProjectId: createdProjectId,
         cadTrustMethodologyId: createdMethodologyId,
       });
+    });
+
+    it('should return 409 when issuance still references project-methodology', async function () {
+      const validation = await ValidationV2.create(addUuidIfNeeded('ValidationV2', {
+        validationId: `VAL-PM-GUARD-${uuidv4().slice(0, 8)}`,
+        validationType: 'Validation of Project Design Document',
+        validationBody: 'Guard validator',
+        cadTrustProjectId: testProjectId,
+      }));
+      const verification = await VerificationV2.create(addUuidIfNeeded('VerificationV2', {
+        verificationId: `VER-PM-GUARD-${uuidv4().slice(0, 8)}`,
+        verificationBody: 'Guard verifier',
+        cadTrustProjectId: testProjectId,
+        cadTrustValidationId: validation.cadTrustValidationId,
+      }));
+      const pmId = uuidv4();
+      await ProjectMethodologyV2.create({
+        cadTrustProjectMethodologyId: pmId,
+        cadTrustProjectId: testProjectId,
+        cadTrustMethodologyId: testMethodologyId,
+      });
+      await IssuanceV2.create(addUuidIfNeeded('IssuanceV2', {
+        issuanceId: `ISS-PM-GUARD-${uuidv4().slice(0, 8)}`,
+        issuanceDate: '2024-06-01',
+        cadTrustVerificationId: verification.cadTrustVerificationId,
+        cadTrustProjectMethodologyId: pmId,
+      }));
+
+      const response = await supertest(app)
+        .delete(`/v2/project-methodology/${pmId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(response.body.references).to.deep.include({ table: 'issuance', count: 1 });
+
+      const stagingForPm = await StagingV2.findAll({
+        where: { table: 'project_methodology', action: 'DELETE' },
+        raw: true,
+      });
+      const blockedRow = stagingForPm.find((row) => {
+        const data = JSON.parse(row.data);
+        return data[0]?.cad_trust_project_methodology_id === pmId;
+      });
+      expect(blockedRow).to.be.undefined;
     });
 
     it('should delete a project-methodology relationship via API', async function () {

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -2247,6 +2247,12 @@ Test Registry,REQ-001,${testProgram.cadTrustProgramId}`;
           projectRegistryName: 'Test Registry',
           projectId: 'UPD-REQ-001',
           projectName: 'Full Project',
+          projectLink: 'https://example.com/update-required',
+          projectSector: ['Agriculture'],
+          projectType: ['Landfill gas'],
+          projectStatus: 'Listed',
+          projectStatusDate: '2024-01-01',
+          projectUnitMetric: 'tCO2e',
           orgUid: homeOrgId,
         }));
 

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StagingV2, ProjectV2, ProgramV2, LocationV2, EstimationV2, RatingV2, CoBenefitV2, ValidationV2, VerificationV2, MethodologyV2, ProjectMethodologyV2, StakeholderV2, StakeholderProjectV2, IssuanceV2, UnitV2, LabelV2, UnitLabelV2 } from '../../../src/models/v2/index.js';
+import { StagingV2, ProjectV2, ProgramV2, LocationV2, EstimationV2, RatingV2, CoBenefitV2, ValidationV2, VerificationV2, MethodologyV2, ProjectMethodologyV2, StakeholderV2, StakeholderProjectV2, IssuanceV2, UnitV2, LabelV2, UnitLabelV2, AefT1SubmissionV2, AefT5AuthorizedEntitiesV2 } from '../../../src/models/v2/index.js';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -1242,6 +1242,103 @@ describe('V2 Project API - Basic CRUD Tests', function () {
         });
         expect(matching, `missing staged delete for ${table}:${id}`).to.exist;
       }
+    });
+
+    it('should return 409 when AEF records reference this project', async function () {
+      const chain = await createV2TestProgramChain({ testId: `PROJ-AEF-PROJ-${uuidv4().slice(0, 8)}` });
+      const t1 = await AefT1SubmissionV2.create({
+        cadTrustAefT1SubmissionId: uuidv4(),
+        aefT1SubmissionParty: 'Project reference guard party',
+        aefT1SubmissionVersion: '1.0',
+        aefT1SubmissionReportYear: 2024,
+        aefT1SubmissionSubmissionDate: '2024-01-15',
+      });
+      await AefT5AuthorizedEntitiesV2.create({
+        cadTrustAefT5AuthorizedEntitiesId: uuidv4(),
+        aefT5AuthorizedEntitiesAuthorizationDate: '2024-01-15',
+        aefT5AuthorizedEntitiesName: 'Project reference guard entity',
+        aefT5AuthorizedEntitiesId: `PROJ-REF-AE-${uuidv4().slice(0, 6)}`,
+        aefT5AuthorizedEntitiesCooperativeApproachId: `PROJ-REF-CA-${uuidv4().slice(0, 6)}`,
+        cadTrustAefT1SubmissionId: t1.cadTrustAefT1SubmissionId,
+        cadTrustProjectId: chain.project.cadTrustProjectId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/project/${chain.project.cadTrustProjectId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(response.body.references).to.deep.include({ table: 'aef_t5_authorized_entities', count: 1 });
+
+      const stagingDeletes = await StagingV2.findAll({
+        where: { table: 'project', action: 'DELETE' },
+        raw: true,
+      });
+      const projectDelete = stagingDeletes.find((row) => {
+        const data = JSON.parse(row.data);
+        return data[0]?.cad_trust_project_id === chain.project.cadTrustProjectId;
+      });
+      expect(projectDelete).to.be.undefined;
+    });
+
+    it('should return 409 when cascade unit has AEF references', async function () {
+      const homeOrgId = await getV2HomeOrgId();
+      const chain = await createV2TestProgramChain({ testId: `PROJ-AEF-GUARD-${uuidv4().slice(0, 8)}` });
+      const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: `PROJ-AEF-UNIT-${uuidv4().slice(0, 8)}`,
+        unitStartBlock: '1',
+        unitEndBlock: '100',
+        unitCount: 50,
+        unitType: 'Avoidance - nature',
+        unitVintageYear: 2024,
+        unitStatus: 'Issued',
+        unitMetric: 'tCO2e',
+        cadTrustIssuanceId: chain.issuance.cadTrustIssuanceId,
+        orgUid: homeOrgId,
+      }));
+      const t1 = await AefT1SubmissionV2.create({
+        cadTrustAefT1SubmissionId: uuidv4(),
+        aefT1SubmissionParty: 'Project cascade guard party',
+        aefT1SubmissionVersion: '1.0',
+        aefT1SubmissionReportYear: 2024,
+        aefT1SubmissionSubmissionDate: '2024-01-15',
+      });
+      await AefT5AuthorizedEntitiesV2.create({
+        cadTrustAefT5AuthorizedEntitiesId: uuidv4(),
+        aefT5AuthorizedEntitiesAuthorizationDate: '2024-01-15',
+        aefT5AuthorizedEntitiesName: 'Project cascade guard entity',
+        aefT5AuthorizedEntitiesId: `PROJ-AE-${uuidv4().slice(0, 6)}`,
+        aefT5AuthorizedEntitiesCooperativeApproachId: `PROJ-CA-${uuidv4().slice(0, 6)}`,
+        cadTrustAefT1SubmissionId: t1.cadTrustAefT1SubmissionId,
+        cadTrustUnitId: unit.cadTrustUnitId,
+        cadTrustProjectId: null,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/project/${chain.project.cadTrustProjectId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(response.body.references).to.deep.include({ table: 'aef_t5_authorized_entities', count: 1 });
+
+      const stagingDeletes = await StagingV2.findAll({
+        where: { action: 'DELETE' },
+        raw: true,
+      });
+      const projectDelete = stagingDeletes.find((row) => {
+        if (row.table !== 'project') return false;
+        const data = JSON.parse(row.data);
+        return data[0]?.cad_trust_project_id === chain.project.cadTrustProjectId;
+      });
+      const unitDelete = stagingDeletes.find((row) => {
+        if (row.table !== 'unit') return false;
+        const data = JSON.parse(row.data);
+        return data[0]?.cad_trust_unit_id === unit.cadTrustUnitId;
+      });
+      expect(projectDelete).to.be.undefined;
+      expect(unitDelete).to.be.undefined;
     });
 
     it('should return 409 when another project references this project', async function () {

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -1243,6 +1243,50 @@ describe('V2 Project API - Basic CRUD Tests', function () {
         expect(matching, `missing staged delete for ${table}:${id}`).to.exist;
       }
     });
+
+    it('should return 409 when another project references this project', async function () {
+      const homeOrgId = await getV2HomeOrgId();
+      const program = await ProgramV2.create({
+        programName: 'Ref guard program',
+        programRegistry: 'Test Registry',
+        programRegistryActivityId: `REF-PGM-${uuidv4().slice(0, 8)}`,
+      });
+      const targetProject = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+        projectRegistryName: 'Test Registry',
+        projectId: `REF-TGT-${uuidv4().slice(0, 8)}`,
+        projectName: 'Target project for ref guard',
+        projectSector: ['Agriculture'],
+        orgUid: homeOrgId,
+        cadTrustProgramId: program.cadTrustProgramId,
+      }));
+      await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+        projectRegistryName: 'Test Registry',
+        projectId: `REF-PTR-${uuidv4().slice(0, 8)}`,
+        projectName: 'Referrer project',
+        projectSector: ['Agriculture'],
+        orgUid: homeOrgId,
+        cadTrustProgramId: program.cadTrustProgramId,
+        cadTrustReferenceProjectId: targetProject.cadTrustProjectId,
+      }));
+
+      const response = await supertest(app)
+        .delete(`/v2/project/${targetProject.cadTrustProjectId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(response.body.references).to.deep.include({ table: 'project', count: 1 });
+
+      const stagingDeletes = await StagingV2.findAll({
+        where: { table: 'project', action: 'DELETE' },
+        raw: true,
+      });
+      const forTarget = stagingDeletes.find((row) => {
+        const data = JSON.parse(row.data);
+        return data[0]?.cad_trust_project_id === targetProject.cadTrustProjectId;
+      });
+      expect(forTarget).to.be.undefined;
+    });
   });
 
   describe('Phase 20.5: Advanced Features Tests', function () {

--- a/tests/v2/integration/stakeholder-v2.spec.js
+++ b/tests/v2/integration/stakeholder-v2.spec.js
@@ -558,7 +558,7 @@ describe('Stakeholder V2 Endpoint Integration Tests', function () {
       expect(response.body.references).to.be.an('array').with.lengthOf(1);
       expect(response.body.references[0].table).to.equal('stakeholder_projects');
       expect(response.body.references[0].count).to.equal(1);
-      expect(response.body.hint).to.include('force=true');
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'stakeholder', action: 'DELETE' },
@@ -597,7 +597,7 @@ describe('Stakeholder V2 Endpoint Integration Tests', function () {
       expect(response.body.references[0].count).to.equal(1);
     });
 
-    it('should allow delete with ?force=true despite references', async function () {
+    it('should return 409 with ?force=true when references still exist', async function () {
       const stakeholder = await StakeholderV2.create({
         cadTrustStakeholderId: uuidv4(),
         stakeholderName: 'Force Delete Stakeholder',
@@ -613,15 +613,15 @@ describe('Stakeholder V2 Endpoint Integration Tests', function () {
       const response = await supertest(app)
         .delete(`/v2/stakeholder/${stakeholder.cadTrustStakeholderId}`)
         .query({ force: 'true' })
-        .expect(200);
+        .expect(409);
 
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Stakeholder delete staged successfully');
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
 
       const stagingRecord = await StagingV2.findOne({
         where: { table: 'stakeholder', action: 'DELETE' },
       });
-      expect(stagingRecord).to.exist;
+      expect(stagingRecord).to.be.null;
     });
   });
 });

--- a/tests/v2/integration/unit-v2.spec.js
+++ b/tests/v2/integration/unit-v2.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StagingV2, UnitV2, IssuanceV2, VerificationV2, MethodologyV2, ProjectMethodologyV2, ProjectV2, ValidationV2, ProgramV2, UnitLabelV2, LabelV2 } from '../../../src/models/v2/index.js';
+import { StagingV2, UnitV2, IssuanceV2, VerificationV2, MethodologyV2, ProjectMethodologyV2, ProjectV2, ValidationV2, ProgramV2, UnitLabelV2, LabelV2, AefT5AuthorizedEntitiesV2, AefT1SubmissionV2 } from '../../../src/models/v2/index.js';
 import { v4 as uuidv4 } from 'uuid';
 import TaskManager from '../../../src/tasks/index.js';
 import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
@@ -1085,6 +1085,58 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
 
       expect(unitDelete).to.exist;
       expect(unitLabelDelete).to.exist;
+    });
+
+    it('should return 409 when AEF-T5 authorized entity references unit', async function () {
+      const homeOrgId = await getV2HomeOrgId();
+      const chain = await createV2TestProgramChain({ testId: `UNIT-AEF5-${uuidv4().slice(0, 8)}` });
+      const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: `SER-AEF5-${uuidv4().slice(0, 8)}`,
+        unitStartBlock: '1',
+        unitEndBlock: '100',
+        unitCount: 50,
+        unitType: 'Avoidance - nature',
+        unitVintageYear: 2024,
+        unitStatus: 'Issued',
+        unitMetric: 'tCO2e',
+        cadTrustIssuanceId: chain.issuance.cadTrustIssuanceId,
+        orgUid: homeOrgId,
+      }));
+      const t1 = await AefT1SubmissionV2.create({
+        cadTrustAefT1SubmissionId: uuidv4(),
+        aefT1SubmissionParty: 'Guard party',
+        aefT1SubmissionVersion: '1.0',
+        aefT1SubmissionReportYear: 2024,
+        aefT1SubmissionSubmissionDate: '2024-01-15',
+      });
+      await AefT5AuthorizedEntitiesV2.create({
+        cadTrustAefT5AuthorizedEntitiesId: uuidv4(),
+        aefT5AuthorizedEntitiesAuthorizationDate: '2024-01-15',
+        aefT5AuthorizedEntitiesName: 'Guard entity',
+        aefT5AuthorizedEntitiesId: `AE-G-${uuidv4().slice(0, 6)}`,
+        aefT5AuthorizedEntitiesCooperativeApproachId: `CA-G-${uuidv4().slice(0, 6)}`,
+        cadTrustAefT1SubmissionId: t1.cadTrustAefT1SubmissionId,
+        cadTrustUnitId: unit.cadTrustUnitId,
+        cadTrustProjectId: chain.project.cadTrustProjectId,
+      });
+
+      const response = await supertest(app)
+        .delete(`/v2/unit/${unit.cadTrustUnitId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(response.body.references.map((r) => r.table)).to.include('aef_t5_authorized_entities');
+
+      const stagingDeletes = await StagingV2.findAll({
+        where: { table: 'unit', action: 'DELETE' },
+        raw: true,
+      });
+      const forThisUnit = stagingDeletes.find((row) => {
+        const data = JSON.parse(row.data);
+        return data[0]?.cad_trust_unit_id === unit.cadTrustUnitId;
+      });
+      expect(forThisUnit).to.be.undefined;
     });
   });
 

--- a/tests/v2/integration/validation-v2.spec.js
+++ b/tests/v2/integration/validation-v2.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { StagingV2, ValidationV2, ProjectV2, ProgramV2 } from '../../../src/models/v2/index.js';
+import { StagingV2, ValidationV2, ProjectV2, ProgramV2, VerificationV2 } from '../../../src/models/v2/index.js';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -524,6 +524,34 @@ describe('V2 Validation API - Basic CRUD Tests', function () {
       // Verify staged deletion data
       const stagedData = JSON.parse(stagingRecord.data);
       expect(stagedData[0].cad_trust_validation_id).to.equal(validation.cadTrustValidationId);
+    });
+
+    it('should return 409 when verification still references validation', async function () {
+      const validation = await ValidationV2.create(addUuidIfNeeded('ValidationV2', {
+        validationId: `VAL-DEL-GUARD-${uuidv4().slice(0, 8)}`,
+        validationType: 'Validation of Project Design Document',
+        validationBody: 'Guard body',
+        cadTrustProjectId: testProject.cadTrustProjectId,
+      }));
+      await VerificationV2.create(addUuidIfNeeded('VerificationV2', {
+        verificationId: `VER-VAL-GUARD-${uuidv4().slice(0, 8)}`,
+        verificationBody: 'Guard verifier',
+        cadTrustProjectId: testProject.cadTrustProjectId,
+        cadTrustValidationId: validation.cadTrustValidationId,
+      }));
+
+      const response = await supertest(app)
+        .delete(`/v2/validation/${validation.cadTrustValidationId}`)
+        .expect(409);
+
+      expect(response.body.success).to.be.false;
+      expect(response.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(response.body.references).to.deep.include({ table: 'verification', count: 1 });
+
+      const stagingDelete = await StagingV2.findOne({
+        where: { table: 'validation', action: 'DELETE' },
+      });
+      expect(stagingDelete).to.be.null;
     });
   });
 });

--- a/tests/v2/live-api/data-short.js
+++ b/tests/v2/live-api/data-short.js
@@ -65,6 +65,7 @@ const deletePhaseTestFiles = [
   'aef-t5-authorized-entities-validation.live.spec.js',
   'aef-t4-holdings-validation.live.spec.js',
   'aef-t3-actions-validation.live.spec.js',
+  'aef-t2-authorizations-validation.live.spec.js',
   'unit-validation.live.spec.js',
   'issuance-validation.live.spec.js',
   'verification-validation.live.spec.js',
@@ -79,7 +80,6 @@ const deletePhaseTestFiles = [
   'program-validation.live.spec.js',
   'stakeholder-validation.live.spec.js',
   'label-validation.live.spec.js',
-  'aef-t2-authorizations-validation.live.spec.js',
   'aef-t1-submission-validation.live.spec.js',
 ];
 

--- a/tests/v2/live-api/data-short.js
+++ b/tests/v2/live-api/data-short.js
@@ -58,6 +58,31 @@ const testFiles = [
   'aef-t5-authorized-entities-validation.live.spec.js',
 ];
 
+/** DELETE phase: dependents first so referential delete guards succeed */
+const deletePhaseTestFiles = [
+  'unit-label-validation.live.spec.js',
+  'stakeholder-projects-validation.live.spec.js',
+  'aef-t5-authorized-entities-validation.live.spec.js',
+  'aef-t4-holdings-validation.live.spec.js',
+  'aef-t3-actions-validation.live.spec.js',
+  'unit-validation.live.spec.js',
+  'issuance-validation.live.spec.js',
+  'verification-validation.live.spec.js',
+  'project-methodology-validation.live.spec.js',
+  'location-validation.live.spec.js',
+  'estimation-validation.live.spec.js',
+  'rating-validation.live.spec.js',
+  'co-benefit-validation.live.spec.js',
+  'validation-validation.live.spec.js',
+  'project-validation.live.spec.js',
+  'methodology-validation.live.spec.js',
+  'program-validation.live.spec.js',
+  'stakeholder-validation.live.spec.js',
+  'label-validation.live.spec.js',
+  'aef-t2-authorizations-validation.live.spec.js',
+  'aef-t1-submission-validation.live.spec.js',
+];
+
 async function runMochaTests(grepPattern, phaseName, filesToRun = null) {
   return new Promise((resolve, reject) => {
     const files = filesToRun || testFiles;
@@ -400,8 +425,13 @@ async function main() {
     await runMochaTests('Step 7: PUT Request Tests', 'PUT Operations');
     await commitAndWait('PUT');
 
-    // Phase 5: DELETE tests
-    await runMochaTests('Step 9: DELETE Request Tests', 'DELETE Operations');
+    // Phase 4.5: DELETE reference guards (requires committed graph from PUT phase)
+    await runMochaTests('Step 8: DELETE Reference Guard Tests', 'DELETE Reference Guards', [
+      'delete-reference-guards.live.spec.js',
+    ]);
+
+    // Phase 5: DELETE tests (dependents first — shared entities last)
+    await runMochaTests('Step 9: DELETE Request Tests', 'DELETE Operations', deletePhaseTestFiles);
     await commitAndWait('DELETE');
 
     console.log('\n=== All phases complete ===\n');

--- a/tests/v2/live-api/delete-reference-guards.live.spec.js
+++ b/tests/v2/live-api/delete-reference-guards.live.spec.js
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { getSharedRequest } from './helpers/shared-setup.js';
+import { getFirstCreatedId, getFirstRecordIdFromDatabase } from './helpers/shared-state.js';
+import { clearStagingTable } from './helpers/live-api-helpers.js';
+
+describe('V2 DELETE reference guard (live)', function () {
+  this.timeout(600000);
+  let request;
+
+  before(async function () {
+    request = getSharedRequest();
+  });
+
+  after(async function () {
+    await clearStagingTable(request);
+  });
+
+  describe('Step 8: DELETE Reference Guard Tests', function () {
+    it('should return 409 when deleting project-methodology referenced by issuance', async function () {
+      let pmId = getFirstCreatedId('project-methodology');
+      if (!pmId) {
+        pmId = await getFirstRecordIdFromDatabase(request, 'project-methodology');
+      }
+      if (!pmId) {
+        this.skip();
+      }
+      const res = await request.delete(`/v2/project-methodology/${pmId}`);
+      expect(res.status).to.equal(409);
+      expect(res.body.success).to.be.false;
+      expect(res.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(res.body.references).to.be.an('array');
+      expect(res.body.references.some((r) => r.table === 'issuance' && r.count >= 1)).to.be.true;
+    });
+
+    it('should return 409 when deleting methodology referenced by project-methodology', async function () {
+      let methodologyId = getFirstCreatedId('methodology');
+      if (!methodologyId) {
+        methodologyId = await getFirstRecordIdFromDatabase(request, 'methodology');
+      }
+      if (!methodologyId) {
+        this.skip();
+      }
+      const res = await request.delete(`/v2/methodology/${methodologyId}`);
+      expect(res.status).to.equal(409);
+      expect(res.body.success).to.be.false;
+      expect(res.body.error).to.equal('Referenced records must be removed before deletion');
+      expect(res.body.references.some((r) => r.table === 'project_methodology' && r.count >= 1)).to.be.true;
+    });
+  });
+});

--- a/tests/v2/live-api/label-validation.live.spec.js
+++ b/tests/v2/live-api/label-validation.live.spec.js
@@ -264,7 +264,7 @@ describe('Label Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/label', id, { query: { force: 'true' } });
+        const response = await makeDeleteRequest(request, '/v2/label', id);
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {

--- a/tests/v2/live-api/methodology-validation.live.spec.js
+++ b/tests/v2/live-api/methodology-validation.live.spec.js
@@ -289,7 +289,7 @@ describe('Methodology Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/methodology', id, { query: { force: 'true' } });
+        const response = await makeDeleteRequest(request, '/v2/methodology', id);
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {

--- a/tests/v2/live-api/program-validation.live.spec.js
+++ b/tests/v2/live-api/program-validation.live.spec.js
@@ -15,16 +15,41 @@ import {
   makeDeleteRequest,
   checkRecordInStaging,
 } from './helpers/api-request-helpers.js';
-import { addCreatedId, shouldAutoCommit, trackBatchVerification, getFirstRecordIdFromDatabase, getAllRecordIdsFromDatabase } from './helpers/shared-state.js';
+import { addCreatedId, getCreatedIds, shouldAutoCommit, trackBatchVerification, getFirstRecordIdFromDatabase, getAllRecordIdsFromDatabase } from './helpers/shared-state.js';
 import {
   generateProgram,
   generateProgramMinimal,
   generateProgramMaximal,
   generateProgramLongStrings,
   generateProgramForbiddenFields,
-  getLongString,
-  getInvalidPicklistValue,
 } from './data/test-data-generators.js';
+
+const REFERENCE_ERROR_CODE = 'Referenced records must be removed before deletion';
+const deleteTargetProgramIds = new Set();
+const blockedProgramIds = new Set();
+
+const getReferencedProgramIds = async (request) => {
+  const referencedProgramIds = new Set();
+  let page = 1;
+  const limit = 1000;
+  let hasMore = true;
+
+  while (hasMore) {
+    const response = await request.get('/v2/project').query({ page, limit }).expect(200);
+    const data = Array.isArray(response.body) ? response.body : (response.body?.data || []);
+    for (const project of data) {
+      if (project.cadTrustProgramId) {
+        referencedProgramIds.add(project.cadTrustProgramId);
+      }
+    }
+
+    const totalPages = response.body?.pageCount || 1;
+    hasMore = page < totalPages && data.length === limit;
+    page++;
+  }
+
+  return referencedProgramIds;
+};
 
 describe('Program Live API Validation Tests', function () {
   this.timeout(600000); // 10 minute timeout
@@ -261,9 +286,9 @@ describe('Program Live API Validation Tests', function () {
     });
   });
   describe('Step 9: DELETE Request Tests', function () {
-    it('should delete all created programs', async function () {
+    it('should delete unreferenced programs and preserve referenced programs', async function () {
       // Get IDs from createdIds (if available) or query database for existing records
-      let idsToDelete = createdIds.length > 0 ? createdIds : [];
+      let idsToDelete = createdIds.length > 0 ? createdIds : getCreatedIds('program');
       if (idsToDelete.length === 0) {
         // Query database to get all existing records (for DELETE tests running in separate process)
         idsToDelete = await getAllRecordIdsFromDatabase(request, 'program');
@@ -273,11 +298,18 @@ describe('Program Live API Validation Tests', function () {
         // No records to delete, skip test
         return;
       }
+      idsToDelete.forEach((id) => deleteTargetProgramIds.add(id));
 
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
         const response = await makeDeleteRequest(request, '/v2/program', id);
+        if (response.success === false && response.error === REFERENCE_ERROR_CODE) {
+          expect(response.references).to.be.an('array').that.is.not.empty;
+          expect(response.references.some((ref) => ref.table === 'project' && ref.count > 0)).to.be.true;
+          blockedProgramIds.add(id);
+          continue;
+        }
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {
@@ -293,11 +325,24 @@ describe('Program Live API Validation Tests', function () {
   });
 
   describe('Step 10: Final Validation', function () {
-    it('should verify all programs are deleted', async function () {
-      const response = await request.get('/v2/program').query({ page: 1, limit: 10 }).expect(200);
-      const data = Array.isArray(response.body) ? response.body : (response.body?.data || []);
-      // Should only have programs that existed before tests
-      expect(data.length).to.equal(0);
+    it('should verify remaining created programs are still referenced', async function () {
+      let idsToCheck = createdIds.length > 0 ? createdIds : getCreatedIds('program');
+      if (idsToCheck.length === 0) {
+        idsToCheck = [...deleteTargetProgramIds];
+      }
+      const referencedProgramIds = await getReferencedProgramIds(request);
+
+      for (const id of idsToCheck) {
+        const response = await request.get(`/v2/program/${id}`);
+        if (response.status === 404) {
+          continue;
+        }
+        expect(response.status).to.equal(200);
+        expect(
+          referencedProgramIds.has(id) || blockedProgramIds.has(id),
+          `Program ${id} remains without committed or delete-time project references`,
+        ).to.be.true;
+      }
     });
   });
 });

--- a/tests/v2/live-api/program-validation.live.spec.js
+++ b/tests/v2/live-api/program-validation.live.spec.js
@@ -277,7 +277,7 @@ describe('Program Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/program', id, { query: { force: 'true' } });
+        const response = await makeDeleteRequest(request, '/v2/program', id);
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {

--- a/tests/v2/live-api/program-validation.live.spec.js
+++ b/tests/v2/live-api/program-validation.live.spec.js
@@ -26,10 +26,42 @@ import {
 
 const REFERENCE_ERROR_CODE = 'Referenced records must be removed before deletion';
 const deleteTargetProgramIds = new Set();
-const blockedProgramIds = new Set();
+
+const getProjectId = (project) => project.cadTrustProjectId || project.cad_trust_project_id;
+const getProgramId = (project) => project.cadTrustProgramId || project.cad_trust_program_id;
+
+const getProjectStagingReferences = async (request) => {
+  const pendingDeleteProjectIds = new Set();
+  const stagedReferencedProgramIds = new Set();
+  const response = await request
+    .get('/v2/staging')
+    .query({ page: 1, limit: 1000, table: 'project', type: 'staged' })
+    .expect(200);
+  const rows = response.body?.data || response.body || [];
+
+  for (const row of rows) {
+    const records = row.diff?.change || [];
+    for (const record of records) {
+      const projectId = getProjectId(record);
+      const programId = getProgramId(record);
+      if (row.action === 'DELETE' && projectId) {
+        pendingDeleteProjectIds.add(projectId);
+      } else if (['INSERT', 'UPDATE'].includes(row.action) && programId) {
+        stagedReferencedProgramIds.add(programId);
+      }
+    }
+  }
+
+  return { pendingDeleteProjectIds, stagedReferencedProgramIds };
+};
 
 const getReferencedProgramIds = async (request) => {
   const referencedProgramIds = new Set();
+  const { pendingDeleteProjectIds, stagedReferencedProgramIds } = await getProjectStagingReferences(request);
+  for (const programId of stagedReferencedProgramIds) {
+    referencedProgramIds.add(programId);
+  }
+
   let page = 1;
   const limit = 1000;
   let hasMore = true;
@@ -38,8 +70,10 @@ const getReferencedProgramIds = async (request) => {
     const response = await request.get('/v2/project').query({ page, limit }).expect(200);
     const data = Array.isArray(response.body) ? response.body : (response.body?.data || []);
     for (const project of data) {
-      if (project.cadTrustProgramId) {
-        referencedProgramIds.add(project.cadTrustProgramId);
+      const projectId = getProjectId(project);
+      const programId = getProgramId(project);
+      if (programId && !pendingDeleteProjectIds.has(projectId)) {
+        referencedProgramIds.add(programId);
       }
     }
 
@@ -299,17 +333,20 @@ describe('Program Live API Validation Tests', function () {
         return;
       }
       idsToDelete.forEach((id) => deleteTargetProgramIds.add(id));
+      const expectedReferencedProgramIds = await getReferencedProgramIds(request);
 
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
         const response = await makeDeleteRequest(request, '/v2/program', id);
-        if (response.success === false && response.error === REFERENCE_ERROR_CODE) {
+        if (expectedReferencedProgramIds.has(id)) {
+          expect(response.success).to.be.false;
+          expect(response.error).to.equal(REFERENCE_ERROR_CODE);
           expect(response.references).to.be.an('array').that.is.not.empty;
           expect(response.references.some((ref) => ref.table === 'project' && ref.count > 0)).to.be.true;
-          blockedProgramIds.add(id);
           continue;
         }
+
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {
@@ -339,7 +376,7 @@ describe('Program Live API Validation Tests', function () {
         }
         expect(response.status).to.equal(200);
         expect(
-          referencedProgramIds.has(id) || blockedProgramIds.has(id),
+          referencedProgramIds.has(id),
           `Program ${id} remains without committed or delete-time project references`,
         ).to.be.true;
       }

--- a/tests/v2/live-api/project-validation.live.spec.js
+++ b/tests/v2/live-api/project-validation.live.spec.js
@@ -15,14 +15,13 @@ import {
   makeDeleteRequest,
   checkRecordInStaging,
 } from './helpers/api-request-helpers.js';
-import { addCreatedId, shouldAutoCommit, trackBatchVerification, getFirstRecordIdFromDatabase, getAllRecordIdsFromDatabase } from './helpers/shared-state.js';
+import { addCreatedId, shouldAutoCommit, trackBatchVerification } from './helpers/shared-state.js';
 import {
   generateProject,
   generateProjectMinimal,
   generateProjectMaximal,
   generateProjectLongStrings,
   generateProjectForbiddenFields,
-  getLongString,
   getInvalidPicklistValue,
 } from './data/test-data-generators.js';
 
@@ -186,9 +185,8 @@ describe('Project Live API Validation Tests', function () {
         // Query for test records by filtering by home org and TEST- prefix
         let page = 1;
         const limit = 100;
-        let found = false;
 
-        while (!found && page <= 10) { // Limit to 10 pages to avoid infinite loop
+        while (page <= 10) { // Limit to 10 pages to avoid infinite loop
           const response = await request.get(`/v2/project?page=${page}&limit=${limit}&orgUid=${homeOrgId}`).expect(200);
           const data = Array.isArray(response.body) ? response.body : (response.body?.data || []);
 
@@ -199,7 +197,6 @@ describe('Project Live API Validation Tests', function () {
 
           if (testRecord) {
             id = testRecord.cadTrustProjectId;
-            found = true;
             break;
           }
 
@@ -230,7 +227,7 @@ describe('Project Live API Validation Tests', function () {
       // Required fields must always be included; optional fields can be null (matching V1 behavior)
       const updateData = {
         projectRegistryName: record.projectRegistryName,
-        projectId: `UPDATED-${Date.now()}`,
+        projectId: `TEST-UPDATED-${Date.now()}`,
         projectName: 'Updated Project Name',
         projectCreditingProgram: record.projectCreditingProgram ?? null,
         projectLink: record.projectLink ?? null,

--- a/tests/v2/live-api/stakeholder-validation.live.spec.js
+++ b/tests/v2/live-api/stakeholder-validation.live.spec.js
@@ -265,7 +265,7 @@ describe('Stakeholder Live API Validation Tests', function () {
       // Delete in reverse order
       for (let i = idsToDelete.length - 1; i >= 0; i--) {
         const id = idsToDelete[i];
-        const response = await makeDeleteRequest(request, '/v2/stakeholder', id, { query: { force: 'true' } });
+        const response = await makeDeleteRequest(request, '/v2/stakeholder', id);
         expect(response.success).to.be.true;
 
         if (shouldAutoCommit()) {


### PR DESCRIPTION
## Summary

- Extend V2 delete reference guards so DELETE handlers return 409 when any committed or staged (`INSERT`/`UPDATE`) row still references the target, regardless of which registry owns the referencing row.
- Remove `?force=true` bypass for guarded deletes; conflict responses use stable `error`, user-facing `message`, and `references: [{ table, count }]` (no `hint`).
- Reorder V2 live short-mode DELETE phase so dependents are deleted before shared roots; add live Step 8 specs for representative 409 cases; update V2 RPC docs for methodology/program/stakeholder/label DELETE examples.

## Test plan

- [x] `bash tests/run-tests.sh npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha ...` for new/updated 409 integration cases (project cross-ref, project-methodology + issuance, location + issuance, validation + verification, unit + AEF-T5) and methodology DELETE guard suite
- [ ] `npm run test:v2` (full V2 integration suite) on CI
- [ ] `npm run test:v2:live:data:short` when exercising live harness (requires live CADT + datalayer)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes DELETE behavior across multiple V2 endpoints by removing the `?force=true` escape hatch and expanding what counts as an inbound reference, which can break existing clients and cleanup workflows. Risk is moderate because it’s primarily guard/response-shape changes but touches core data lifecycle paths.
> 
> **Overview**
> **V2 DELETE endpoints now hard-block deletes when inbound references exist**, considering both committed rows and staged `INSERT`/`UPDATE` rows, and treating references from any synced registry the same.
> 
> Removes the `?force=true` bypass for guarded entities (e.g., `methodology`, `program`, `stakeholder`, `label`) and extends guards to additional entities/relationships (`project`, `unit`, `location`, `validation`, `project_methodology`), including checks for downstream/cascade units when deleting a `project`.
> 
> Standardizes 409 responses to include a stable `error` code plus a clearer `message` and `references` list (dropping the prior `hint`), updates RPC docs accordingly, and updates integration/live tests (including new live “Step 8” guard tests and DELETE ordering so dependents delete before shared roots).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc31e658acc6e60e480355c095cd7ac6ac927689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->