### PR TITLE
docs(API): document /diagnostics system endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,20 @@ This script does the following:
 
 A development environment for CADT assumes a synced Chia wallet running locally. [Node version manager (nvm)](https://github.com/nvm-sh/nvm) is used to switch node environments quickly. The repo contains a `.nvmrc` file that specifies the node version the CADT is expected to use and developers can do `nvm use` to switch to the version in the `.nvmrc`.
 
+### Diagnostics
+
+When debugging a local CADT install (wallet not reachable, DataLayer not syncing, network mismatch, low disk space), use the system-wide diagnostics endpoint. It is mounted at the server root, not under `/v1` or `/v2`:
+
+```bash
+curl -s -H 'x-api-key: YOUR_CADT_API_KEY' http://localhost:31310/diagnostics | jq .
+```
+
+Omit the `x-api-key` header only when `CADT_API_KEY` is not configured. The endpoint returns **403** on read-only observer nodes (`READ_ONLY=true`). It is designed to stay usable while other API routes are blocked by sync checks.
+
+Lighter-weight health checks are also available: `GET /health`, `GET /v1/health`, `GET /v2/health`, and `GET /v1/health/wallet` or `GET /v2/health/wallet` for wallet-specific status.
+
+See [System endpoints in the V1 RPC guide](docs/cadt_rpc_api.md#system-endpoints) and [System endpoints in the V2 RPC guide](docs/cadt_rpc_api_v2.md#system-endpoints) for request examples and response fields.
+
 ### Contributing
 
 All branches should be created from the `develop` branch and not from `main`. All pull requests should be made against the `develop` branch unless it is a new release. The `develop` branch will be merged into the `main` branch to create a release. Automation in the CI will create the [release](https://github.com/Chia-Network/cadt/releases) and attach the installation files to it automatically whenever code is merged to `main`. Additionally, the changelog will automatically be updated in the `main` branch. Therefore, the `main` branch should always be a representation of the latest released code.

--- a/docs/cadt_rpc_api.md
+++ b/docs/cadt_rpc_api.md
@@ -31,8 +31,83 @@ If using a `CADT_API_KEY` append `--header 'x-api-key: <your-api-key-here>'` to 
 
 For the V2 API, update and delete requests can only stage mutations for records owned by the home organization. See the V2 API guide for details on `orgUid` ownership and child-record ownership resolution.
 
+## System endpoints
+
+Several routes are mounted on the server root (not under `/v1` or `/v2`). They are for monitoring and troubleshooting. Unlike most API routes, they are not blocked when the wallet or DataLayer is still syncing or migrations are in progress.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /health` | CADT process liveness; includes disk-space summary for the Chia root partition |
+| `GET /v1/health` | V1 API liveness (same disk-space fields as `/health`) |
+| `GET /v2/health` | V2 API liveness (documented in the [V2 RPC guide](/docs/cadt_rpc_api_v2.md#system-endpoints)) |
+| `GET /v1/health/wallet` | V1 wallet sync and pending-transaction summary |
+| `GET /v2/health/wallet` | V2 wallet sync and pending-transaction summary (see V2 guide) |
+| `GET /diagnostics` | System-wide debug snapshot (CADT, Chia, DataLayer, host) |
+
+If `CADT_API_KEY` is set, these endpoints use the same global `x-api-key` check as the rest of the API.
+
+<a id="diagnostics"></a>
+### Diagnostics snapshot (`GET /diagnostics`)
+
+Returns one JSON object summarizing CADT configuration, Chia wallet/full-node/DataLayer status, DataLayer subscriptions, local Chia processes, and host CPU/memory/disk. Each major subsection may include a `status` of `ok`, `warning`, or `critical`, plus an optional `message` when attention is needed. External calls use per-section timeouts and degrade gracefully when a subsystem is down.
+
+- **Not available on read-only nodes:** returns **403** when `READ_ONLY` is `true` for V1 or V2.
+- **Response time:** usually well under a second on a healthy install; individual probes can take up to about 10 seconds each, with a worst-case total near 30 seconds when something is wedged.
+
+Request (include the header when an API key is configured):
+
+```shell
+curl -s -H 'x-api-key: <your-api-key-here>' http://localhost:31310/diagnostics
+```
+
+Response (top-level shape; nested fields vary with the environment):
+
+```json
+{
+  "timestamp": "2024-01-15T12:00:00.000Z",
+  "cadt": {
+    "version": "1.0.0",
+    "configDir": "/home/user/.chia/mainnet/cadt",
+    "v1": { "enabled": true, "readOnly": false },
+    "v2": { "enabled": true, "readOnly": false }
+  },
+  "network": { "cadt": "mainnet", "chia": "mainnet", "matches": true, "status": "ok" },
+  "chia": {
+    "version": "2.4.0",
+    "wallet": { "reachable": true, "synced": true },
+    "fullNode": { "reachable": false },
+    "datalayer": { "reachable": true, "subscriptions": [] },
+    "runningProcesses": { "matches": [] }
+  },
+  "system": {
+    "platform": "linux",
+    "cpu": { "cores": 8 },
+    "memory": { "percentUsed": 42 },
+    "disk": { "percentUsed": 55 }
+  }
+}
+```
+
+<a id="v1-health-check"></a>
+### V1 health check (`GET /v1/health`)
+
+```shell
+curl --location --request GET 'http://localhost:31310/v1/health' --header 'Content-Type: application/json'
+```
+
+```json
+{
+  "message": "V1 API is running",
+  "timestamp": "2024-01-15T12:00:00.000Z",
+  "diskSpace": {}
+}
+```
+
 ## Commands
 
+- [System endpoints](#system-endpoints)
+  - [Diagnostics snapshot](#diagnostics)
+  - [V1 health check](#v1-health-check)
 - [`organizations`](#organizations)
   - [GET Examples](#get-examples)
     - [List all subscribed organizations](#list-all-subscribed-organizations)

--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -35,6 +35,78 @@ The CADT RPC API V2 is exposed by default on port 31310. This document will give
 
 If using a `CADT_API_KEY` append `--header 'x-api-key: <your-api-key-here>'` to your `curl` request.
 
+## System endpoints
+
+Several routes are mounted on the server root (not under `/v1` or `/v2`). They are for monitoring and troubleshooting. Unlike most API routes, they are not blocked when the wallet or DataLayer is still syncing or migrations are in progress.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /health` | CADT process liveness; includes disk-space summary for the Chia root partition |
+| `GET /v1/health` | V1 API liveness (same disk-space fields as `/health`) |
+| `GET /v2/health` | V2 API liveness (same disk-space fields as `/health`) |
+| `GET /v1/health/wallet` | V1 wallet sync and pending-transaction summary |
+| `GET /v2/health/wallet` | V2 wallet sync and pending-transaction summary |
+| `GET /diagnostics` | System-wide debug snapshot (CADT, Chia, DataLayer, host) |
+
+If `CADT_API_KEY` is set, these endpoints use the same global `x-api-key` check as the rest of the API.
+
+<a id="diagnostics"></a>
+### Diagnostics snapshot (`GET /diagnostics`)
+
+Returns one JSON object summarizing CADT configuration, Chia wallet/full-node/DataLayer status, DataLayer subscriptions, local Chia processes, and host CPU/memory/disk. Each major subsection may include a `status` of `ok`, `warning`, or `critical`, plus an optional `message` when attention is needed. External calls use per-section timeouts and degrade gracefully when a subsystem is down.
+
+- **Not available on read-only nodes:** returns **403** when `READ_ONLY` is `true` for V1 or V2.
+- **Response time:** usually well under a second on a healthy install; individual probes can take up to about 10 seconds each, with a worst-case total near 30 seconds when something is wedged.
+
+Request (include the header when an API key is configured):
+
+```shell
+curl -s -H 'x-api-key: <your-api-key-here>' http://localhost:31310/diagnostics
+```
+
+Response (top-level shape; nested fields vary with the environment):
+
+```json
+{
+  "timestamp": "2024-01-15T12:00:00.000Z",
+  "cadt": {
+    "version": "1.0.0",
+    "configDir": "/home/user/.chia/mainnet/cadt",
+    "v1": { "enabled": true, "readOnly": false },
+    "v2": { "enabled": true, "readOnly": false }
+  },
+  "network": { "cadt": "mainnet", "chia": "mainnet", "matches": true, "status": "ok" },
+  "chia": {
+    "version": "2.4.0",
+    "wallet": { "reachable": true, "synced": true },
+    "fullNode": { "reachable": false },
+    "datalayer": { "reachable": true, "subscriptions": [] },
+    "runningProcesses": { "matches": [] }
+  },
+  "system": {
+    "platform": "linux",
+    "cpu": { "cores": 8 },
+    "memory": { "percentUsed": 42 },
+    "disk": { "percentUsed": 55 }
+  }
+}
+```
+
+<a id="health-check"></a>
+### V2 health check (`GET /v2/health`)
+
+```shell
+curl --location --request GET 'http://localhost:31310/v2/health' --header 'Content-Type: application/json'
+```
+
+```json
+{
+  "message": "V2 API is running",
+  "timestamp": "2024-01-15T12:00:00.000Z",
+  "diskSpace": {}
+}
+```
+
 ### Organization Filtering
 
 All GET list endpoints support the `?orgUid=` query parameter to filter records by organization:
@@ -171,6 +243,9 @@ These files use `NEW-<n>` placeholder IDs and demonstrate the expected column na
 
 ## Commands
 
+- [System endpoints](#system-endpoints)
+  - [Diagnostics snapshot](#diagnostics)
+  - [V2 health check](#health-check)
 - [`organizations`](#organizations)
   - [GET Examples](#organizations-get-examples)
     - [List all organizations](#list-all-organizations)
@@ -481,9 +556,7 @@ These files use `NEW-<n>` placeholder IDs and demonstrate the expected column na
     - [Unsubscribe from filestore](#unsubscribe-from-filestore)
   - [DELETE Examples](#filestore-delete-examples)
     - [Delete file from filestore](#delete-file-from-filestore)
-- [`health`](#health)
-  - [GET Examples](#health-get-examples)
-    - [Health check](#health-check)
+
 ---
 
 ## Reference
@@ -6625,28 +6698,5 @@ Response
 }
 ```
 
----
-
-## `health`
-
-Functionality: Health check endpoint for V2 API
-
-<a id="health-get-examples"></a>
-### GET Examples
-
-#### Health check
-
-Request
-```shell
-curl --location --request GET 'localhost:31310/v2/health' --header 'Content-Type: application/json'
-```
-
-Response
-```json
-{
-  "message": "V2 API is running",
-  "timestamp": "2022-03-11T05:17:55.427Z"
-}
-```
 
 ---


### PR DESCRIPTION
## Summary

- Add a **System endpoints** section to the V1 and V2 RPC guides covering `/health`, version health routes, wallet health, and `GET /diagnostics`
- Add a **Diagnostics** subsection under the README Developer Guide with a quick `curl` example and links to the RPC docs
- Consolidate the V2 guide's standalone `health` section into System endpoints to avoid duplication

## Test plan

- [x] Documentation-only change; no code or tests modified
- [ ] Review markdown links and anchors render correctly on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes; no runtime or API behavior is modified.
> 
> **Overview**
> This PR documents **root-level monitoring routes** (`/health`, versioned health and wallet health, and **`GET /diagnostics`**) that are not under `/v1` or `/v2`, including that they stay available during sync/migration blocks and share **`x-api-key`** behavior when configured.
> 
> The **README Developer Guide** gains a **Diagnostics** subsection with a sample `curl` to `/diagnostics`, notes on **403** for read-only observers, and pointers to the RPC guides. The **V1 and V2 RPC guides** each add a **System endpoints** section (endpoint table, diagnostics request/response shape, timeouts, and a version-specific health example) and refresh the **Commands** TOC; the V2 guide **removes** the old standalone **`health`** section so health is documented once under System endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a80062d5fdda7e006fe4b46b9202c659d48ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->