### PR TITLE
fix(API): mirror chia is_trusted_peer in /diagnostics trusted peers

### DIFF
--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -362,12 +362,29 @@ const isTrustedCidr = (peerHost, trustedCidrs) => {
   const hostFamily = hostType === 6 ? 'ipv6' : 'ipv4';
 
   for (const cidr of trustedCidrs) {
-    const slash = String(cidr).lastIndexOf('/');
-    if (slash === -1) continue;
-    const network = String(cidr).slice(0, slash);
-    const prefix = Number(String(cidr).slice(slash + 1));
+    const cidrStr = String(cidr);
+    const slash = cidrStr.lastIndexOf('/');
+    let network;
+    let prefix;
+    if (slash === -1) {
+      // Bare IP, no prefix. chia's ip_network() treats this as a host route
+      // (/32 for IPv4, /128 for IPv6), so trust an exact-match peer.
+      network = cidrStr;
+      const bareType = net.isIP(network);
+      if (bareType === 0) continue;
+      prefix = bareType === 6 ? 128 : 32;
+    } else {
+      network = cidrStr.slice(0, slash);
+      const prefixStr = cidrStr.slice(slash + 1);
+      // Require an explicit decimal prefix. Number('') and Number(' ') both
+      // coerce to 0, which would silently widen a typo'd CIDR like "10.0.0.0/"
+      // into /0 and trust every peer; hex/float forms ("/0x10", "/1.5") would
+      // also be misread. chia's ipaddress parser rejects all of these.
+      if (!/^\d+$/.test(prefixStr)) continue;
+      prefix = Number(prefixStr);
+    }
     const netType = net.isIP(network);
-    if (netType === 0 || !Number.isInteger(prefix)) continue;
+    if (netType === 0) continue;
     try {
       const blockList = new net.BlockList();
       blockList.addSubnet(network, prefix, netType === 6 ? 'ipv6' : 'ipv4');
@@ -386,15 +403,23 @@ const isTrustedCidr = (peerHost, trustedCidrs) => {
  *
  *   trusted = is_localhost(host) OR node_id in trusted_peers OR is_trusted_cidr
  *
- * Returns the matched reason so the diagnostics output explains *why* a peer
- * is trusted (e.g. a localhost full node is trusted even when trusted_peers
- * still holds the default placeholder node id).
+ * Returns `{ trusted, reason }` where `trusted` is true / false / 'unknown'.
+ * Localhost is detectable from the peer host alone, so it is evaluated even
+ * without the chia config. The trusted_peers / trusted_cidrs rules require
+ * the config, so when it is unavailable (`configReadable === false`) a
+ * non-localhost peer is 'unknown' rather than false -- CADT and chia can run
+ * in separate containers where CADT has no access to the chia config.yaml,
+ * and reporting 'untrusted' there would be wrong (the peer may well be
+ * trusted via trusted_cidrs we simply can't see).
  */
-const classifyTrust = (peerHost, nodeId, normalizedTrustedSet, trustedCidrs) => {
-  if (isLocalhost(peerHost)) return 'localhost';
-  if (normalizedTrustedSet && normalizedTrustedSet.has(normalizeNodeId(nodeId))) return 'configured';
-  if (isTrustedCidr(peerHost, trustedCidrs)) return 'cidr';
-  return null;
+const classifyTrust = (peerHost, nodeId, normalizedTrustedSet, trustedCidrs, configReadable) => {
+  if (isLocalhost(peerHost)) return { trusted: true, reason: 'localhost' };
+  if (!configReadable) return { trusted: 'unknown', reason: 'chia-config-unavailable' };
+  if (normalizedTrustedSet && normalizedTrustedSet.has(normalizeNodeId(nodeId))) {
+    return { trusted: true, reason: 'configured' };
+  }
+  if (isTrustedCidr(peerHost, trustedCidrs)) return { trusted: true, reason: 'cidr' };
+  return { trusted: false, reason: null };
 };
 
 /**
@@ -409,11 +434,17 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
     configuredTrustedCidrs: [],
     connected: [],
     hasTrustedConnection: false,
+    // True when trust could not be determined -- either the chia config was
+    // unavailable (so trusted_peers/trusted_cidrs can't be checked) or the
+    // wallet connections couldn't be enumerated at all. Distinguishes "known
+    // untrusted" from "can't tell" so callers don't raise a false alarm.
+    trustUnknown: false,
   };
 
+  const configReadable = chiaConfigResult?.ok === true;
   let normalizedTrustedSet = null;
   let trustedCidrs = [];
-  if (chiaConfigResult?.ok) {
+  if (configReadable) {
     const trustedPeerMap = _.get(chiaConfigResult.value, 'wallet.trusted_peers', null);
     if (trustedPeerMap && typeof trustedPeerMap === 'object') {
       // trusted_peers is `{ <peer_node_id>: <cert_path or 'Does_not_matter'> }`
@@ -435,18 +466,41 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
   if (connectionsResult?.ok && connectionsResult.value?.success !== false) {
     const connections = connectionsResult.value?.connections || [];
     view.connected = connections.map((c) => {
-      const trustedReason = classifyTrust(c.peerHost, c.nodeId, normalizedTrustedSet, trustedCidrs);
-      const trusted = trustedReason !== null;
-      if (trusted) view.hasTrustedConnection = true;
-      return { peerHost: c.peerHost, peerPort: c.peerPort, type: c.type, trusted, trustedReason };
+      const { trusted, reason } = classifyTrust(
+        c.peerHost,
+        c.nodeId,
+        normalizedTrustedSet,
+        trustedCidrs,
+        configReadable,
+      );
+      if (trusted === true) view.hasTrustedConnection = true;
+      if (trusted === 'unknown') view.trustUnknown = true;
+      return { peerHost: c.peerHost, peerPort: c.peerPort, type: c.type, trusted, trustedReason: reason };
     });
   } else if (connectionsResult) {
     view.connectionsError = connectionsResult.ok
       ? connectionsResult.value?.error || 'wallet connections unavailable'
       : connectionsResult.error;
+    // Connections couldn't be enumerated -- we can't tell whether a trusted
+    // peer exists, so treat it as unknown rather than "definitively untrusted".
+    view.trustUnknown = true;
   }
 
   return view;
+};
+
+/**
+ * Whether to warn that the wallet is not connected to a trusted full-node
+ * peer. Only warn when we can *definitively* say there is no trusted peer:
+ * the wallet is reachable, nothing is trusted, and no peer's trust is
+ * unknown. When trust is unknown (chia config unreadable, e.g. split
+ * CADT/chia containers) we stay silent rather than raise a false warning.
+ */
+const shouldWarnNoTrustedPeer = (walletReachable, trustedFullNodePeers) => {
+  if (!walletReachable || !trustedFullNodePeers) return false;
+  if (trustedFullNodePeers.hasTrustedConnection) return false;
+  if (trustedFullNodePeers.trustUnknown) return false;
+  return true;
 };
 
 /**
@@ -899,7 +953,7 @@ export const getDiagnosticsResponse = async () => {
       }
     }
 
-    if (walletReachable && walletSection.trustedFullNodePeers?.hasTrustedConnection === false) {
+    if (shouldWarnNoTrustedPeer(walletReachable, walletSection.trustedFullNodePeers)) {
       walletStatus.escalate(
         'warning',
         'Performance is severely degraded when the Chia wallet is not connected to a trusted full node peer',
@@ -946,6 +1000,7 @@ export const __test = {
   isLocalhost,
   isTrustedCidr,
   classifyTrust,
+  shouldWarnNoTrustedPeer,
   collectOwnedStoreExpectations,
   escalateLostOwnedStores,
   StatusAccumulator,

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -11,6 +11,8 @@
  * middleware returning 403), so there is no reduced-information path.
  */
 
+import net from 'net';
+
 import _ from 'lodash';
 
 import { getConfig, getConfigV2 } from '../utils/config-loader.js';
@@ -340,20 +342,77 @@ const normalizeNodeId = (id) => {
   return s.startsWith('0x') ? s.slice(2) : s;
 };
 
+// Mirrors chia's chia.util.network.is_localhost. The wallet trusts any
+// localhost peer unconditionally, so a connection to 127.0.0.1 is trusted
+// even when wallet.trusted_peers is left at its default placeholder.
+const LOCALHOST_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '0:0:0:0:0:0:0:1']);
+const stripBrackets = (host) => String(host ?? '').replace(/^\[/, '').replace(/\]$/, '');
+const isLocalhost = (peerHost) => LOCALHOST_HOSTS.has(stripBrackets(peerHost));
+
 /**
- * Cross-reference connected wallet peers against the trusted_peers map in
- * the chia config.yaml. Returns a small object suitable for embedding in
- * the diagnostics response, including whether at least one connection is
- * trusted.
+ * Mirror chia's chia.util.network.is_trusted_cidr: true when peerHost parses
+ * to an IP that falls inside any configured CIDR. Never throws -- a malformed
+ * CIDR entry is skipped rather than failing the whole diagnostics response.
+ */
+const isTrustedCidr = (peerHost, trustedCidrs) => {
+  if (!Array.isArray(trustedCidrs) || trustedCidrs.length === 0) return false;
+  const host = stripBrackets(peerHost);
+  const hostType = net.isIP(host);
+  if (hostType === 0) return false;
+  const hostFamily = hostType === 6 ? 'ipv6' : 'ipv4';
+
+  for (const cidr of trustedCidrs) {
+    const slash = String(cidr).lastIndexOf('/');
+    if (slash === -1) continue;
+    const network = String(cidr).slice(0, slash);
+    const prefix = Number(String(cidr).slice(slash + 1));
+    const netType = net.isIP(network);
+    if (netType === 0 || !Number.isInteger(prefix)) continue;
+    try {
+      const blockList = new net.BlockList();
+      blockList.addSubnet(network, prefix, netType === 6 ? 'ipv6' : 'ipv4');
+      if (blockList.check(host, hostFamily)) return true;
+    } catch {
+      // Malformed CIDR (e.g. prefix out of range) -- skip it.
+    }
+  }
+  return false;
+};
+
+/**
+ * Decide whether a single connection is trusted, mirroring chia's
+ * chia.util.network.is_trusted_peer (and the `chia peer`/`chia wallet show`
+ * CLI, which computes trust client-side -- the RPC does not return it):
+ *
+ *   trusted = is_localhost(host) OR node_id in trusted_peers OR is_trusted_cidr
+ *
+ * Returns the matched reason so the diagnostics output explains *why* a peer
+ * is trusted (e.g. a localhost full node is trusted even when trusted_peers
+ * still holds the default placeholder node id).
+ */
+const classifyTrust = (peerHost, nodeId, normalizedTrustedSet, trustedCidrs) => {
+  if (isLocalhost(peerHost)) return 'localhost';
+  if (normalizedTrustedSet && normalizedTrustedSet.has(normalizeNodeId(nodeId))) return 'configured';
+  if (isTrustedCidr(peerHost, trustedCidrs)) return 'cidr';
+  return null;
+};
+
+/**
+ * Cross-reference connected wallet peers against the chia config.yaml trust
+ * settings (wallet.trusted_peers + wallet.trusted_cidrs) plus chia's implicit
+ * localhost rule. Returns a small object suitable for embedding in the
+ * diagnostics response, including whether at least one connection is trusted.
  */
 const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
   const view = {
     configuredTrustedNodeIds: [],
+    configuredTrustedCidrs: [],
     connected: [],
     hasTrustedConnection: false,
   };
 
   let normalizedTrustedSet = null;
+  let trustedCidrs = [];
   if (chiaConfigResult?.ok) {
     const trustedPeerMap = _.get(chiaConfigResult.value, 'wallet.trusted_peers', null);
     if (trustedPeerMap && typeof trustedPeerMap === 'object') {
@@ -364,6 +423,11 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
       view.configuredTrustedNodeIds = keys;
       normalizedTrustedSet = new Set(keys.map(normalizeNodeId));
     }
+    const configuredCidrs = _.get(chiaConfigResult.value, 'wallet.trusted_cidrs', null);
+    if (Array.isArray(configuredCidrs)) {
+      trustedCidrs = configuredCidrs;
+      view.configuredTrustedCidrs = configuredCidrs;
+    }
   } else if (chiaConfigResult) {
     view.chiaConfigError = chiaConfigResult.error;
   }
@@ -371,11 +435,10 @@ const buildTrustedPeerView = (connectionsResult, chiaConfigResult) => {
   if (connectionsResult?.ok && connectionsResult.value?.success !== false) {
     const connections = connectionsResult.value?.connections || [];
     view.connected = connections.map((c) => {
-      const trusted = !!(
-        normalizedTrustedSet && normalizedTrustedSet.has(normalizeNodeId(c.nodeId))
-      );
+      const trustedReason = classifyTrust(c.peerHost, c.nodeId, normalizedTrustedSet, trustedCidrs);
+      const trusted = trustedReason !== null;
       if (trusted) view.hasTrustedConnection = true;
-      return { peerHost: c.peerHost, peerPort: c.peerPort, type: c.type, trusted };
+      return { peerHost: c.peerHost, peerPort: c.peerPort, type: c.type, trusted, trustedReason };
     });
   } else if (connectionsResult) {
     view.connectionsError = connectionsResult.ok
@@ -880,6 +943,9 @@ export const __test = {
   collectSubscriptions,
   buildTrustedPeerView,
   normalizeNodeId,
+  isLocalhost,
+  isTrustedCidr,
+  classifyTrust,
   collectOwnedStoreExpectations,
   escalateLostOwnedStores,
   StatusAccumulator,

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -298,7 +298,112 @@ describe('/diagnostics endpoint', function () {
         expect(view.connected[0].trusted).to.equal(true);
         expect(view.connected[0].trustedReason).to.equal('cidr');
         expect(view.connected[1].trusted).to.equal(false);
+        expect(view.connected[1].trustedReason).to.equal(null);
         expect(view.configuredTrustedCidrs).to.deep.equal(['10.0.0.0/24']);
+      });
+
+      it('marks trust unknown when wallet connections cannot be enumerated', function () {
+        // Wallet reachable but get_connections failed: we can't tell whether a
+        // trusted peer exists, so trust is unknown rather than untrusted.
+        const view = diagnostics.__test.buildTrustedPeerView(
+          { ok: false, error: 'wallet RPC refused connection' },
+          { ok: true, value: { wallet: { trusted_cidrs: ['10.0.0.0/8'] } } },
+        );
+        expect(view.connected).to.deep.equal([]);
+        expect(view.hasTrustedConnection).to.equal(false);
+        expect(view.trustUnknown).to.equal(true);
+        expect(view.connectionsError).to.be.a('string').and.not.empty;
+      });
+
+      it('reports unknown (not untrusted) for non-localhost peers when chia config is unreadable', function () {
+        // Split-deployment case: CADT and chia run in separate containers and
+        // CADT cannot read the chia config.yaml, so trusted_peers/trusted_cidrs
+        // are unavailable. A non-localhost peer's trust is unknown, not false.
+        const view = diagnostics.__test.buildTrustedPeerView(
+          {
+            ok: true,
+            value: {
+              connections: [
+                { peerHost: '10.48.83.174', peerPort: 58444, type: 1, nodeId: 'a676d602' },
+              ],
+            },
+          },
+          { ok: false, error: "ENOENT: no such file or directory, open '/root/.chia/mainnet/config/config.yaml'" },
+        );
+        expect(view.connected[0].trusted).to.equal('unknown');
+        expect(view.connected[0].trustedReason).to.equal('chia-config-unavailable');
+        expect(view.hasTrustedConnection).to.equal(false);
+        expect(view.trustUnknown).to.equal(true);
+        expect(view.chiaConfigError).to.be.a('string').and.not.empty;
+      });
+
+      it('still trusts a localhost peer when chia config is unreadable', function () {
+        // Localhost is determinable from the peer host alone, so an
+        // unreadable config does not make a localhost peer unknown.
+        const view = diagnostics.__test.buildTrustedPeerView(
+          {
+            ok: true,
+            value: {
+              connections: [
+                { peerHost: '127.0.0.1', peerPort: 58444, type: 1, nodeId: 'aa' },
+              ],
+            },
+          },
+          { ok: false, error: 'ENOENT' },
+        );
+        expect(view.connected[0].trusted).to.equal(true);
+        expect(view.connected[0].trustedReason).to.equal('localhost');
+        expect(view.hasTrustedConnection).to.equal(true);
+        expect(view.trustUnknown).to.equal(false);
+      });
+    });
+
+    describe('shouldWarnNoTrustedPeer', function () {
+      it('warns only when trust is known and no peer is trusted', function () {
+        expect(
+          diagnostics.__test.shouldWarnNoTrustedPeer(true, { hasTrustedConnection: false, trustUnknown: false }),
+        ).to.equal(true);
+      });
+
+      it('does not warn when a trusted connection exists', function () {
+        expect(
+          diagnostics.__test.shouldWarnNoTrustedPeer(true, { hasTrustedConnection: true, trustUnknown: false }),
+        ).to.equal(false);
+      });
+
+      it('does not warn when trust is unknown (config unreadable)', function () {
+        expect(
+          diagnostics.__test.shouldWarnNoTrustedPeer(true, { hasTrustedConnection: false, trustUnknown: true }),
+        ).to.equal(false);
+      });
+
+      it('does not warn when the wallet is unreachable', function () {
+        expect(
+          diagnostics.__test.shouldWarnNoTrustedPeer(false, { hasTrustedConnection: false, trustUnknown: false }),
+        ).to.equal(false);
+      });
+    });
+
+    describe('classifyTrust', function () {
+      it('returns unknown for a non-localhost peer when config is not readable', function () {
+        expect(diagnostics.__test.classifyTrust('1.2.3.4', 'aa', null, [], false)).to.deep.equal({
+          trusted: 'unknown',
+          reason: 'chia-config-unavailable',
+        });
+      });
+
+      it('returns localhost trust even when config is not readable', function () {
+        expect(diagnostics.__test.classifyTrust('127.0.0.1', 'aa', null, [], false)).to.deep.equal({
+          trusted: true,
+          reason: 'localhost',
+        });
+      });
+
+      it('returns false for an untrusted peer when config is readable', function () {
+        expect(diagnostics.__test.classifyTrust('1.2.3.4', 'aa', new Set(['bb']), [], true)).to.deep.equal({
+          trusted: false,
+          reason: null,
+        });
       });
     });
 
@@ -323,12 +428,37 @@ describe('/diagnostics endpoint', function () {
         expect(isTrustedCidr('2001:db8::1', ['2001:db8::/32'])).to.equal(true);
       });
 
+      it('treats a host-bits-set CIDR like chia (strict=False masks host bits)', function () {
+        // chia uses ip_network(cidr, strict=False); "10.0.0.5/24" masks to
+        // 10.0.0.0/24 rather than being rejected.
+        const { isTrustedCidr } = diagnostics.__test;
+        expect(isTrustedCidr('10.0.0.1', ['10.0.0.5/24'])).to.equal(true);
+      });
+
+      it('treats a bare IP as a host route (/32 or /128) like chia', function () {
+        const { isTrustedCidr } = diagnostics.__test;
+        expect(isTrustedCidr('10.0.0.5', ['10.0.0.5'])).to.equal(true);
+        expect(isTrustedCidr('10.0.0.6', ['10.0.0.5'])).to.equal(false);
+        expect(isTrustedCidr('2001:db8::1', ['2001:db8::1'])).to.equal(true);
+      });
+
       it('never throws on malformed input', function () {
         const { isTrustedCidr } = diagnostics.__test;
         expect(isTrustedCidr('not-an-ip', ['10.0.0.0/24'])).to.equal(false);
         expect(isTrustedCidr('10.0.0.5', ['garbage', '10.0.0.0/99', '10.0.0.0'])).to.equal(false);
         expect(isTrustedCidr('10.0.0.5', [])).to.equal(false);
         expect(isTrustedCidr('10.0.0.5', null)).to.equal(false);
+      });
+
+      it('does not treat a malformed prefix as /0 (must not trust every peer)', function () {
+        // Number('')===0 and Number('0x10')===16 would silently widen a
+        // typo'd CIDR; the prefix must be an explicit decimal or be skipped.
+        const { isTrustedCidr } = diagnostics.__test;
+        expect(isTrustedCidr('8.8.8.8', ['10.0.0.0/'])).to.equal(false);
+        expect(isTrustedCidr('8.8.8.8', ['10.0.0.0/ '])).to.equal(false);
+        expect(isTrustedCidr('10.0.255.1', ['10.0.0.0/0x10'])).to.equal(false);
+        // A genuine /0 written explicitly still matches everything.
+        expect(isTrustedCidr('8.8.8.8', ['0.0.0.0/0'])).to.equal(true);
       });
     });
 

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -218,7 +218,6 @@ describe('/diagnostics endpoint', function () {
     });
 
     describe('buildTrustedPeerView', function () {
-      const { buildTrustedPeerView } = (async () => null)(); // placeholder to keep diff small
       it('matches connected peers against trusted_peers regardless of 0x prefix or case', function () {
         const view = diagnostics.__test.buildTrustedPeerView(
           {
@@ -237,18 +236,99 @@ describe('/diagnostics endpoint', function () {
         );
         expect(view.hasTrustedConnection).to.equal(true);
         expect(view.connected[0].trusted).to.equal(true);
+        expect(view.connected[0].trustedReason).to.equal('configured');
         expect(view.connected[1].trusted).to.equal(false);
+        expect(view.connected[1].trustedReason).to.equal(null);
         expect(view.configuredTrustedNodeIds).to.deep.equal(['abcdef12']);
       });
 
       it('reports empty trusted set when chia config has no trusted_peers', function () {
         const view = diagnostics.__test.buildTrustedPeerView(
-          { ok: true, value: { connections: [{ peerHost: 'h', peerPort: 0, type: 1, nodeId: 'aa' }] } },
+          { ok: true, value: { connections: [{ peerHost: '5.6.7.8', peerPort: 0, type: 1, nodeId: 'aa' }] } },
           { ok: true, value: { wallet: {} } },
         );
         expect(view.hasTrustedConnection).to.equal(false);
         expect(view.connected[0].trusted).to.equal(false);
         expect(view.configuredTrustedNodeIds).to.deep.equal([]);
+        expect(view.configuredTrustedCidrs).to.deep.equal([]);
+      });
+
+      it('trusts a localhost peer even when trusted_peers holds only the default placeholder', function () {
+        // Reproduces the real-world case: chia auto-trusts 127.0.0.1, but the
+        // config still contains the example placeholder node id, so a
+        // node-id-only check would wrongly report the peer as untrusted.
+        const view = diagnostics.__test.buildTrustedPeerView(
+          {
+            ok: true,
+            value: {
+              connections: [
+                { peerHost: '127.0.0.1', peerPort: 58444, type: 1, nodeId: 'bf628b52deadbeef' },
+              ],
+            },
+          },
+          {
+            ok: true,
+            value: {
+              wallet: {
+                trusted_peers: {
+                  '0ThisisanexampleNodeID7ff9d60f1c3fa270c213c0ad0cb89c01274634a7c3cb9': 'Does_not_matter',
+                },
+              },
+            },
+          },
+        );
+        expect(view.hasTrustedConnection).to.equal(true);
+        expect(view.connected[0].trusted).to.equal(true);
+        expect(view.connected[0].trustedReason).to.equal('localhost');
+      });
+
+      it('trusts a peer whose IP falls inside a configured trusted CIDR', function () {
+        const view = diagnostics.__test.buildTrustedPeerView(
+          {
+            ok: true,
+            value: {
+              connections: [
+                { peerHost: '10.0.0.5', peerPort: 8444, type: 1, nodeId: 'aa' },
+                { peerHost: '192.168.1.5', peerPort: 8444, type: 1, nodeId: 'bb' },
+              ],
+            },
+          },
+          { ok: true, value: { wallet: { trusted_cidrs: ['10.0.0.0/24'] } } },
+        );
+        expect(view.connected[0].trusted).to.equal(true);
+        expect(view.connected[0].trustedReason).to.equal('cidr');
+        expect(view.connected[1].trusted).to.equal(false);
+        expect(view.configuredTrustedCidrs).to.deep.equal(['10.0.0.0/24']);
+      });
+    });
+
+    describe('isLocalhost', function () {
+      it('recognizes the loopback hosts chia treats as localhost', function () {
+        const { isLocalhost } = diagnostics.__test;
+        expect(isLocalhost('127.0.0.1')).to.equal(true);
+        expect(isLocalhost('localhost')).to.equal(true);
+        expect(isLocalhost('::1')).to.equal(true);
+        expect(isLocalhost('[::1]')).to.equal(true);
+        expect(isLocalhost('0:0:0:0:0:0:0:1')).to.equal(true);
+        expect(isLocalhost('1.2.3.4')).to.equal(false);
+        expect(isLocalhost(null)).to.equal(false);
+      });
+    });
+
+    describe('isTrustedCidr', function () {
+      it('matches IPv4 and IPv6 addresses inside configured ranges', function () {
+        const { isTrustedCidr } = diagnostics.__test;
+        expect(isTrustedCidr('10.0.0.5', ['10.0.0.0/24'])).to.equal(true);
+        expect(isTrustedCidr('10.0.1.5', ['10.0.0.0/24'])).to.equal(false);
+        expect(isTrustedCidr('2001:db8::1', ['2001:db8::/32'])).to.equal(true);
+      });
+
+      it('never throws on malformed input', function () {
+        const { isTrustedCidr } = diagnostics.__test;
+        expect(isTrustedCidr('not-an-ip', ['10.0.0.0/24'])).to.equal(false);
+        expect(isTrustedCidr('10.0.0.5', ['garbage', '10.0.0.0/99', '10.0.0.0'])).to.equal(false);
+        expect(isTrustedCidr('10.0.0.5', [])).to.equal(false);
+        expect(isTrustedCidr('10.0.0.5', null)).to.equal(false);
       });
     });
 


### PR DESCRIPTION
## Summary

- `/diagnostics` now classifies wallet full-node trust the same way `chia wallet show` does: localhost OR `wallet.trusted_peers` OR `wallet.trusted_cidrs` (the wallet RPC `get_connections` response has no `trusted` field).
- Fixes false "performance severely degraded" warnings when the wallet is connected to a local full node (`127.0.0.1`) but `trusted_peers` still contains the default placeholder node id.
- Each connected peer includes `trustedReason` (`localhost` | `configured` | `cidr` | null); the view also exposes `configuredTrustedCidrs`.

## Test plan

- [x] `npx cross-env NODE_ENV=test USE_SIMULATOR=true mocha tests/v2/integration/diagnostics.spec.js` (49 passing)
- [ ] On a node with localhost full-node connection, confirm `/diagnostics` reports `hasTrustedConnection: true` and `trustedReason: "localhost"`
- [ ] Confirm warning no longer appears when only trust gap was localhost vs placeholder `trusted_peers`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to diagnostics trust classification and warning logic, with broad unit tests and no auth or data-path changes.
> 
> **Overview**
> **`/diagnostics`** now judges wallet full-node trust the same way Chia does (`localhost` **or** `wallet.trusted_peers` **or** `wallet.trusted_cidrs`), instead of only matching node IDs in `trusted_peers`. That fixes false “performance severely degraded” warnings when the wallet talks to **`127.0.0.1`** but the config still has the default placeholder peer.
> 
> The trusted-peer view adds **`configuredTrustedCidrs`**, per-connection **`trustedReason`**, and **`trustUnknown`** when config or connections can’t be read (e.g. split CADT/Chia containers). **`trusted`** can be **`'unknown'`** in those cases. The degraded-performance warning runs only when trust is **known** and no peer is trusted (**`shouldWarnNoTrustedPeer`**).
> 
> CIDR matching uses Node’s **`net.BlockList`**, with guards so bad prefix strings don’t widen to `/0`. Unit tests cover localhost, CIDR, unknown trust, and warning gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b003033f8d395ee5b29019a20f90ef6051ee2160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->