### PR TITLE
test: harden v2 empty-check and add mirror gate unit tests

### DIFF
--- a/tests/integration/mirror-sync-gate.spec.js
+++ b/tests/integration/mirror-sync-gate.spec.js
@@ -1,0 +1,196 @@
+import { expect } from 'chai';
+
+import {
+  isMirrorInSync,
+  matchingUpdatedAtAttr,
+  UPDATED_AT_ATTR_CANDIDATES,
+} from '../../src/database/mirror-sync-gate.js';
+
+/**
+ * Direct unit tests for the shared mirror in-sync gate.
+ *
+ * The V1/V2 backfill-dedupe integration specs drive isMirrorInSync through
+ * real Sequelize models, but they cannot reach the "non-zero count with a
+ * null MAX(updatedAt)" defensive branch: every CADT mirror model declares
+ * `timestamps: true`, so SQLite rejects any write that would leave
+ * updated_at null. That branch is therefore exercised here against
+ * lightweight stub models, where we control exactly what count()/max()
+ * return without fighting a NOT NULL constraint.
+ *
+ * Stub model: only count() and max() are used by isMirrorInSync, so a plain
+ * object with those two async methods is a faithful stand-in for a Sequelize
+ * model as far as the gate is concerned.
+ */
+const makeModel = ({ count, max }) => ({
+  count: async () => count,
+  max: async () => max,
+});
+
+// Silent logger - the gate only logs at debug level; we don't assert on it.
+const silentLogger = { debug: () => {} };
+
+describe('Mirror in-sync gate (isMirrorInSync) — unit', function () {
+  const ATTR = 'updatedAt';
+
+  it('skips when both sides are empty (count 0 on both)', async function () {
+    const source = makeModel({ count: 0, max: null });
+    const mirror = makeModel({ count: 0, max: null });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(true);
+  });
+
+  it('falls through when counts mismatch', async function () {
+    const source = makeModel({ count: 5, max: '2026-01-01 00:00:00' });
+    const mirror = makeModel({ count: 4, max: '2026-01-01 00:00:00' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  it('skips when counts match and mirror max(updatedAt) >= source', async function () {
+    const source = makeModel({ count: 3, max: '2026-01-01 00:00:00' });
+    const mirror = makeModel({ count: 3, max: '2026-01-02 00:00:00' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(true);
+  });
+
+  it('falls through when mirror max(updatedAt) is older than source', async function () {
+    const source = makeModel({ count: 3, max: '2026-02-01 00:00:00' });
+    const mirror = makeModel({ count: 3, max: '2026-01-01 00:00:00' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  // The documented gap: non-zero count but a null MAX(updatedAt). The gate
+  // must NOT misclassify this as "empty / in sync" - it can't compare
+  // freshness, so it must fall through to the full sync.
+  it('falls through when source max(updatedAt) is null with rows present', async function () {
+    const source = makeModel({ count: 2, max: null });
+    const mirror = makeModel({ count: 2, max: '2026-01-01 00:00:00' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  it('falls through when mirror max(updatedAt) is null with rows present', async function () {
+    const source = makeModel({ count: 2, max: '2026-01-01 00:00:00' });
+    const mirror = makeModel({ count: 2, max: null });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  it('falls through when max(updatedAt) is non-parseable with rows present', async function () {
+    const source = makeModel({ count: 1, max: 'not-a-date' });
+    const mirror = makeModel({ count: 1, max: 'not-a-date' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  it('falls through (does not throw) when a probe query errors', async function () {
+    const source = {
+      count: async () => {
+        throw new Error('boom');
+      },
+      max: async () => null,
+    };
+    const mirror = makeModel({ count: 0, max: null });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+});
+
+describe('matchingUpdatedAtAttr — unit', function () {
+  const withAttrs = (...names) => ({
+    rawAttributes: Object.fromEntries(names.map((n) => [n, {}])),
+  });
+
+  it('returns the shared camelCase attribute (V1 convention)', function () {
+    const attr = matchingUpdatedAtAttr(
+      withAttrs('updatedAt'),
+      withAttrs('updatedAt'),
+    );
+    expect(attr).to.equal('updatedAt');
+  });
+
+  it('returns the shared snake_case attribute (V2 convention)', function () {
+    const attr = matchingUpdatedAtAttr(
+      withAttrs('updated_at'),
+      withAttrs('updated_at'),
+    );
+    expect(attr).to.equal('updated_at');
+  });
+
+  it('returns null when source and mirror disagree on the attribute name', function () {
+    const attr = matchingUpdatedAtAttr(
+      withAttrs('updatedAt'),
+      withAttrs('updated_at'),
+    );
+    expect(attr).to.equal(null);
+  });
+
+  it('only considers the known candidate attribute names', function () {
+    expect(UPDATED_AT_ATTR_CANDIDATES).to.deep.equal(['updatedAt', 'updated_at']);
+  });
+});

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -498,26 +498,84 @@ export const checkDatabaseEmpty = async (request) => {
   ];
 
   const nonEmptyTables = [];
+  const syncedNonHomeTables = [];
+  const probeFailures = [];
 
   for (const table of dataTables) {
+    // Home-scoped probe: this is the actual cleanliness gate. Scope to
+    // home-org-owned records only because, with governance sync enabled, the
+    // node legitimately syncs in data owned by other organizations; that data
+    // is not leftover test state and must not fail the empty check.
+    let homeResponse;
     try {
-      // Scope to home-org-owned records only. When governance sync is enabled,
-      // the node legitimately syncs in data owned by other organizations; that
-      // data is not leftover test state and must not fail the empty check.
-      const response = await request.get(`/v2/${table}`).query({ page: 1, limit: 1000, orgUid: 'me' });
-      const data = response.body?.data || [];
-
-      if (response.status === 200 && Array.isArray(data) && data.length > 0) {
-        nonEmptyTables.push({ table, count: data.length });
-      }
+      homeResponse = await request
+        .get(`/v2/${table}`)
+        .query({ page: 1, limit: 1000, orgUid: 'me' });
     } catch (error) {
-      // Table might not exist or endpoint might not be available, skip
+      probeFailures.push({ table, reason: error.message });
+      continue;
     }
+
+    // A non-200 means the gate could not actually inspect this table - e.g.
+    // 'me' failed to resolve because no home organization is configured. Treat
+    // that as a hard failure rather than silently assuming the table is empty:
+    // a silently-skipped table would let leftover state slip past the guard.
+    if (homeResponse.status !== 200) {
+      probeFailures.push({
+        table,
+        reason: `home-scoped GET returned status ${homeResponse.status}`,
+      });
+      continue;
+    }
+
+    const homeData = Array.isArray(homeResponse.body?.data)
+      ? homeResponse.body.data
+      : [];
+    if (homeData.length > 0) {
+      nonEmptyTables.push({ table, count: homeData.length });
+    }
+
+    // Unfiltered probe: advisory only. Surfaces synced non-home data so a
+    // genuine leak of foreign rows is at least visible in the logs, without
+    // failing the run when governance sync legitimately populated it.
+    try {
+      const allResponse = await request
+        .get(`/v2/${table}`)
+        .query({ page: 1, limit: 1000 });
+      if (allResponse.status === 200) {
+        const allData = Array.isArray(allResponse.body?.data)
+          ? allResponse.body.data
+          : [];
+        const nonHomeCount = allData.length - homeData.length;
+        if (nonHomeCount > 0) {
+          syncedNonHomeTables.push({ table, count: nonHomeCount });
+        }
+      }
+    } catch {
+      // Advisory probe only - never fail the run on it.
+    }
+  }
+
+  if (probeFailures.length > 0) {
+    const detail = probeFailures
+      .map(({ table, reason }) => `   - ${table}: ${reason}`)
+      .join('\n');
+    throw new Error(
+      `Database empty-check could not inspect every table (is a home organization configured?):\n${detail}`,
+    );
   }
 
   if (nonEmptyTables.length > 0) {
     const errorMsg = `Database is not empty. Found home-org data in:\n${nonEmptyTables.map(({ table, count }) => `   - ${table}: ${count} record(s)`).join('\n')}\nPlease clear the database before running tests.`;
     throw new Error(errorMsg);
+  }
+
+  if (syncedNonHomeTables.length > 0) {
+    console.log(
+      `⚠ Ignoring synced non-home data (not leftover test state):\n${syncedNonHomeTables
+        .map(({ table, count }) => `   - ${table}: ${count} record(s)`)
+        .join('\n')}`,
+    );
   }
 
   console.log('✓ Database is empty of home-org data (synced non-home data ignored)');


### PR DESCRIPTION
## Summary

Two test-effectiveness follow-ups from the review of #1643 (v2-rc2). Both are test-only; no product code changes.

- **Harden `checkDatabaseEmpty` (v2 live-api helper).** The empty-check probe scopes to `orgUid=me` (correct — governance sync legitimately brings in foreign-org data). But it also silently swallowed any non-200 response or thrown error, so a table it *couldn't actually inspect* — e.g. when no home org is configured and `'me'` fails to resolve — was treated as empty and slipped past the guard. It now:
  - fails loudly listing every un-inspectable table (with the reason), and
  - runs an advisory unfiltered probe that surfaces synced non-home rows in the logs (`⚠ Ignoring synced non-home data …`) instead of ignoring them outright, so a genuine foreign-row leak is at least visible.
- **Add direct unit coverage for the shared mirror in-sync gate** (`isMirrorInSync` / `matchingUpdatedAtAttr` in `src/database/mirror-sync-gate.js`). The V1/V2 backfill-dedupe specs can't reach the "non-zero count with null `MAX(updatedAt)`" defensive branch because every mirror model declares `timestamps: true` (NOT NULL `updated_at`), so SQLite rejects the write needed to set it up. The new `tests/integration/mirror-sync-gate.spec.js` exercises that branch (plus count-mismatch, stale-max, non-parseable-max, error fall-through, and attr-name matching) against lightweight stub models.

## Test plan

- [x] `mocha tests/integration/mirror-sync-gate.spec.js` — 12 passing
- [x] `eslint` clean on both touched files (pre-existing unused-`error` at line 238 of `live-api-helpers.js` is unrelated and present on `v2-rc2`)
- [ ] CI green
- [ ] live-api suite still gates correctly against a node with governance-synced foreign data (manual, on a real node)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test helpers and new unit/integration specs; no production runtime behavior is modified.
> 
> **Overview**
> Test-only follow-up: strengthens how v2 live-api suites verify a clean DB and adds focused unit tests for the mirror in-sync gate.
> 
> **`checkDatabaseEmpty`** (v2 live-api helper) still treats only `orgUid=me` rows as blocking leftover state, but no longer treats failed or non-200 home-scoped probes as “empty.” Those cases now abort with a per-table reason (e.g. missing home org / unresolved `me`). An extra unfiltered GET logs synced non-home row counts as a warning without failing the run.
> 
> **`tests/integration/mirror-sync-gate.spec.js`** exercises `isMirrorInSync` and `matchingUpdatedAtAttr` via stub models so branches integration tests cannot hit—especially non-zero row counts with null or bad `MAX(updatedAt)`, plus count mismatch, stale max, and probe errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892dd9b4c8ee31d75dcab1e9ad6fab80fa9dd456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->