### PR TITLE
feat(API): gate /diagnostics chia-tools check on chia locality

### DIFF
--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -340,6 +340,32 @@ const normalizeNodeId = (id) => {
   return s.startsWith('0x') ? s.slice(2) : s;
 };
 
+// Loopback hosts that mean the Chia service runs on the same machine as CADT.
+// Node's URL parser returns IPv6 hosts in bracketed form (e.g. "[::1]"), so we
+// list the bracketed form for IPv6 loopback. The whole 127.0.0.0/8 block is
+// loopback and handled by the prefix check in isLocalChiaUrl.
+const LOCAL_CHIA_HOSTNAMES = new Set([
+  'localhost',
+  '0.0.0.0',
+  '[::1]',
+]);
+
+/**
+ * Whether a Chia RPC URL points at the local machine. Treats localhost, the
+ * full 127.0.0.0/8 loopback block, 0.0.0.0, and IPv6 loopback as local;
+ * anything else is remote. Malformed/empty URLs are treated as non-local
+ * (we can't prove locality, so we don't claim it).
+ */
+const isLocalChiaUrl = (url) => {
+  if (!url) return false;
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    return LOCAL_CHIA_HOSTNAMES.has(hostname) || hostname.startsWith('127.');
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Cross-reference connected wallet peers against the trusted_peers map in
  * the chia config.yaml. Returns a small object suitable for embedding in
@@ -688,9 +714,31 @@ export const getDiagnosticsResponse = async () => {
   })();
 
   // ---- Chia: chia-tools / processes ---------------------------------------
-  const chiaToolsSection = chiaToolsRes.ok
-    ? chiaToolsRes.value
-    : { installed: false, version: null, error: chiaToolsRes.error, note: 'probe failed' };
+  // chia-tools only needs to be installed when the Chia wallet and DataLayer
+  // run on this machine. When either is remote, CADT can't inspect that host,
+  // so we report installed: 'unknown' rather than a misleading "not installed".
+  const chiaIsLocal =
+    isLocalChiaUrl(appConfig.WALLET_URL) && isLocalChiaUrl(appConfig.DATALAYER_URL);
+
+  let chiaToolsSection;
+  if (!chiaIsLocal) {
+    chiaToolsSection = {
+      installed: 'unknown',
+      version: null,
+      chiaIsLocal: false,
+      note: 'Chia wallet/DataLayer are remote; chia-tools is not required on this host',
+    };
+  } else if (chiaToolsRes.ok) {
+    chiaToolsSection = { ...chiaToolsRes.value, chiaIsLocal: true };
+  } else {
+    chiaToolsSection = {
+      installed: false,
+      version: null,
+      chiaIsLocal: true,
+      error: chiaToolsRes.error,
+      note: 'probe failed',
+    };
+  }
 
   // ---- System -------------------------------------------------------------
   const systemSection = systemInfoRes.ok
