### PR TITLE
chore: add min-release-age npm policy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1


### PR DESCRIPTION
## Summary
- Add project `.npmrc` with `min-release-age=1` so npm only resolves package versions published at least one day ago
- Applies to local installs and CI; lockfile-pinned versions in `package-lock.json` are unaffected

## Test plan
- [ ] `npm ci` succeeds on a clean checkout
- [ ] CI install steps pass on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects npm dependency resolution timing but does not change runtime code or lockfile-pinned versions.
> 
> **Overview**
> Adds a project-level `.npmrc` setting `min-release-age=1` so npm only resolves dependency versions published at least one day ago, reducing exposure to newly published releases during local installs and CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28eed0a7f9646c6e751c7771a2e9bee4e87401e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->