### PR TITLE
feat(API): cross-reference datalayer-owned stores in /diagnostics

### DIFF
--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -80,16 +80,63 @@ const settle = async (label, producer, timeoutMs = DEFAULT_TIMEOUT_MS) => {
   }
 };
 
-const readHomeOrgId = async (Model, getter = 'getHomeOrg') => {
+/**
+ * Returns the full home-org record (raw object) for the given Model, or null
+ * when no home org is configured. Used to populate both the cadtSection
+ * homeOrgId field and the expected-owned-stores helper. We prefer
+ * Model.getHomeOrg(false) (includeAddress=false) so any model-level
+ * processing (metadata parsing, field normalization) is applied -- and to
+ * avoid the wallet RPC call that includeAddress=true triggers, which
+ * /diagnostics must not require.
+ *
+ * If `getHomeOrg` throws (e.g. V1 throws on malformed `metadata` JSON --
+ * see organizations.model.js, no try/catch around JSON.parse), we fall
+ * back to a direct raw findOne on the home-org row. That recovers the
+ * owned-store cross-reference for the very failure mode operators are
+ * likely hitting /diagnostics to debug.
+ */
+const readHomeOrgRecord = async (Model, getter = 'getHomeOrg', whereClause) => {
   try {
-    // includeAddress=false avoids a wallet RPC call inside getHomeOrg --
-    // /diagnostics must keep working when the wallet is unreachable.
-    const homeOrg = await Model[getter](false);
-    if (!homeOrg) return null;
-    // V1 uses `orgUid`, V2 uses `org_uid`
-    return homeOrg.orgUid || homeOrg.org_uid || null;
+    // `null` is a legitimate "no home org configured" answer (common on
+    // fresh installs) -- return it without triggering the fallback, which
+    // is only useful when getHomeOrg threw on otherwise-valid data.
+    return (await Model[getter](false)) || null;
   } catch (error) {
-    logger.debug(`[diagnostics]: home org lookup failed: ${error.message}`);
+    logger.warn(`[diagnostics]: ${getter} failed: ${error.message}; trying raw findOne`);
+  }
+  if (!whereClause) return null;
+  try {
+    return (await Model.findOne({ where: whereClause, raw: true })) || null;
+  } catch (error) {
+    logger.warn(`[diagnostics]: raw home org fallback failed: ${error.message}`);
+    return null;
+  }
+};
+
+const homeOrgUid = (record) =>
+  record ? record.orgUid || record.org_uid || null : null;
+
+/**
+ * Read a single string value out of the V1 Meta table, or null when the key
+ * is absent. Used for governance store IDs that only exist when this node
+ * IS the governance body (the local creation flow upserts these keys).
+ */
+const readMetaValueV1 = async (Meta, metaKey) => {
+  try {
+    const row = await Meta.findOne({ where: { metaKey }, raw: true });
+    return row?.metaValue || null;
+  } catch (error) {
+    logger.debug(`[diagnostics]: V1 Meta[${metaKey}] lookup failed: ${error.message}`);
+    return null;
+  }
+};
+
+const readMetaValueV2 = async (MetaV2, metaKey) => {
+  try {
+    const row = await MetaV2.findOne({ where: { meta_key: metaKey }, raw: true });
+    return row?.meta_value || null;
+  } catch (error) {
+    logger.debug(`[diagnostics]: V2 Meta[${metaKey}] lookup failed: ${error.message}`);
     return null;
   }
 };
@@ -177,6 +224,111 @@ const collectSubscriptions = async (persistance) => {
 };
 
 /**
+ * Pure helper: given the list of expected-owned-store entries (as produced
+ * by `collectOwnedStoreExpectations`), escalate `accumulator` to critical
+ * when one or more entries have `owned === false`. Entries with
+ * `owned === null` (datalayer RPC failure -> ownership unknown) are not
+ * escalated -- the existing datalayer-unreachable critical already covers
+ * that case. Returns the list of escalated entries for tests/log purposes.
+ *
+ * Exported through `__test` so the integration test can drive the real
+ * escalation path (instead of re-implementing it).
+ */
+const escalateLostOwnedStores = (accumulator, expectedOwnedStores) => {
+  const lostStores = (expectedOwnedStores || []).filter((s) => s.owned === false);
+  if (lostStores.length > 0) {
+    const detail = lostStores.map((s) => `${s.storeId} (${s.label})`).join(', ');
+    accumulator.escalate(
+      'critical',
+      `expected owned store is not owned by datalayer and can't be written to: ${detail}`,
+    );
+  }
+  return lostStores;
+};
+
+/**
+ * Pure helper: cross-reference the set of datalayer-owned store IDs against
+ * the stores CADT itself created (home org + registry + lazily-created
+ * file/data-model stores + locally-created governance stores). Detects the
+ * "datalayer/chia wallet forgot about a store we created" failure mode,
+ * which leaves the store unwritable until the wallet is restored.
+ *
+ * Inputs are pre-resolved so this function is sync and trivially testable.
+ *  - ownedStoresResult: result from persistance.getOwnedStores() or null on RPC failure
+ *  - v1HomeOrg / v2HomeOrg: home org records or null
+ *  - v1GovernanceBodyStoreId / v1GovernanceVersionStoreId / v2GovernanceBodyStoreId /
+ *    v2GovernanceVersionStoreId: governance store IDs that this node owns. The
+ *    caller is responsible for distinguishing owner vs subscriber: it must
+ *    pass null for any key the local node does not own. V1 has no
+ *    subscribe-to-governance-body flow so both V1 keys are always owned when
+ *    present; V2 *does* have one, and `MetaV2.governanceBodyId` is upserted
+ *    on subscribe -- so the V2 caller must gate both V2 entries on the
+ *    presence of `MetaV2.mainGoveranceBodyId`, which subscribers do not write.
+ *
+ * Lazily-created stores (V1 fileStoreId / dataModelVersionStoreId, V2
+ * file_store_subscribed / data_model_version_store_id) are skipped when
+ * NULL -- datalayer cannot have "forgotten" a store CADT hasn't asked it
+ * to create yet, so listing them would generate false-positive criticals.
+ */
+const collectOwnedStoreExpectations = ({
+  ownedStoresResult,
+  v1HomeOrg,
+  v2HomeOrg,
+  v1GovernanceBodyStoreId,
+  v1GovernanceVersionStoreId,
+  v2GovernanceBodyStoreId,
+  v2GovernanceVersionStoreId,
+}) => {
+  const ownedStores =
+    ownedStoresResult && ownedStoresResult.success ? ownedStoresResult.storeIds || [] : null;
+  const ownedSet = ownedStores ? new Set(ownedStores) : null;
+
+  const expected = [];
+  const push = (storeId, label) => {
+    if (storeId) expected.push({ storeId, label });
+  };
+
+  if (v1HomeOrg) {
+    push(v1HomeOrg.orgUid, 'v1 home org');
+    push(v1HomeOrg.registryId, 'v1 registry');
+    push(v1HomeOrg.fileStoreId, 'v1 file store');
+    push(v1HomeOrg.dataModelVersionStoreId, 'v1 data model version store');
+  }
+
+  if (v2HomeOrg) {
+    push(v2HomeOrg.org_uid, 'v2 home org');
+    push(v2HomeOrg.registry_id, 'v2 registry');
+    // file_store_subscribed is overloaded: on the home org row it stores the
+    // locally-created file store ID (filestore-v2.model.js
+    // createDataLayerStoreWithRetry path) and is genuinely owned. On a
+    // non-home/subscribed org row it stores a REMOTE org's file store ID
+    // (organizations-v2.model.js upsert path). The caller only passes the
+    // home-org record here, so this is safe today -- if a future code path
+    // ever lands a non-owned ID on the home-org row, it will produce a
+    // false-positive critical, so any future writer of this column must
+    // continue to use a locally-created store ID for is_home=true rows.
+    push(v2HomeOrg.file_store_subscribed, 'v2 file store');
+    push(v2HomeOrg.data_model_version_store_id, 'v2 data model version store');
+  }
+
+  push(v1GovernanceBodyStoreId, 'v1 governance body');
+  push(v1GovernanceVersionStoreId, 'v1 governance version store');
+  push(v2GovernanceBodyStoreId, 'v2 governance body');
+  push(v2GovernanceVersionStoreId, 'v2 governance version store');
+
+  const expectedOwnedStores = expected.map((entry) => ({
+    ...entry,
+    owned: ownedSet ? ownedSet.has(entry.storeId) : null,
+  }));
+
+  return {
+    ownedStores,
+    totalOwnedStores: ownedStores ? ownedStores.length : null,
+    expectedOwnedStores,
+  };
+};
+
+/**
  * Normalize a chia peer node_id for comparison: strip a leading 0x and
  * lowercase. Both the chia config's `wallet.trusted_peers` keys and the
  * `get_connections` RPC values are hex, but they differ on the 0x prefix
@@ -251,8 +403,8 @@ export const getDiagnosticsResponse = async () => {
   const wallet = (await import('../datalayer/wallet.js')).default;
   const fullNodeRpc = (await import('../datalayer/fullNodeRpc.js')).default;
   const persistance = await import('../datalayer/persistance.js');
-  const { Organization } = await import('../models/index.js');
-  const { OrganizationsV2 } = await import('../models/v2/index.js');
+  const { Organization, Meta } = await import('../models/index.js');
+  const { OrganizationsV2, MetaV2 } = await import('../models/v2/index.js');
   const fullNodeModule = await import('../datalayer/fullNode.js');
 
   // Phase 1: fast local probes (process scan, system info, chia-tools).
@@ -303,8 +455,52 @@ export const getDiagnosticsResponse = async () => {
       () => collectSubscriptions(persistance),
       SUBSCRIPTION_BUDGET_MS + 1000,
     ),
-    settle('Organization.getHomeOrg', () => readHomeOrgId(Organization), DEFAULT_TIMEOUT_MS),
-    settle('OrganizationsV2.getHomeOrg', () => readHomeOrgId(OrganizationsV2), DEFAULT_TIMEOUT_MS),
+    settle(
+      'Organization.getHomeOrg',
+      () => readHomeOrgRecord(Organization, 'getHomeOrg', { isHome: true }),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    settle(
+      'OrganizationsV2.getHomeOrg',
+      () => readHomeOrgRecord(OrganizationsV2, 'getHomeOrg', { is_home: true }),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    // Detect "datalayer/chia wallet forgot about a store CADT owns" failures
+    // (see chia.datalayer.expectedOwnedStores in the response). Falls back to
+    // ownedStoresResult=null on RPC failure, which makes per-expected owned
+    // flags null (unknown) rather than false -- the existing datalayer-
+    // unreachable critical already covers that case.
+    settle('persistance.getOwnedStores', () => persistance.getOwnedStores(), DEFAULT_TIMEOUT_MS),
+    // V1 governance: both Meta keys are upserted only by
+    // Governance.createGoveranceBody (there is no V1 subscribe-to-body
+    // flow), so both are always owned when present.
+    settle(
+      'Meta.mainGoveranceBodyId',
+      () => readMetaValueV1(Meta, 'mainGoveranceBodyId'),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    settle(
+      'Meta.governanceBodyId',
+      () => readMetaValueV1(Meta, 'governanceBodyId'),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    // V2 governance: `mainGoveranceBodyId` is upserted ONLY by the create
+    // paths (createGoveranceBody / addV2ToExistingGovernanceBody), never by
+    // GovernanceV2.subscribeToGovernanceBody. `governanceBodyId` is upserted
+    // by both create AND subscribe, so it cannot be treated as an
+    // owned-store marker on its own. We use the presence of
+    // `mainGoveranceBodyId` below as the binary "this node IS the V2
+    // governance body" gate before publishing either V2 entry.
+    settle(
+      'MetaV2.mainGoveranceBodyId',
+      () => readMetaValueV2(MetaV2, 'mainGoveranceBodyId'),
+      DEFAULT_TIMEOUT_MS,
+    ),
+    settle(
+      'MetaV2.governanceBodyId',
+      () => readMetaValueV2(MetaV2, 'governanceBodyId'),
+      DEFAULT_TIMEOUT_MS,
+    ),
   ];
 
   const [
@@ -320,6 +516,11 @@ export const getDiagnosticsResponse = async () => {
     subscriptionsRes,
     homeOrgV1Res,
     homeOrgV2Res,
+    ownedStoresRes,
+    metaV1MainGovBodyRes,
+    metaV1GovBodyRes,
+    metaV2MainGovBodyRes,
+    metaV2GovBodyRes,
   ] = await Promise.all(rpcSettles);
 
   // walletReachable: derived from the get_network_info RPC return value, NOT
@@ -340,6 +541,9 @@ export const getDiagnosticsResponse = async () => {
   const enableV2 = configV2?.ENABLE !== false;
   const chiaRoot = getChiaRoot();
 
+  const v1HomeOrg = homeOrgV1Res.ok ? homeOrgV1Res.value : null;
+  const v2HomeOrg = homeOrgV2Res.ok ? homeOrgV2Res.value : null;
+
   // ---- CADT section -------------------------------------------------------
   const cadtSection = {
     version: packageJson.version,
@@ -359,7 +563,7 @@ export const getDiagnosticsResponse = async () => {
       isGovernanceBody: configV1.IS_GOVERNANCE_BODY === true,
       apiKeyConfigured: !!(configV1.CADT_API_KEY && configV1.CADT_API_KEY !== ''),
       governanceBodyId: configV1.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
-      homeOrgId: homeOrgV1Res.ok ? homeOrgV1Res.value : null,
+      homeOrgId: homeOrgUid(v1HomeOrg),
     },
     v2: {
       enabled: enableV2,
@@ -367,7 +571,7 @@ export const getDiagnosticsResponse = async () => {
       isGovernanceBody: configV2.IS_GOVERNANCE_BODY === true,
       apiKeyConfigured: !!(configV2.CADT_API_KEY && configV2.CADT_API_KEY !== ''),
       governanceBodyId: configV2.GOVERNANCE?.GOVERNANCE_BODY_ID || null,
-      homeOrgId: homeOrgV2Res.ok ? homeOrgV2Res.value : null,
+      homeOrgId: homeOrgUid(v2HomeOrg),
     },
   };
 
@@ -446,6 +650,29 @@ export const getDiagnosticsResponse = async () => {
     const subscriptionsValue = subscriptionsRes.ok
       ? subscriptionsRes.value
       : { available: false, subscriptions: [], truncated: false, totalSubscriptions: 0, error: subscriptionsRes.error };
+
+    // Owned-store cross-reference: detect the "datalayer/chia wallet forgot
+    // about a store CADT owns" failure mode. The pure helper handles all
+    // null/missing cases (no home org, RPC failure, lazy stores not yet
+    // created). V2 governance store IDs are gated on
+    // MetaV2.mainGoveranceBodyId being present -- that key is set ONLY by
+    // the create paths, never by GovernanceV2.subscribeToGovernanceBody, so
+    // its presence is the binary "this node IS the V2 governance body"
+    // signal. V1 has no subscribe path, so both V1 governance keys are
+    // always owned when present.
+    const v2IsGovernanceBody = !!(metaV2MainGovBodyRes.ok && metaV2MainGovBodyRes.value);
+    const ownedStoreView = collectOwnedStoreExpectations({
+      ownedStoresResult: ownedStoresRes.ok ? ownedStoresRes.value : null,
+      v1HomeOrg,
+      v2HomeOrg,
+      v1GovernanceBodyStoreId: metaV1MainGovBodyRes.ok ? metaV1MainGovBodyRes.value : null,
+      v1GovernanceVersionStoreId: metaV1GovBodyRes.ok ? metaV1GovBodyRes.value : null,
+      v2GovernanceBodyStoreId: v2IsGovernanceBody ? metaV2MainGovBodyRes.value : null,
+      v2GovernanceVersionStoreId:
+        v2IsGovernanceBody && metaV2GovBodyRes.ok ? metaV2GovBodyRes.value : null,
+    });
+    const ownedStoresError = ownedStoresRes.ok ? null : ownedStoresRes.error;
+
     return {
       rpcUrl: appConfig.DATALAYER_URL || null,
       reachable,
@@ -453,6 +680,10 @@ export const getDiagnosticsResponse = async () => {
       totalSubscriptions: subscriptionsValue.totalSubscriptions,
       truncated: subscriptionsValue.truncated,
       ...(subscriptionsValue.error ? { subscriptionsError: subscriptionsValue.error } : {}),
+      ownedStores: ownedStoreView.ownedStores,
+      totalOwnedStores: ownedStoreView.totalOwnedStores,
+      expectedOwnedStores: ownedStoreView.expectedOwnedStores,
+      ...(ownedStoresError ? { ownedStoresError } : {}),
     };
   })();
 
@@ -545,6 +776,11 @@ export const getDiagnosticsResponse = async () => {
     if (datalayerSection.subscriptions?.some((s) => s.synced === false)) {
       dlStatus.escalate('warning', 'One or more DataLayer subscriptions are not synced');
     }
+    // Critical when CADT believes it owns a store the datalayer has lost
+    // track of -- that store cannot be written to and usually requires
+    // operator intervention (the chia wallet occasionally "forgets" a
+    // store it created).
+    escalateLostOwnedStores(dlStatus, datalayerSection.expectedOwnedStores);
     Object.assign(datalayerSection, dlStatus.result());
   }
 
@@ -644,5 +880,7 @@ export const __test = {
   collectSubscriptions,
   buildTrustedPeerView,
   normalizeNodeId,
+  collectOwnedStoreExpectations,
+  escalateLostOwnedStores,
   StatusAccumulator,
 };

--- a/tests/v2/integration/diagnostics-helpers.spec.js
+++ b/tests/v2/integration/diagnostics-helpers.spec.js
@@ -388,3 +388,193 @@ describe('collectSubscriptions', function () {
     expect(result.subscriptions[0].error).to.equal('no sync status returned');
   });
 });
+
+describe('collectOwnedStoreExpectations', function () {
+  const { collectOwnedStoreExpectations } = diagnosticsTest;
+
+  it('returns empty expected list and null ownedStores when nothing is configured', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: null,
+      v1HomeOrg: null,
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.ownedStores).to.equal(null);
+    expect(result.totalOwnedStores).to.equal(null);
+    expect(result.expectedOwnedStores).to.deep.equal([]);
+  });
+
+  it('lists V1 home-org stores, skipping null lazy stores', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: true, storeIds: ['org1', 'reg1'] },
+      v1HomeOrg: {
+        orgUid: 'org1',
+        registryId: 'reg1',
+        fileStoreId: null,
+        dataModelVersionStoreId: null,
+      },
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.expectedOwnedStores).to.have.length(2);
+    expect(result.expectedOwnedStores.map((e) => e.label)).to.deep.equal([
+      'v1 home org',
+      'v1 registry',
+    ]);
+    expect(result.expectedOwnedStores.every((e) => e.owned === true)).to.equal(true);
+  });
+
+  it('lists V2 home-org stores using snake_case fields', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: true, storeIds: ['orgA', 'regA', 'fsA', 'dmA'] },
+      v1HomeOrg: null,
+      v2HomeOrg: {
+        org_uid: 'orgA',
+        registry_id: 'regA',
+        file_store_subscribed: 'fsA',
+        data_model_version_store_id: 'dmA',
+      },
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.expectedOwnedStores.map((e) => e.label)).to.deep.equal([
+      'v2 home org',
+      'v2 registry',
+      'v2 file store',
+      'v2 data model version store',
+    ]);
+    expect(result.expectedOwnedStores.every((e) => e.owned === true)).to.equal(true);
+  });
+
+  it('flags an expected store as owned=false when datalayer does not list it', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: true, storeIds: ['org1'] },
+      v1HomeOrg: { orgUid: 'org1', registryId: 'reg1' },
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    const byLabel = Object.fromEntries(
+      result.expectedOwnedStores.map((e) => [e.label, e]),
+    );
+    expect(byLabel['v1 home org'].owned).to.equal(true);
+    expect(byLabel['v1 registry'].owned).to.equal(false);
+  });
+
+  it('marks owned as null (unknown) when datalayer RPC failed', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: null,
+      v1HomeOrg: { orgUid: 'org1', registryId: 'reg1' },
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.ownedStores).to.equal(null);
+    expect(result.expectedOwnedStores.every((e) => e.owned === null)).to.equal(true);
+  });
+
+  it('marks owned as null when datalayer returned success=false', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: false, storeIds: [] },
+      v1HomeOrg: { orgUid: 'org1' },
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.ownedStores).to.equal(null);
+    expect(result.expectedOwnedStores[0].owned).to.equal(null);
+  });
+
+  it('includes governance stores when this node IS the governance body', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: {
+        success: true,
+        storeIds: ['gov-body-v1', 'gov-version-v1', 'gov-body-v2', 'gov-version-v2'],
+      },
+      v1HomeOrg: null,
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: 'gov-body-v1',
+      v1GovernanceVersionStoreId: 'gov-version-v1',
+      v2GovernanceBodyStoreId: 'gov-body-v2',
+      v2GovernanceVersionStoreId: 'gov-version-v2',
+    });
+    expect(result.expectedOwnedStores.map((e) => e.label)).to.deep.equal([
+      'v1 governance body',
+      'v1 governance version store',
+      'v2 governance body',
+      'v2 governance version store',
+    ]);
+    expect(result.expectedOwnedStores.every((e) => e.owned === true)).to.equal(true);
+  });
+
+  it('excludes V2 governance keys when caller signals subscriber (mainGoveranceBodyId absent)', function () {
+    // V2 subscribers have governanceBodyId set in MetaV2 (subscribe upserts
+    // it) but no mainGoveranceBodyId. The caller is responsible for passing
+    // null for both v2 fields in that case; the helper just trusts it.
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: true, storeIds: [] },
+      v1HomeOrg: null,
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v1GovernanceVersionStoreId: null,
+      v2GovernanceBodyStoreId: null, // gated off by caller
+      v2GovernanceVersionStoreId: null, // gated off by caller
+    });
+    expect(result.expectedOwnedStores).to.deep.equal([]);
+  });
+
+  it('combines home-org and governance-body expectations in a single list', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: true, storeIds: ['org', 'reg', 'gov-body'] },
+      v1HomeOrg: { orgUid: 'org', registryId: 'reg' },
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: 'gov-body',
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.expectedOwnedStores.map((e) => e.label)).to.deep.equal([
+      'v1 home org',
+      'v1 registry',
+      'v1 governance body',
+    ]);
+    expect(result.expectedOwnedStores.every((e) => e.owned === true)).to.equal(true);
+  });
+
+  it('reports totalOwnedStores from the actual datalayer-owned list', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: true, storeIds: ['a', 'b', 'c', 'd'] },
+      v1HomeOrg: { orgUid: 'a', registryId: 'b' }, // only 2 expected
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.totalOwnedStores).to.equal(4);
+    expect(result.expectedOwnedStores).to.have.length(2);
+  });
+
+  it('skips entries with falsy storeId without throwing', function () {
+    const result = collectOwnedStoreExpectations({
+      ownedStoresResult: { success: true, storeIds: [] },
+      v1HomeOrg: {
+        orgUid: '', // falsy -- should be skipped
+        registryId: 'reg1',
+        fileStoreId: undefined,
+        dataModelVersionStoreId: null,
+      },
+      v2HomeOrg: null,
+      v1GovernanceBodyStoreId: null,
+      v2GovernanceBodyStoreId: null,
+      v2GovernanceVersionStoreId: null,
+    });
+    expect(result.expectedOwnedStores.map((e) => e.label)).to.deep.equal(['v1 registry']);
+  });
+});

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -4,7 +4,7 @@ import supertest from 'supertest';
 import app from '../../../src/server.js';
 import { prepareDb } from '../../../src/database/index.js';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
-import { withConfigOverride } from '../utils/v2-test-helpers.js';
+import { createV2TestHomeOrg, withConfigOverride } from '../utils/v2-test-helpers.js';
 
 describe('/diagnostics endpoint', function () {
   this.timeout(60000);
@@ -420,6 +420,97 @@ describe('/diagnostics endpoint', function () {
     it('response does not contain chia.services', async function () {
       const response = await supertest(app).get('/diagnostics').expect(200);
       expect(response.body.chia).to.not.have.property('services');
+    });
+
+    it('chia.datalayer exposes ownedStores and expectedOwnedStores fields', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      const datalayer = response.body.chia.datalayer;
+      // ownedStores is either an array (datalayer reachable) or null (RPC
+      // failed); totalOwnedStores must match.
+      expect(datalayer).to.have.property('ownedStores');
+      expect(datalayer).to.have.property('totalOwnedStores');
+      if (datalayer.ownedStores === null) {
+        expect(datalayer.totalOwnedStores).to.equal(null);
+      } else {
+        expect(datalayer.ownedStores).to.be.an('array');
+        expect(datalayer.totalOwnedStores).to.equal(datalayer.ownedStores.length);
+      }
+      expect(datalayer).to.have.property('expectedOwnedStores').that.is.an('array');
+      datalayer.expectedOwnedStores.forEach((entry) => {
+        expect(entry).to.have.property('storeId').that.is.a('string');
+        expect(entry).to.have.property('label').that.is.a('string');
+        expect(entry).to.have.property('owned');
+        expect(entry.owned === true || entry.owned === false || entry.owned === null).to.equal(true);
+      });
+    });
+
+    it('escalateLostOwnedStores (production helper) escalates only on owned=false entries', async function () {
+      // Drives the actual exported production helper -- not a re-implementation --
+      // so this test fails if the escalation logic changes severity, message,
+      // or filter behavior. owned=null (RPC failure) must NOT escalate; the
+      // datalayer-unreachable critical above the helper handles that case.
+      const { StatusAccumulator, escalateLostOwnedStores } = (
+        await import('../../../src/routes/diagnostics.js')
+      ).__test;
+      const compute = (expectedOwnedStores) => {
+        const acc = new StatusAccumulator();
+        escalateLostOwnedStores(acc, expectedOwnedStores);
+        return acc.result();
+      };
+
+      expect(compute([{ storeId: 'a', label: 'v1 home org', owned: true }]).status).to.equal('ok');
+      expect(compute([{ storeId: 'a', label: 'v1 home org', owned: null }]).status).to.equal('ok');
+      expect(compute([]).status).to.equal('ok');
+      expect(compute(undefined).status).to.equal('ok');
+
+      const critical = compute([
+        { storeId: 'a', label: 'v1 home org', owned: true },
+        { storeId: 'b', label: 'v1 registry', owned: false },
+        { storeId: 'c', label: 'v1 file store', owned: null }, // unknown -- ignored
+      ]);
+      expect(critical.status).to.equal('critical');
+      expect(critical.message).to.include('b (v1 registry)');
+      expect(critical.message).to.not.include('a (v1 home org)');
+      expect(critical.message).to.not.include('c (v1 file store)');
+      expect(critical.message).to.include("can't be written to");
+    });
+
+    describe('end-to-end with seeded home org', function () {
+      // The mocha file order puts diagnostics.spec.js early in the v2 run;
+      // leaving a `test-home-org-v2` row behind would risk downstream
+      // tests that probe `is_home: true` finding it. Tear it back down
+      // after each test in this block.
+      afterEach(async function () {
+        const { OrganizationsV2 } = await import('../../../src/models/v2/index.js');
+        await OrganizationsV2.destroy({ where: { org_uid: 'test-home-org-v2' } });
+      });
+
+      it('when home org exists but datalayer owns no stores, status is critical', async function () {
+        // Real end-to-end check of the production wiring: seed a V2 home org
+        // with all four store IDs populated, then hit /diagnostics. The
+        // simulator's get_owned_stores returns an empty list, so the
+        // production escalation path must fire critical with the documented
+        // message -- exercising collectOwnedStoreExpectations, the V2
+        // governance gating, escalateLostOwnedStores, and datalayer status
+        // assembly all on the real code path.
+        await createV2TestHomeOrg();
+        const response = await supertest(app).get('/diagnostics').expect(200);
+        const datalayer = response.body.chia.datalayer;
+        expect(datalayer.ownedStores).to.be.an('array').that.is.empty;
+        expect(datalayer.expectedOwnedStores).to.be.an('array').that.is.not.empty;
+        const lost = datalayer.expectedOwnedStores.filter((e) => e.owned === false);
+        expect(lost.length).to.be.greaterThan(0);
+        const lostLabels = lost.map((e) => e.label);
+        expect(lostLabels).to.include('v2 home org');
+        expect(lostLabels).to.include('v2 registry');
+        expect(lostLabels).to.include('v2 file store');
+        expect(lostLabels).to.include('v2 data model version store');
+        expect(datalayer.status).to.equal('critical');
+        expect(datalayer.message).to.include("expected owned store is not owned by datalayer");
+        lost.forEach((entry) => {
+          expect(datalayer.message).to.include(`${entry.storeId} (${entry.label})`);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds owned-store cross-reference to `chia.datalayer` in `/diagnostics` to detect the *"datalayer or chia wallet forgot about a store CADT owns"* failure mode. When this happens the store is unwritable until the wallet is restored, and operators previously had no signal short of a failing mirror or write.

### New response fields under `chia.datalayer`

```json
{
  "ownedStores": ["abc...", "def..."],
  "totalOwnedStores": 2,
  "expectedOwnedStores": [
    { "storeId": "abc...", "label": "v2 home org", "owned": true },
    { "storeId": "def...", "label": "v2 registry", "owned": true },
    { "storeId": "ghi...", "label": "v2 file store", "owned": false }
  ],
  "status": "critical",
  "message": "expected owned store is not owned by datalayer and can't be written to: ghi... (v2 file store)"
}
```

`ownedStores` is the actual list from the datalayer `get_owned_stores` RPC. `expectedOwnedStores` is sourced from CADT's own database: the V1 + V2 home-org records (`orgUid` / `registryId` / `fileStoreId` / `dataModelVersionStoreId`, and the V2 snake-case equivalents), plus governance-body store IDs from the local Meta tables when this node IS the governance body.

`status` escalates to `critical` only when an entry has `owned === false`. `owned === null` (datalayer RPC failure -> ownership unknown) does **not** escalate -- the existing datalayer-unreachable critical already covers that case.

### Design choices worth calling out

- **V2 governance gating.** `MetaV2.governanceBodyId` is upserted by both the create paths *and* `GovernanceV2.subscribeToGovernanceBody`. Treating it as an owned-store marker on its own would generate a false-positive critical on every V2 participant node. Both V2 governance entries are therefore gated on `MetaV2.mainGoveranceBodyId` being present -- that key is upserted **only** by the V2 create paths, so its presence is the binary "this node IS the V2 governance body" signal. V1 has no subscribe-to-body flow, so both V1 keys pass through ungated.
- **Lazy store skip.** V1 `fileStoreId` / `dataModelVersionStoreId` and V2 `file_store_subscribed` / `data_model_version_store_id` are skipped when null. Datalayer cannot have *forgotten* a store CADT has not asked it to create yet.
- **Corrupted-metadata resilience.** `readHomeOrgRecord` falls back to a direct raw `findOne` if `getHomeOrg` throws (V1's `JSON.parse(metadata)` has no try/catch). Without the fallback, corrupted org metadata would silently drop the entire owned-store cross-reference -- exactly the failure operators are likely hitting `/diagnostics` to debug.
- **READ_ONLY unaffected.** Endpoint already returns 403 on read-only nodes (existing behavior).

### Files

| File | Change |
|---|---|
| `src/routes/diagnostics.js` | + `collectOwnedStoreExpectations` (pure helper), + `escalateLostOwnedStores` (pure helper), + `readMetaValueV1/V2`, refactor `readHomeOrgId` -> `readHomeOrgRecord` with raw-`findOne` fallback, + 4 new parallel settles (`getOwnedStores`, 2x V1 Meta, 2x V2 Meta), merge into `datalayerSection`, status escalation via the new helper |
| `tests/v2/integration/diagnostics-helpers.spec.js` | + 11 pure-function unit tests for `collectOwnedStoreExpectations` covering V1/V2 schemas, null lazy-store skip, governance inclusion when local, V2 subscriber gating, RPC failure -> `owned=null`, falsy storeId skipping |
| `tests/v2/integration/diagnostics.spec.js` | + 1 shape test for the new fields, + 1 test driving the production `escalateLostOwnedStores` helper directly (not a re-implementation), + 1 end-to-end test that seeds a V2 home org via `createV2TestHomeOrg` and asserts `datalayer.status === 'critical'` against the real production wiring (with `afterEach` cleanup to avoid leaving the seeded row for downstream tests) |

### Test plan

- [x] `npm run test:v1` -- 146 passing, 5 pending, 0 failing
- [x] `npm run test:v2` -- 1671 passing, 0 failing (was 1657 baseline; +14 new tests)
- [x] eslint clean on `src/routes/diagnostics.js` (only preexisting `no-restricted-syntax` dynamic-import warnings, identical count vs `origin/v2-rc2`)
- [x] Pre-push adversarial diff review by fresh-context subagent -- 2 critical + 4 warning findings on first pass, all addressed; re-review confirmed all prior findings fixed, 2 newly-noted issues fixed (unnecessary fallback on legit null, test cleanup), 3 newly-noted issues dismissed with reason (preexisting governance upsert-order race out of scope; trivial helper test coverage diminishing returns; informative duplicate-label entry for shared V1/V2 governance body)

### Manual smoke check (suggested for reviewers)

```bash
curl -s -H "x-api-key: \$CADT_API_KEY" http://localhost:31310/diagnostics | jq '.chia.datalayer | {ownedStores, totalOwnedStores, expectedOwnedStores, status, message}'
```

Expected on a healthy install: all `expectedOwnedStores[].owned === true`, `status === "ok"`. If a home-org store is missing from `ownedStores`, the entry's `owned` will be `false` and `status` will be `critical` with the documented message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DataLayer RPC + DB lookups and new critical escalation logic in `/diagnostics`, which could change operational alerting and has some risk of false positives/extra latency if the new probes misbehave.
> 
> **Overview**
> Enhances `/diagnostics` to **cross-check DataLayer-owned store IDs against CADT-expected stores** (home org, registry, lazily-created file/model stores, and governance stores) and exposes this in `chia.datalayer` via new `ownedStores`, `totalOwnedStores`, and `expectedOwnedStores` fields.
> 
> Adds logic to **escalate `chia.datalayer` to `critical`** when CADT expects to own a store but `get_owned_stores` does not list it (while treating RPC failures as `owned: null`), and makes home-org lookup more resilient by falling back to a raw DB query if `getHomeOrg` throws. Includes new integration/unit tests covering the helper logic, response shape, and an end-to-end “lost owned stores” critical scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f65fafeee0b5bba3cb84feacda4e5799d977183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->