@@ -758,7 +806,10 @@ export const getDiagnosticsResponse = async () => {
   // chiaTools
   {
     const ctStatus = new StatusAccumulator();
-    if (!chiaToolsSection.installed) {
+    // Only nudge about installing chia-tools when Chia is local. On remote-Chia
+    // setups the binary isn't expected on this host, so installed === 'unknown'
+    // and we leave the status at ok.
+    if (chiaToolsSection.chiaIsLocal && chiaToolsSection.installed !== true) {
       ctStatus.escalate('warning', 'chia-tools is recommended to help manage Chia');
     }
     Object.assign(chiaToolsSection, ctStatus.result());
@@ -880,6 +931,7 @@ export const __test = {
   collectSubscriptions,
   buildTrustedPeerView,
   normalizeNodeId,
+  isLocalChiaUrl,
   collectOwnedStoreExpectations,
   escalateLostOwnedStores,
   StatusAccumulator,

--- a/tests/v2/integration/diagnostics.spec.js
+++ b/tests/v2/integration/diagnostics.spec.js
@@ -217,6 +217,32 @@ describe('/diagnostics endpoint', function () {
       });
     });
 
+    describe('isLocalChiaUrl', function () {
+      it('treats loopback hosts as local', function () {
+        const isLocal = diagnostics.__test.isLocalChiaUrl;
+        expect(isLocal('https://localhost:9256')).to.equal(true);
+        expect(isLocal('https://127.0.0.1:9256')).to.equal(true);
+        expect(isLocal('https://127.0.0.2:9256')).to.equal(true);
+        expect(isLocal('https://0.0.0.0:9256')).to.equal(true);
+        expect(isLocal('https://[::1]:8562')).to.equal(true);
+      });
+
+      it('treats non-loopback hosts as remote', function () {
+        const isLocal = diagnostics.__test.isLocalChiaUrl;
+        expect(isLocal('https://wallet.example.com:9256')).to.equal(false);
+        expect(isLocal('https://10.0.0.5:9256')).to.equal(false);
+        expect(isLocal('https://192.168.1.20:8562')).to.equal(false);
+      });
+
+      it('returns false for empty or malformed input', function () {
+        const isLocal = diagnostics.__test.isLocalChiaUrl;
+        expect(isLocal('')).to.equal(false);
+        expect(isLocal(null)).to.equal(false);
+        expect(isLocal(undefined)).to.equal(false);
+        expect(isLocal('not a url')).to.equal(false);
+      });
+    });
+
     describe('buildTrustedPeerView', function () {
       const { buildTrustedPeerView } = (async () => null)(); // placeholder to keep diff small
       it('matches connected peers against trusted_peers regardless of 0x prefix or case', function () {
@@ -365,6 +391,43 @@ describe('/diagnostics endpoint', function () {
         expect(chiaTools.status).to.equal('warning');
         expect(chiaTools.message).to.include('chia-tools');
       }
+    });
+
+    it('chiaTools reports chiaIsLocal=true under the default loopback config', async function () {
+      const response = await supertest(app).get('/diagnostics').expect(200);
+      expect(response.body.chia.chiaTools).to.have.property('chiaIsLocal', true);
+    });
+
+    it('chiaTools reports installed "unknown" with ok status when Chia is remote', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app).get('/diagnostics').expect(200);
+        const chiaTools = response.body.chia.chiaTools;
+        expect(chiaTools.chiaIsLocal).to.equal(false);
+        expect(chiaTools.installed).to.equal('unknown');
+        // Remote Chia means chia-tools isn't expected locally, so no warning.
+        expect(chiaTools.status).to.equal('ok');
+        expect(chiaTools.note).to.include('remote');
+      }, {
+        APP: {
+          WALLET_URL: 'https://wallet.example.com:9256',
+          DATALAYER_URL: 'https://datalayer.example.com:8562',
+        },
+      });
+    });
+
+    it('chiaTools is gated remote when only the DataLayer is remote', async function () {
+      await withConfigOverride(async () => {
+        const response = await supertest(app).get('/diagnostics').expect(200);
+        const chiaTools = response.body.chia.chiaTools;
+        expect(chiaTools.chiaIsLocal).to.equal(false);
+        expect(chiaTools.installed).to.equal('unknown');
+        expect(chiaTools.status).to.equal('ok');
+      }, {
+        APP: {
+          WALLET_URL: 'https://localhost:9256',
+          DATALAYER_URL: 'https://datalayer.example.com:8562',
+        },
+      });
     });
 
     it('network status is ok when matches is null or true', async function () {

--- a/tests/v2/live-api/wallet-health.live.spec.js
+++ b/tests/v2/live-api/wallet-health.live.spec.js
@@ -184,7 +184,14 @@ describe('Wallet Health - Live', function () {
       expect(body.chia.runningProcesses).to.be.an('object');
       expect(body.chia.runningProcesses.matches).to.be.an('array');
       expect(body.chia.chiaTools).to.be.an('object');
-      expect(body.chia.chiaTools.installed).to.be.a('boolean');
+      expect(body.chia.chiaTools).to.have.property('chiaIsLocal').that.is.a('boolean');
+      // installed is a boolean when Chia runs locally, or the string 'unknown'
+      // when the wallet/DataLayer are remote (chia-tools can't be probed there).
+      if (body.chia.chiaTools.chiaIsLocal) {
+        expect(body.chia.chiaTools.installed).to.be.a('boolean');
+      } else {
+        expect(body.chia.chiaTools.installed).to.equal('unknown');
+      }
       expect(body.chia.chiaTools.note).to.be.a('string').and.not.empty;
     });
 


### PR DESCRIPTION
## Summary

- The `/diagnostics` endpoint reports `chia-tools` as a recommended local tool, but `chia-tools` is only relevant when the Chia wallet and DataLayer run on the same machine as CADT.
- When either `WALLET_URL` or `DATALAYER_URL` points at a remote host, CADT can't inspect that machine, so the `chia.chiaTools` section now reports `installed: "unknown"` (with `chiaIsLocal: false`) and leaves status at `ok` instead of emitting a misleading "chia-tools is recommended" warning.
- When Chia is local, behavior is unchanged: the binary is probed and a warning is raised if it's missing. A new `chiaIsLocal` flag is added to the section in all cases.

## Details

- Locality is derived from the RPC URL host: `localhost`, the full `127.0.0.0/8` loopback block, `0.0.0.0`, and IPv6 loopback (`[::1]`) are treated as local; anything else is remote. Malformed/empty URLs are treated as non-local.
- The status gate only warns when `chiaIsLocal && installed !== true`, so the existing local-not-installed warning is preserved while remote setups stay quiet.

## Test plan

- [x] `npm run test:v2` scope — `tests/v2/integration/diagnostics.spec.js` (50 passing), including:
  - unit tests for the host classifier (`isLocalChiaUrl`: loopback incl. `127.0.0.0/8`, remote, malformed)
  - integration tests asserting `installed: "unknown"` + `status: "ok"` when wallet/DataLayer are remote (both fully-remote and DataLayer-only-remote)
  - `chiaIsLocal: true` under the default loopback config
- [x] Relaxed the live-API contract test (`wallet-health.live.spec.js`) to accept the tri-state `installed` value, gated on `chiaIsLocal`
- [ ] Manual check against a remote-wallet deployment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only behavior change with conservative remote URL handling; local installs keep prior probe and warning semantics.
> 
> **Overview**
> **`/diagnostics` no longer warns about missing `chia-tools` when Chia wallet and DataLayer are configured on remote hosts.**
> 
> The endpoint adds **`isLocalChiaUrl`** (loopback hosts including `127.0.0.0/8`, `localhost`, `[::1]`, etc.) and treats Chia as local only when **both** `WALLET_URL` and `DATALAYER_URL` look local. If either is remote, `chia.chiaTools` reports **`installed: "unknown"`**, **`chiaIsLocal: false`**, and an explanatory note instead of probing the binary; status stays **`ok`**. Local setups still probe `chia-tools` and raise the existing warning when it is not installed.
> 
> The chia-tools status gate now escalates only when **`chiaIsLocal && installed !== true`**. Integration and live API tests cover the classifier and remote vs local response shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fd71479423b3b2dcf1d0fa37e6057ea43f7022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->