### PR TITLE
docs(V2): document referential integrity guards for remaining DELETE endpoints

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -2764,17 +2764,29 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustValidationId`.
 
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `verification` records reference this validation via `cadTrustValidationId`, the request returns `409 Conflict` until those references are removed. References from any synced registry count the same.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/validation/a1b2c3d4-e5f6-7890-abcd-ef1234567890' \
 --header 'Content-Type: application/json'
 ```
 
-Response
+Response (success — no references)
 ```json
 {
-  "message": "Validation deletion staged successfully",
+  "message": "Validation delete staged successfully",
   "success": true
+}
+```
+
+Response (409 — references exist)
+```json
+{
+  "success": false,
+  "message": "Cannot delete validation: it is still referenced by 2 verifications. Remove those references before deleting this validation.",
+  "error": "Referenced records must be removed before deletion",
+  "references": [{ "table": "verification", "count": 2 }]
 }
 ```
 
@@ -2937,6 +2949,8 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustVerificationId`.
 
+**Cascade delete**: Deleting a verification automatically stages DELETE entries for all child issuances and their units. The `stagedChildDeletes` field in the response reports the total number of child rows staged.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/verification/b2c3d4e5-f6a7-8901-bcde-f23456789012' \
@@ -2946,7 +2960,8 @@ curl --location --request DELETE 'localhost:31310/v2/verification/b2c3d4e5-f6a7-
 Response
 ```json
 {
-  "message": "Verification deletion staged successfully",
+  "message": "Verification delete staged successfully",
+  "stagedChildDeletes": 5,
   "success": true
 }
 ```
@@ -3110,17 +3125,29 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustLocationId`.
 
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `issuance` records reference this location via `cadTrustLocationId`, the request returns `409 Conflict` until those references are removed. References from any synced registry count the same.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/location/8182100d-7794-4df7-b3b3-758391d13011' \
 --header 'Content-Type: application/json'
 ```
 
-Response
+Response (success — no references)
 ```json
 {
-  "message": "Location deletion staged successfully",
+  "message": "Location deleted successfully",
   "success": true
+}
+```
+
+Response (409 — references exist)
+```json
+{
+  "success": false,
+  "message": "Cannot delete location: it is still referenced by 3 issuance records. Remove those references before deleting this location.",
+  "error": "Referenced records must be removed before deletion",
+  "references": [{ "table": "issuance", "count": 3 }]
 }
 ```
 
@@ -3276,6 +3303,8 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustIssuanceId`.
 
+**Cascade delete**: Deleting an issuance automatically stages DELETE entries for all child units and their unit labels. The `stagedChildDeletes` field in the response reports the total number of child rows staged.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/issuance/d9f58b08-af25-461c-88eb-403bb02b135e' \
@@ -3285,7 +3314,8 @@ curl --location --request DELETE 'localhost:31310/v2/issuance/d9f58b08-af25-461c
 Response
 ```json
 {
-  "message": "Issuance deletion staged successfully",
+  "message": "Issuance delete staged successfully",
+  "stagedChildDeletes": 3,
   "success": true
 }
 ```
@@ -4503,17 +4533,29 @@ Response
 
 **Note**: The ID in the URL path is the `cadTrustProjectMethodologyId`.
 
+**Referential integrity**: If any committed or staged (`INSERT`/`UPDATE`) `issuance` records reference this project-methodology link via `cadTrustProjectMethodologyId`, the request returns `409 Conflict` until those references are removed. References from any synced registry count the same.
+
 Request
 ```shell
 curl --location --request DELETE 'localhost:31310/v2/project-methodology/a1b2c3d4-e5f6-7890-abcd-ef1234567890' \
 --header 'Content-Type: application/json'
 ```
 
-Response
+Response (success — no references)
 ```json
 {
-  "message": "Project-Methodology relationship deletion staged successfully",
+  "message": "Project-Methodology relationship delete staged successfully",
   "success": true
+}
+```
+
+Response (409 — references exist)
+```json
+{
+  "success": false,
+  "message": "Cannot delete project-methodology relationship: it is still referenced by 2 issuance records. Remove those references before deleting this project-methodology relationship.",
+  "error": "Referenced records must be removed before deletion",
+  "references": [{ "table": "issuance", "count": 2 }]
 }
 ```
 


### PR DESCRIPTION
## Summary

- Add **Referential integrity** notes + 409 response examples to the `validation`, `location`, and `project-methodology` DELETE sections (these three have reference guards that block deletion when downstream records reference them, but were missing from the docs after #1629 landed)
- Add **Cascade delete** notes and `stagedChildDeletes` to the `verification` and `issuance` DELETE sections (these cascade to child records; the success response includes `stagedChildDeletes` but the docs only showed a bare success response)
- Fix stale success message strings: `"deletion staged"` → `"delete staged"` / `"deleted"` to match actual controller responses

## Entities covered

| Entity | Change |
|--------|--------|
| `validation` | Add referential integrity note + 409 example (blocked by `verification`) |
| `verification` | Add cascade delete note + `stagedChildDeletes` in success response |
| `location` | Add referential integrity note + 409 example (blocked by `issuance`) |
| `issuance` | Add cascade delete note + `stagedChildDeletes` in success response |
| `project-methodology` | Add referential integrity note + 409 example (blocked by `issuance`) |

## Test plan

- [ ] Docs-only change; no code modifications

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in cadt_rpc_api_v2.md; no runtime or API code modified.
> 
> **Overview**
> Updates **`docs/cadt_rpc_api_v2.md`** so five V2 DELETE sections match current API behavior (after #1629).
> 
> For **`validation`**, **`location`**, and **`project-methodology`**, the docs now describe **referential integrity** (blocked when committed or staged `INSERT`/`UPDATE` children reference the row, including synced registries) and add **409** examples with `references` counts.
> 
> For **`verification`** and **`issuance`**, the docs add **cascade delete** behavior and show **`stagedChildDeletes`** on successful responses.
> 
> Success **`message`** strings are corrected (e.g. `"deletion staged"` → `"delete staged"`; location uses `"Location deleted successfully"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55189d52bb5cd57ffd15bd7f05e3fadd65c9e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->