### PR TITLE
Ensure unitStatusReason is editable in v2 unit split

### DIFF
--- a/tests/v2/integration/unit-v2.spec.js
+++ b/tests/v2/integration/unit-v2.spec.js
@@ -1174,6 +1174,7 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
               unitBlockEnd: '1029',
               unitCurrentOwner: 'Owner 1',
               unitStatus: 'Issued',
+              unitStatusReason: 'Issued after split',
             },
             {
               unitCount: 40,
@@ -1181,6 +1182,7 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
               unitBlockEnd: '1069',
               unitCurrentOwner: 'Owner 2',
               unitStatus: 'Held',
+              unitStatusReason: 'Held after split',
             },
             {
               unitCount: 30,
@@ -1188,6 +1190,7 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
               unitBlockEnd: '1099',
               unitCurrentOwner: 'Owner 3',
               unitStatus: 'Retired',
+              unitStatusReason: 'Retired after split',
             },
           ],
         };
@@ -1218,6 +1221,9 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
         expect(stagedData.length).to.equal(3);
         expect(stagedData[0].cadTrustUnitId).to.equal(unit.cadTrustUnitId); // First keeps original ID
         expect(stagedData[1].cadTrustUnitId).to.not.equal(unit.cadTrustUnitId); // Others get new IDs
+        expect(stagedData[0].unitStatusReason).to.equal('Issued after split');
+        expect(stagedData[1].unitStatusReason).to.equal('Held after split');
+        expect(stagedData[2].unitStatusReason).to.equal('Retired after split');
       });
 
       it('should return error if cadTrustUnitId is missing', async function () {


### PR DESCRIPTION
## Summary
- Adds regression coverage that `unitStatusReason` can be supplied per record to `POST /v2/unit/split`.
- Verifies each staged split unit preserves its requested status reason.

## Test plan
- `eval "$(fnm env)" && fnm use && bash tests/run-tests.sh npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js 'tests/v2/integration/unit-v2.spec.js' --reporter spec --exit --timeout 300000`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add/strengthen integration test assertions around `POST /v2/unit/split` without modifying production logic.
> 
> **Overview**
> Adds regression coverage for `POST /v2/unit/split` to ensure each split record can supply its own `unitStatusReason`.
> 
> The integration test now sends `unitStatusReason` per split record and asserts the staged split payload preserves those reasons for all three resulting units.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ed5379cedd5f19b083ddfd5a65db0aff95093c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->