### PR TITLE
perf: speed up and bound memory of v1/v2 audit list endpoints

### DIFF
--- a/docs/cadt_rpc_api.md
+++ b/docs/cadt_rpc_api.md
@@ -2201,8 +2201,9 @@ Options:
 |:---------:|:-----------------:|:------------------------------------------------------------------------------------------------------:|
 |  orgUid   | (Required) String |                            Display subscribed projects matching this orgUid                            |
 |   order   |      String       |            Sort the audit records by `ASC` or `DESC` order based on confirmation timestamp             |
-|   limit   | (Required) Number | Limit the number of subscribed projects to be displayed (must be used with page, eg `?page=5&limit=2`) |
+|   limit   | (Required) Number | Limit the number of records to be displayed, between 1 and 1000 (must be used with page, eg `?page=5&limit=2`) |
 |   page    | (Required) Number |       Only display results from this page number (must be used with limit, eg `?page=5&limit=2`)       |
+| excludeChange | Boolean | When `true`, omit the large `change` column from each record to reduce response size (default `false`) |
 
 
 ### GET Examples

--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -6298,8 +6298,9 @@ Options:
 |:---------:|:-----------------:|:------------------------------------------------------------------------------------------------------:|
 |  orgUid   | (Required) String |                            Display audit records matching this orgUid                            |
 |   order   |      String       |            Sort the audit records by `ASC` or `DESC` order based on confirmation timestamp             |
-|   limit   | (Required) Number | Limit the number of audit records to be displayed (must be used with page, eg `?page=5&limit=2`) |
+|   limit   | (Required) Number | Limit the number of audit records to be displayed, between 1 and 1000 (must be used with page, eg `?page=5&limit=2`) |
 |   page    | (Required) Number |       Only display results from this page number (must be used with limit, eg `?page=5&limit=2`)       |
+| excludeChange | Boolean | When `true`, omit the large `change` column from each record to reduce response size (default `false`) |
 
 <a id="audit-get-examples"></a>
 ### GET Examples

--- a/src/controllers/audit.controller.js
+++ b/src/controllers/audit.controller.js
@@ -3,22 +3,39 @@ import _ from 'lodash';
 import {
   paginationParams,
   optionallyPaginatedResponse,
+  normalizeRawTimestamps,
 } from '../utils/helpers';
+import { getCachedCount } from '../utils/audit-count-cache.js';
 import { assertIfReadOnlyMode } from '../utils/data-assertions.js';
 
 export const findAll = async (req, res) => {
   try {
-    const { page, limit, orgUid, order } = req.query;
+    const { page, limit, orgUid, order, excludeChange } = req.query;
 
     const pagination = paginationParams(page, limit);
+    const where = { orgUid };
 
-    const auditResults = await Audit.findAndCountAll({
-      where: { orgUid },
+    const queryOptions = {
+      where,
       order: [['onchainConfirmationTimeStamp', order || 'DESC']],
       ...pagination,
-    });
+      raw: true,
+    };
 
-    return res.json(optionallyPaginatedResponse(auditResults, page, limit));
+    if (excludeChange) {
+      queryOptions.attributes = { exclude: ['change'] };
+    }
+
+    const rows = await Audit.findAll(queryOptions);
+    normalizeRawTimestamps(rows, ['createdAt', 'updatedAt']);
+
+    // Only the paginated response needs a total; cache it so deep pagination
+    // does not re-run an identical COUNT(*) on every page.
+    const count = page && limit
+      ? await getCachedCount(`v1:${orgUid}`, () => Audit.count({ where }))
+      : rows.length;
+
+    return res.json(optionallyPaginatedResponse({ count, rows }, page, limit));
   } catch (error) {
     res.status(400).json({
       message: 'Can not retrieve audit data',

--- a/src/controllers/v2/audit-v2.controller.js
+++ b/src/controllers/v2/audit-v2.controller.js
@@ -18,7 +18,7 @@ import {
  */
 export const findAll = async (req, res) => {
   try {
-    const { page, limit, orgUid, order } = req.query;
+    const { page, limit, orgUid, order, excludeChange } = req.query;
 
     // Validate pagination parameters BEFORE normalization to catch invalid values
     // This prevents normalization from masking validation errors
@@ -28,10 +28,10 @@ export const findAll = async (req, res) => {
 
     if (limit !== undefined && limit !== null && limit !== '') {
       const safeLimit = parseInt(limit, 10);
-      if (isNaN(safeLimit) || safeLimit < 1 || safeLimit > 10000) {
+      if (isNaN(safeLimit) || safeLimit < 1 || safeLimit > 1000) {
         return res.status(400).json({
           message: 'Cannot retrieve audit data',
-          error: 'Invalid limit value. Must be between 1 and 10000',
+          error: 'Invalid limit value. Must be between 1 and 1000',
           success: false,
         });
       }
@@ -64,6 +64,7 @@ export const findAll = async (req, res) => {
       validatedOrder,
       pagination.limit,
       validatedPage,
+      excludeChange,
     );
 
     return res.json(optionallyPaginatedResponse(auditResults, validatedPage, validatedLimit));

--- a/src/database/migrations/20260615120000-add-audit-list-index.js
+++ b/src/database/migrations/20260615120000-add-audit-list-index.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Composite index on the V1 audit table to make the audit list endpoint's
+// per-org, time-ordered pagination usable by the SQLite planner.
+//
+// Hot-path query in src/controllers/audit.controller.js findAll:
+//
+//   Audit.findAll({
+//     where: { orgUid },
+//     order: [['onchainConfirmationTimeStamp', order]],
+//     limit, offset,
+//   })
+//
+// Without an index covering both the WHERE and the ORDER BY, the planner
+// materializes the org's entire row set (including the large `change` TEXT)
+// and does a temp-B-tree sort on every request. The composite index lets it
+// do an ordered range scan, removing the sort; deep OFFSET still walks index
+// entries but no longer reads the `change` blob for skipped rows. Idempotent
+// so re-running is safe.
+
+const INDEXES = [
+  {
+    fields: ['orgUid', 'onchainConfirmationTimeStamp'],
+    name: 'audit_org_uid_onchain_timestamp',
+  },
+];
+
+const isDuplicateIndexError = (error) => {
+  const message = error?.message || '';
+  return /already exists/i.test(message) || /duplicate key name/i.test(message);
+};
+
+export default {
+  async up(queryInterface) {
+    for (const { fields, name } of INDEXES) {
+      try {
+        await queryInterface.addIndex('audit', fields, { name });
+      } catch (error) {
+        // Idempotent: ignore "already exists" so re-running the migration
+        // (e.g. after a partial run) doesn't fail.
+        if (!isDuplicateIndexError(error)) {
+          throw error;
+        }
+      }
+    }
+  },
+
+  async down(queryInterface) {
+    for (const { name } of INDEXES) {
+      try {
+        await queryInterface.removeIndex('audit', name);
+      } catch {
+        // Best-effort drop on rollback.
+      }
+    }
+  },
+};

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -35,6 +35,7 @@ import OrgSyncRemaining from './20231020214357-OrgSyncRemainingCount';
 import AddGenerationIndexToAudit from './20231207142225-AddGenerationIndexToAudit';
 import AddDataModelVersionStoreToOrganizationTable from './20241211153456-add-data-model-version-store-to-organization-table.js';
 import AddAuditSyncIndexes from './20260301120000-add-audit-sync-indexes.js';
+import AddAuditListIndex from './20260615120000-add-audit-list-index.js';
 
 export const migrations = [
   {
@@ -188,5 +189,9 @@ export const migrations = [
   {
     migration: AddAuditSyncIndexes,
     name: '20260301120000-add-audit-sync-indexes',
+  },
+  {
+    migration: AddAuditListIndex,
+    name: '20260615120000-add-audit-list-index',
   },
 ];

--- a/src/database/v2/migrations/20260615120000-add-audit-list-index-v2.js
+++ b/src/database/v2/migrations/20260615120000-add-audit-list-index-v2.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Composite index on the V2 audit table to make the audit list endpoint's
+// per-org, time-ordered pagination usable by the SQLite/MySQL planner.
+//
+// Hot-path query in src/models/v2/audit-v2.model.js findAuditHistory:
+//
+//   AuditV2.findAll({
+//     where: { org_uid },
+//     order: [['onchain_confirmation_time_stamp', order]],
+//     limit, offset,
+//   })
+//
+// Without an index covering both the WHERE and the ORDER BY, the planner
+// materializes the org's entire row set (including the large `change` TEXT)
+// and does a temp-B-tree sort on every request. The composite index removes
+// the sort; deep OFFSET still walks index entries but no longer reads the
+// `change` blob for skipped rows. Symmetric with the V1 audit-list index
+// migration. Idempotent so re-running is safe.
+
+const INDEXES = [
+  {
+    fields: ['org_uid', 'onchain_confirmation_time_stamp'],
+    name: 'audit_v2_org_uid_onchain_timestamp',
+  },
+];
+
+const isDuplicateIndexError = (error) => {
+  const message = error?.message || '';
+  return /already exists/i.test(message) || /duplicate key name/i.test(message);
+};
+
+export default {
+  async up(queryInterface) {
+    for (const { fields, name } of INDEXES) {
+      try {
+        await queryInterface.addIndex('audit', fields, { name });
+      } catch (error) {
+        // Idempotent: ignore "already exists" so re-running the migration
+        // doesn't fail on either dialect.
+        if (!isDuplicateIndexError(error)) {
+          throw error;
+        }
+      }
+    }
+  },
+
+  async down(queryInterface) {
+    for (const { name } of INDEXES) {
+      try {
+        await queryInterface.removeIndex('audit', name);
+      } catch {
+        // Best-effort drop on rollback.
+      }
+    }
+  },
+};

--- a/src/database/v2/migrations/index.js
+++ b/src/database/v2/migrations/index.js
@@ -49,6 +49,9 @@ import AddOrgUidToStandaloneTablesV2 from './20260220120000-add-org-uid-to-stand
 // V2 Sync Performance: composite audit indexes for the per-tick generation lookup
 import AddAuditSyncIndexesV2 from './20260301120000-add-audit-sync-indexes-v2.js';
 
+// V2 Audit list endpoint: composite index covering per-org time-ordered pagination
+import AddAuditListIndexV2 from './20260615120000-add-audit-list-index-v2.js';
+
 export const migrations = [
   {
     migration: CreateStagingV2,
@@ -189,5 +192,9 @@ export const migrations = [
   {
     migration: AddAuditSyncIndexesV2,
     name: '20260301120000-add-audit-sync-indexes-v2',
+  },
+  {
+    migration: AddAuditListIndexV2,
+    name: '20260615120000-add-audit-list-index-v2',
   },
 ];

--- a/src/models/audit/audit.model.js
+++ b/src/models/audit/audit.model.js
@@ -7,6 +7,7 @@ import ModelTypes from './audit.modeltypes.js';
 import findDuplicateIssuancesSql from './sql/find-duplicate-issuances.sql.js';
 import { Organization } from '../organizations/index.js';
 import { waitForSyncRegistriesTransaction } from '../../utils/model-utils.js';
+import { clearAuditCountCache } from '../../utils/audit-count-cache.js';
 
 class Audit extends Model {
   static async create(values, options) {
@@ -17,7 +18,9 @@ class Audit extends Model {
       };
       await AuditMirror.create(values, mirrorOptions);
     }, options?.mirrorTransaction);
-    return super.create(values, options);
+    const result = await super.create(values, options);
+    clearAuditCountCache();
+    return result;
   }
 
   static async bulkCreate(values, options) {
@@ -28,7 +31,9 @@ class Audit extends Model {
       };
       await AuditMirror.bulkCreate(values, mirrorOptions);
     }, options?.mirrorTransaction);
-    return super.bulkCreate(values, options);
+    const result = await super.bulkCreate(values, options);
+    clearAuditCountCache();
+    return result;
   }
 
   static async destroy(options) {
@@ -39,7 +44,9 @@ class Audit extends Model {
       };
       await AuditMirror.destroy(mirrorOptions);
     }, options?.mirrorTransaction);
-    return super.destroy(options);
+    const result = await super.destroy(options);
+    clearAuditCountCache();
+    return result;
   }
 
   static async upsert(values, options) {
@@ -50,7 +57,9 @@ class Audit extends Model {
       };
       await AuditMirror.upsert(values, mirrorOptions);
     }, options?.mirrorTransaction);
-    return super.upsert(values, options);
+    const result = await super.upsert(values, options);
+    clearAuditCountCache();
+    return result;
   }
 
   static async findConflicts() {

--- a/src/models/v2/audit-v2.model.js
+++ b/src/models/v2/audit-v2.model.js
@@ -8,6 +8,11 @@ import OrganizationsV2 from './organizations-v2.model.js';
 import { loggerV2 } from '../../config/logger.js';
 
 import ModelTypes from './audit-v2.modeltypes.js';
+import {
+  getCachedCount,
+  clearAuditCountCache,
+} from '../../utils/audit-count-cache.js';
+import { normalizeRawTimestamps } from '../../utils/helpers.js';
 
 class AuditV2 extends Model {
   static async create(values, options) {
@@ -19,6 +24,7 @@ class AuditV2 extends Model {
       await AuditV2Mirror.create(values, mirrorOptions);
     }, options?.mirrorTransaction);
     const result = await super.create(values, options);
+    clearAuditCountCache();
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
@@ -32,6 +38,7 @@ class AuditV2 extends Model {
       await AuditV2Mirror.bulkCreate(values, mirrorOptions);
     }, options?.mirrorTransaction);
     const result = await super.bulkCreate(values, options);
+    clearAuditCountCache();
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
@@ -45,6 +52,7 @@ class AuditV2 extends Model {
       await AuditV2Mirror.update(values, mirrorOptions);
     }, options?.mirrorTransaction);
     const result = await super.update(values, options);
+    clearAuditCountCache();
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
@@ -58,6 +66,7 @@ class AuditV2 extends Model {
       await AuditV2Mirror.upsert(values, mirrorOptions);
     }, options?.mirrorTransaction);
     const result = await super.upsert(values, options);
+    clearAuditCountCache();
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
@@ -71,6 +80,7 @@ class AuditV2 extends Model {
       await AuditV2Mirror.destroy(mirrorOptions);
     }, options?.mirrorTransaction);
     const result = await super.destroy(options);
+    clearAuditCountCache();
     if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
@@ -82,10 +92,11 @@ class AuditV2 extends Model {
    * @param {string} order - Sort order ('ASC' or 'DESC', defaults to 'DESC')
    * @param {number} limit - Number of records per page
    * @param {number} page - Page number (1-indexed)
+   * @param {boolean} excludeChange - When true, omit the heavy `change` column
    * @returns {Promise<{rows: Array, count: number}>} Audit records with total count
    * @throws {Error} If orgUid is invalid
    */
-  static async findAuditHistory(orgUid, order = 'DESC', limit, page) {
+  static async findAuditHistory(orgUid, order = 'DESC', limit, page, excludeChange = false) {
     // Validate orgUid exists in V2 organizations if provided
     if (orgUid) {
       // Get all organizations and check if orgUid exists
@@ -113,16 +124,24 @@ class AuditV2 extends Model {
     const queryOptions = {
       where,
       order: [['onchain_confirmation_time_stamp', safeOrder]],
+      // Plain objects instead of Sequelize instances to avoid the
+      // dataValues/_previousDataValues memory overhead on large pages.
+      raw: true,
     };
+
+    if (excludeChange) {
+      queryOptions.attributes = { exclude: ['change'] };
+    }
 
     // Add pagination if limit and page are provided
     // Validate and sanitize limit and page to prevent SQL injection
-    if (limit && page) {
+    const isPaginated = Boolean(limit && page);
+    if (isPaginated) {
       // Validate limit is a safe integer
       const safeLimit = parseInt(limit, 10);
-      if (isNaN(safeLimit) || safeLimit < 1 || safeLimit > 10000) {
+      if (isNaN(safeLimit) || safeLimit < 1 || safeLimit > 1000) {
         loggerV2.warn('[v2]: Invalid limit value in findAuditHistory', { providedLimit: limit });
-        throw new Error('Invalid limit value. Must be between 1 and 10000');
+        throw new Error('Invalid limit value. Must be between 1 and 1000');
       }
 
       // Validate page is a safe integer
@@ -137,8 +156,15 @@ class AuditV2 extends Model {
       queryOptions.offset = offset;
     }
 
-    // Call Sequelize's findAndCountAll directly (not overridden)
-    return await AuditV2.findAndCountAll(queryOptions);
+    // Decouple rows from the count: only the paginated response needs a total,
+    // and the cached count avoids re-running COUNT(*) on every deep page.
+    const rows = await AuditV2.findAll(queryOptions);
+    normalizeRawTimestamps(rows, ['created_at', 'updated_at']);
+    const count = isPaginated
+      ? await getCachedCount(`v2:${orgUid}`, () => AuditV2.count({ where }))
+      : rows.length;
+
+    return { count, rows };
   }
 
   /**

--- a/src/utils/audit-count-cache.js
+++ b/src/utils/audit-count-cache.js
@@ -1,0 +1,56 @@
+// In-memory cache for audit row counts. The audit list endpoint paginates with
+// findAll + a separate count; deep pagination would otherwise re-run an
+// identical COUNT(*) on every page even though the total only changes when an
+// audit write happens. The count is freshened two ways: the audit models call
+// clearAuditCountCache() on every write (so single-process counts stay
+// accurate), and the TTL bounds worst-case staleness if a write path is ever
+// missed or the process is one of several sharing the DB. pageCount may
+// therefore lag by at most the TTL, which is acceptable for pagination
+// metadata.
+
+const DEFAULT_TTL_MS = 15_000;
+
+// Bound the number of distinct keys; eviction is oldest-first (Map insertion
+// order). Set far above the realistic number of subscribed orgs, so this only
+// trips on pathological key churn rather than normal operation.
+const MAX_ENTRIES = 10_000;
+
+const cache = new Map(); // key -> { value, expires }
+
+// Bumped on every clearAuditCountCache(). A compute that started before a clear
+// must not repopulate the cache with its now-stale result, so getCachedCount
+// only writes back when the generation is unchanged across the await.
+let generation = 0;
+
+export async function getCachedCount(key, computeFn, ttlMs = DEFAULT_TTL_MS) {
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && hit.expires > now) {
+    return hit.value;
+  }
+  if (hit) {
+    cache.delete(key); // drop the expired entry before recomputing
+  }
+
+  const startGeneration = generation;
+  const value = await computeFn();
+  // A write invalidated the cache while COUNT(*) was in flight; the computed
+  // value may predate that write, so return it without caching.
+  if (generation !== startGeneration) {
+    return value;
+  }
+
+  if (cache.size >= MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) {
+      cache.delete(oldest);
+    }
+  }
+  cache.set(key, { value, expires: Date.now() + ttlMs });
+  return value;
+}
+
+export function clearAuditCountCache() {
+  generation += 1;
+  cache.clear();
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -51,6 +51,25 @@ export const optionallyPaginatedResponse = ({ count, rows }, page, limit) => {
   }
 };
 
+// `raw: true` rows return DATE columns as the dialect's stored value (SQLite
+// hands back a "YYYY-MM-DD HH:mm:ss.SSS +00:00" string) instead of a Date,
+// which would serialize differently from the prior Sequelize-instance ISO-8601
+// output. Re-normalize the given fields in place so the wire format is
+// unchanged. Mutates rows; unparseable/absent values are left as-is.
+export const normalizeRawTimestamps = (rows, fields) => {
+  for (const row of rows) {
+    for (const field of fields) {
+      const value = row[field];
+      if (value == null) continue;
+      const date = value instanceof Date ? value : new Date(value);
+      if (!Number.isNaN(date.getTime())) {
+        row[field] = date.toISOString();
+      }
+    }
+  }
+  return rows;
+};
+
 /**
  *
  * @param userColumns {string[]}

--- a/src/validations/audit.validations.js
+++ b/src/validations/audit.validations.js
@@ -9,15 +9,16 @@ export const auditGetSchema = Joi.object()
       'number.max': 'Invalid page value. Must be between 1 and 100000',
       'any.required': 'page is required',
     }),
-    limit: Joi.number().integer().min(1).max(10000).required().messages({
+    limit: Joi.number().integer().min(1).max(1000).required().messages({
       'number.base': 'Invalid limit value. Must be a number',
       'number.integer': 'Invalid limit value. Must be an integer',
-      'number.min': 'Invalid limit value. Must be between 1 and 10000',
-      'number.max': 'Invalid limit value. Must be between 1 and 10000',
+      'number.min': 'Invalid limit value. Must be between 1 and 1000',
+      'number.max': 'Invalid limit value. Must be between 1 and 1000',
       'any.required': 'limit is required',
     }),
     orgUid: Joi.string().required(),
     order: Joi.string().optional(), // Allow any string, controller will default invalid values to DESC
+    excludeChange: Joi.boolean().optional(), // When true, omit the heavy `change` column from rows
   })
   .with('page', 'limit')
   .with('limit', 'page');

--- a/tests/integration/audit-count-cache.spec.js
+++ b/tests/integration/audit-count-cache.spec.js
@@ -1,0 +1,124 @@
+import { expect } from 'chai';
+import {
+  getCachedCount,
+  clearAuditCountCache,
+} from '../../src/utils/audit-count-cache.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('audit count cache', function () {
+  beforeEach(function () {
+    clearAuditCountCache();
+  });
+
+  after(function () {
+    clearAuditCountCache();
+  });
+
+  it('computes on a miss and serves the memoized value on a hit', async function () {
+    let calls = 0;
+    const compute = async () => {
+      calls += 1;
+      return 42;
+    };
+
+    const first = await getCachedCount('test:org-a', compute, 10000);
+    const second = await getCachedCount('test:org-a', compute, 10000);
+
+    expect(first).to.equal(42);
+    expect(second).to.equal(42);
+    expect(calls).to.equal(1);
+  });
+
+  it('recomputes once the TTL has expired', async function () {
+    let calls = 0;
+    const compute = async () => {
+      calls += 1;
+      return calls;
+    };
+
+    const first = await getCachedCount('test:org-b', compute, 20);
+    expect(first).to.equal(1);
+
+    await sleep(30);
+
+    const second = await getCachedCount('test:org-b', compute, 20);
+    expect(second).to.equal(2);
+    expect(calls).to.equal(2);
+  });
+
+  it('recomputes after clearAuditCountCache invalidates the entry', async function () {
+    let calls = 0;
+    const compute = async () => {
+      calls += 1;
+      return calls;
+    };
+
+    await getCachedCount('test:org-c', compute, 10000);
+    clearAuditCountCache();
+    const afterClear = await getCachedCount('test:org-c', compute, 10000);
+
+    expect(afterClear).to.equal(2);
+    expect(calls).to.equal(2);
+  });
+
+  it('keys entries independently', async function () {
+    const a = await getCachedCount('test:org-d', async () => 1, 10000);
+    const b = await getCachedCount('test:org-e', async () => 2, 10000);
+
+    expect(a).to.equal(1);
+    expect(b).to.equal(2);
+  });
+
+  it('evicts the oldest entry once the size cap is exceeded', async function () {
+    this.timeout(20000);
+    const MAX_ENTRIES = 10000;
+
+    // Fill the cache to the cap; the first key inserted is the oldest.
+    for (let i = 0; i < MAX_ENTRIES; i += 1) {
+      await getCachedCount(`evict:${i}`, async () => i, 60000);
+    }
+
+    // One more distinct key trips eviction of the oldest (evict:0).
+    await getCachedCount('evict:overflow', async () => -1, 60000);
+
+    let recomputed = false;
+    const value = await getCachedCount(
+      'evict:0',
+      async () => {
+        recomputed = true;
+        return 999;
+      },
+      60000,
+    );
+
+    expect(recomputed).to.equal(true);
+    expect(value).to.equal(999);
+  });
+
+  it('does not cache a value computed before a concurrent invalidation', async function () {
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+
+    let calls = 0;
+    const compute = async () => {
+      calls += 1;
+      await gate;
+      return calls;
+    };
+
+    // Start a compute, invalidate mid-flight, then let the compute finish.
+    const inFlight = getCachedCount('test:race', compute, 10000);
+    clearAuditCountCache();
+    release();
+    const racedValue = await inFlight;
+    expect(racedValue).to.equal(1);
+
+    // The raced value must not have been cached, so the next read recomputes.
+    const next = await getCachedCount('test:race', compute, 10000);
+    expect(next).to.equal(2);
+    expect(calls).to.equal(2);
+  });
+});

--- a/tests/integration/audit.spec.js
+++ b/tests/integration/audit.spec.js
@@ -1,0 +1,145 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+
+import app from '../../src/server.js';
+import { prepareDb, sequelize } from '../../src/database/index.js';
+import { Audit } from '../../src/models/index.js';
+import TaskManager from '../../src/tasks/index.js';
+import { getConfig, getConfigV2 } from '../../src/utils/config-loader.js';
+
+describe('Audit Resource (V1) — list endpoint', function () {
+  this.timeout(30000);
+
+  let orgUid;
+
+  before(async function () {
+    await prepareDb();
+    // Stop background sync so it doesn't hold the audit beforeFind mutex
+    // or mutate the audit table mid-test.
+    TaskManager.stopAll();
+  });
+
+  after(async function () {
+    const configV1 = getConfig();
+    const configV2 = getConfigV2();
+    TaskManager.start(configV1?.ENABLE !== false, configV2?.ENABLE !== false);
+  });
+
+  beforeEach(async function () {
+    await Audit.destroy({ where: {} });
+    orgUid = uuidv4();
+    const now = Math.floor(Date.now() / 1000);
+    await Audit.bulkCreate([
+      {
+        orgUid,
+        registryId: 'test-registry-1',
+        rootHash: 'hash1',
+        type: 'insert',
+        change: '{"test": "data1"}',
+        table: 'project',
+        onchainConfirmationTimeStamp: now.toString(),
+        generation: 1,
+      },
+      {
+        orgUid,
+        registryId: 'test-registry-1',
+        rootHash: 'hash2',
+        type: 'update',
+        change: '{"test": "data2"}',
+        table: 'project',
+        onchainConfirmationTimeStamp: (now + 1).toString(),
+        generation: 2,
+      },
+    ]);
+  });
+
+  describe('GET /v1/audit - pagination shape', function () {
+    it('should return the paginated response shape', async function () {
+      const response = await supertest(app)
+        .get('/v1/audit')
+        .query({ orgUid, page: 1, limit: 1 })
+        .expect(200);
+
+      expect(response.body).to.have.property('page', 1);
+      expect(response.body).to.have.property('pageCount', 2);
+      expect(response.body).to.have.property('data').that.is.an('array');
+      expect(response.body.data).to.have.length(1);
+    });
+  });
+
+  describe('GET /v1/audit - excludeChange parameter', function () {
+    it('should include the change column by default', async function () {
+      const response = await supertest(app)
+        .get('/v1/audit')
+        .query({ orgUid, page: 1, limit: 10 })
+        .expect(200);
+
+      expect(response.body.data).to.have.length(2);
+      expect(response.body.data[0]).to.have.property('change');
+      // raw:true must not regress the timestamp wire format away from ISO-8601
+      expect(response.body.data[0].createdAt).to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+    });
+
+    it('should omit the change column when excludeChange=true', async function () {
+      const response = await supertest(app)
+        .get('/v1/audit')
+        .query({ orgUid, page: 1, limit: 10, excludeChange: true })
+        .expect(200);
+
+      expect(response.body.data).to.have.length(2);
+      response.body.data.forEach((row) => {
+        expect(row).to.not.have.property('change');
+      });
+      // Other columns are still present
+      expect(response.body.data[0]).to.have.property('rootHash');
+    });
+
+    it('should include the change column when excludeChange=false', async function () {
+      const response = await supertest(app)
+        .get('/v1/audit')
+        .query({ orgUid, page: 1, limit: 10, excludeChange: false })
+        .expect(200);
+
+      expect(response.body.data).to.have.length(2);
+      expect(response.body.data[0]).to.have.property('change');
+    });
+  });
+
+  describe('GET /v1/audit - limit cap', function () {
+    it('should accept limit at the maximum bound (1000)', async function () {
+      const response = await supertest(app)
+        .get('/v1/audit')
+        .query({ orgUid, page: 1, limit: 1000 })
+        .expect(200);
+
+      expect(response.body.data).to.have.length(2);
+    });
+
+    it('should reject limit above the maximum bound (1001)', async function () {
+      const response = await supertest(app)
+        .get('/v1/audit')
+        .query({ orgUid, page: 1, limit: 1001 })
+        .expect(400);
+
+      const messages = response.body.errors || [response.body.error];
+      expect(messages.some((m) => m && m.includes('Invalid limit value'))).to.be
+        .true;
+    });
+  });
+
+  describe('GET /v1/audit - query plan uses the covering index', function () {
+    it('serves the list query from the composite index without a temp sort', async function () {
+      const plan = await sequelize.query(
+        "EXPLAIN QUERY PLAN SELECT * FROM audit WHERE orgUid = 'x' ORDER BY onchainConfirmationTimeStamp DESC LIMIT 1000",
+        { type: sequelize.QueryTypes.SELECT },
+      );
+      const details = plan.map((row) => row.detail).join(' | ');
+
+      expect(details).to.include('audit_org_uid_onchain_timestamp');
+      expect(details).to.not.match(/TEMP B-TREE/i);
+    });
+  });
+});

--- a/tests/integration/helpers-normalize-timestamps.spec.js
+++ b/tests/integration/helpers-normalize-timestamps.spec.js
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { normalizeRawTimestamps } from '../../src/utils/helpers.js';
+
+describe('normalizeRawTimestamps', function () {
+  it('converts a SQLite datetime string to ISO-8601', function () {
+    const rows = [{ createdAt: '2026-06-15 19:19:58.131 +00:00' }];
+    normalizeRawTimestamps(rows, ['createdAt']);
+    expect(rows[0].createdAt).to.equal('2026-06-15T19:19:58.131Z');
+  });
+
+  it('converts a Date instance (MySQL driver) to ISO-8601', function () {
+    const date = new Date('2026-06-15T19:19:58.131Z');
+    const rows = [{ created_at: date }];
+    normalizeRawTimestamps(rows, ['created_at']);
+    expect(rows[0].created_at).to.equal('2026-06-15T19:19:58.131Z');
+  });
+
+  it('leaves null and undefined values untouched', function () {
+    const rows = [{ createdAt: null, updatedAt: undefined }];
+    normalizeRawTimestamps(rows, ['createdAt', 'updatedAt']);
+    expect(rows[0].createdAt).to.equal(null);
+    expect(rows[0].updatedAt).to.equal(undefined);
+  });
+
+  it('leaves unparseable values untouched', function () {
+    const rows = [{ createdAt: 'not-a-date' }];
+    normalizeRawTimestamps(rows, ['createdAt']);
+    expect(rows[0].createdAt).to.equal('not-a-date');
+  });
+
+  it('normalizes every row and only the requested fields', function () {
+    const rows = [
+      { createdAt: '2026-01-01 00:00:00.000 +00:00', other: 'keep' },
+      { createdAt: '2026-02-02 00:00:00.000 +00:00', other: 'keep' },
+    ];
+    normalizeRawTimestamps(rows, ['createdAt']);
+    expect(rows[0].createdAt).to.equal('2026-01-01T00:00:00.000Z');
+    expect(rows[1].createdAt).to.equal('2026-02-02T00:00:00.000Z');
+    expect(rows[0].other).to.equal('keep');
+  });
+});

--- a/tests/v2/integration/audit-v2-model.spec.js
+++ b/tests/v2/integration/audit-v2-model.spec.js
@@ -54,7 +54,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
 
     it('should return audit records with pagination', async function () {
       // Snapshot baseline — background sync can insert audit records for testOrgUid
-      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 10000, 1);
+      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 1000, 1);
       const baselineCount = baseline.count;
 
       // Use timestamps far in the future so test records always sort last/first
@@ -102,7 +102,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
     });
 
     it('should return audit records ordered ASC', async function () {
-      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'ASC', 10000, 1);
+      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'ASC', 1000, 1);
       const baselineCount = baseline.count;
 
       const futureTs = '9999999991';
@@ -129,7 +129,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
         },
       ]);
 
-      const result = await AuditV2.findAuditHistory(testOrgUid, 'ASC', 10000, 1);
+      const result = await AuditV2.findAuditHistory(testOrgUid, 'ASC', 1000, 1);
 
       expect(result.count).to.equal(baselineCount + 2);
       // Verify our test records appear in ASC order at the end
@@ -140,7 +140,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
     });
 
     it('should filter by orgUid', async function () {
-      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 10000, 1);
+      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 1000, 1);
       const baselineCount = baseline.count;
 
       const otherOrg = await OrganizationsV2.create({
@@ -175,7 +175,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
         },
       ]);
 
-      const result = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 10000, 1);
+      const result = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 1000, 1);
 
       // Only one new record for testOrgUid; the other-org record is excluded
       expect(result.count).to.equal(baselineCount + 1);
@@ -217,7 +217,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
 
     it('should throw error for invalid limit value (too large)', async function () {
       try {
-        await AuditV2.findAuditHistory(testOrgUid, 'DESC', 10001, 1);
+        await AuditV2.findAuditHistory(testOrgUid, 'DESC', 1001, 1);
         expect.fail('Should have thrown an error');
       } catch (error) {
         expect(error.message).to.include('Invalid limit value');
@@ -270,7 +270,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
     });
 
     it('should accept valid limit and page at maximum bounds', async function () {
-      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 10000, 1);
+      const baseline = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 1000, 1);
       const baselineCount = baseline.count;
 
       const futureTs = '9999999991';
@@ -287,7 +287,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
         },
       ]);
 
-      const result = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 10000, 1);
+      const result = await AuditV2.findAuditHistory(testOrgUid, 'DESC', 1000, 1);
       expect(result.count).to.equal(baselineCount + 1);
     });
 
@@ -317,7 +317,7 @@ describe('Phase 17.1: AuditV2 Model Methods', function () {
       ]);
 
       // Invalid order should default to DESC — our future-timestamped records come first
-      const result = await AuditV2.findAuditHistory(testOrgUid, 'INVALID', 10000, 1);
+      const result = await AuditV2.findAuditHistory(testOrgUid, 'INVALID', 1000, 1);
       const testRows = result.rows.filter((r) => r.root_hash.startsWith('order-'));
       expect(testRows).to.have.length(2);
       // DESC: 9902 before 9901

--- a/tests/v2/integration/audit-v2.spec.js
+++ b/tests/v2/integration/audit-v2.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../../../src/server.js';
-import { prepareV2Db } from '../../../src/database/v2/index.js';
+import { prepareV2Db, sequelizeV2 } from '../../../src/database/v2/index.js';
 import { AuditV2, OrganizationsV2 } from '../../../src/models/v2/index.js';
 import { Audit } from '../../../src/models/index.js';
 import { createV2TestHomeOrg } from '../utils/v2-test-helpers.js';
@@ -435,7 +435,7 @@ describe('Phase 17.5: AuditV2 Comprehensive Integration Tests', function () {
         .query({
           orgUid: testOrgUid,
           page: 1,
-          limit: 10001, // Exceeds maximum of 10000
+          limit: 1001, // Exceeds maximum of 1000
         })
         .expect(400);
 
@@ -563,11 +563,13 @@ describe('Phase 17.5: AuditV2 Comprehensive Integration Tests', function () {
         .query({
           orgUid: testOrgUid,
           page: 1,
-          limit: 10000, // Maximum allowed
+          limit: 1000, // Maximum allowed
         })
         .expect(200);
 
-      expect(response.body.success).to.not.equal(false);
+      expect(response.body).to.have.property('page', 1);
+      expect(response.body).to.have.property('pageCount');
+      expect(response.body.data).to.be.an('array').with.length(1);
     });
 
     it('should accept valid order values (ASC)', async function () {
@@ -789,6 +791,90 @@ describe('Phase 17.5: AuditV2 Comprehensive Integration Tests', function () {
       expect(v2CountAfter).to.be.lessThan(v2CountBefore);
       // V1 count should remain unchanged
       expect(v1CountAfter).to.equal(v1CountBefore);
+    });
+  });
+
+  describe('GET /v2/audit - excludeChange parameter', function () {
+    beforeEach(async function () {
+      const now = Math.floor(Date.now() / 1000).toString();
+      await AuditV2.bulkCreate([
+        {
+          org_uid: testOrgUid,
+          registry_id: 'test-registry-1',
+          root_hash: 'hash1',
+          type: 'insert',
+          change: '{"test": "data1"}',
+          table: 'project',
+          onchain_confirmation_time_stamp: now,
+          generation: 1,
+        },
+      ]);
+    });
+
+    it('should include the change column by default', async function () {
+      const response = await supertest(app)
+        .get('/v2/audit')
+        .query({ orgUid: testOrgUid, page: 1, limit: 10 })
+        .expect(200);
+
+      expect(response.body.data).to.have.length(1);
+      expect(response.body.data[0]).to.have.property('change', '{"test": "data1"}');
+      // raw:true must not regress the timestamp wire format away from ISO-8601
+      expect(response.body.data[0].created_at).to.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+    });
+
+    it('should omit the change column when excludeChange=true', async function () {
+      const response = await supertest(app)
+        .get('/v2/audit')
+        .query({ orgUid: testOrgUid, page: 1, limit: 10, excludeChange: true })
+        .expect(200);
+
+      expect(response.body.data).to.have.length(1);
+      expect(response.body.data[0]).to.not.have.property('change');
+      // Other columns are still present
+      expect(response.body.data[0]).to.have.property('generation', 1);
+    });
+
+    it('should preserve the paginated response shape', async function () {
+      const response = await supertest(app)
+        .get('/v2/audit')
+        .query({ orgUid: testOrgUid, page: 1, limit: 10, excludeChange: true })
+        .expect(200);
+
+      expect(response.body).to.have.property('page', 1);
+      expect(response.body).to.have.property('pageCount', 1);
+      expect(response.body).to.have.property('data').that.is.an('array');
+    });
+
+    it('should include the change column when excludeChange=false', async function () {
+      const response = await supertest(app)
+        .get('/v2/audit')
+        .query({ orgUid: testOrgUid, page: 1, limit: 10, excludeChange: false })
+        .expect(200);
+
+      expect(response.body.data).to.have.length(1);
+      expect(response.body.data[0]).to.have.property('change', '{"test": "data1"}');
+    });
+  });
+
+  describe('GET /v2/audit - query plan uses the covering index', function () {
+    it('serves the list query from the composite index without a temp sort', async function () {
+      const plan = await sequelizeV2.query(
+        `EXPLAIN QUERY PLAN SELECT * FROM audit
+         WHERE org_uid = :orgUid
+         ORDER BY onchain_confirmation_time_stamp DESC
+         LIMIT 1000`,
+        {
+          replacements: { orgUid: testOrgUid },
+          type: sequelizeV2.QueryTypes.SELECT,
+        },
+      );
+      const details = plan.map((row) => row.detail).join(' | ');
+
+      expect(details).to.include('audit_v2_org_uid_onchain_timestamp');
+      expect(details).to.not.match(/TEMP B-TREE/i);
     });
   });
 });


### PR DESCRIPTION
## Summary

The public mainnet observer was repeatedly OOM-killed because the `/v1/audit` list endpoint built very large in-memory result sets. This makes the v1 and v2 audit list endpoints faster and lower-memory. The response shape (`{ page, pageCount, data }`) is unchanged, and default behavior is preserved.

- **Covering index** on `(orgUid, onchainConfirmationTimeStamp)` for both the v1 and v2 audit tables, so the planner does an ordered index range scan instead of materializing the org's whole history and doing a temp-B-tree sort on every request.
- **Decoupled + cached count**: `findAndCountAll` → `findAll({ raw: true })` for rows plus a short-TTL, write-invalidated per-org count cache, so deep pagination no longer re-runs an identical `COUNT(*)` on every page. An epoch guard prevents an in-flight count from caching a pre-write value.
- **`raw: true` wire-format parity**: `createdAt`/`updatedAt` are normalized back to ISO-8601 so the JSON output is byte-identical to the prior Sequelize-instance output.
- **Opt-out `excludeChange` param** to drop the heavy `change` column from rows. Default off, so existing clients are unaffected.
- **Lowered max `limit` from 10000 to 1000** to bound per-request memory.

### Behavior / compatibility notes

- The `limit` cap change is backward-incompatible for any caller passing `1001`–`10000`; such requests now return `400`. The cap is applied consistently across the shared Joi schema, the v2 controller, and the v2 model, and both API docs are updated. This affects the shared schema, so it applies to the stable v1 endpoint as well.
- `pageCount` is now eventually-consistent: it can lag the true total by at most the cache TTL (15s) in multi-process deployments or briefly around a write. This is acceptable for pagination metadata.
- On first deploy the new index is built by scanning the `audit` table; large MySQL deployments may want a brief maintenance window (consistent with the existing audit sync-index migration).

## Test plan

- [x] `npm run test:v1` — 192 passing
- [x] `npm run test:v2` — 1788 passing
- [x] `eslint` on changed files (no new violations introduced)
- [x] New tests: v1 audit endpoint integration (`excludeChange` include/exclude, limit cap 1000/1001, ISO date wire format, `EXPLAIN QUERY PLAN` index usage); extended v2 equivalents; count-cache unit tests (hit/miss, TTL expiry, write invalidation, size-cap eviction, in-flight-invalidation guard); `normalizeRawTimestamps` unit tests
- [x] New `.js` migrations validated; both run idempotently with working `down`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Backward-incompatible `limit` cap on stable v1/v2 audit APIs and eventually consistent `pageCount` from the count cache; deploy adds index builds on large audit tables.
> 
> **Overview**
> **Optimizes v1 and v2 audit history listing** to cut memory and database work while keeping the paginated JSON shape (`page`, `pageCount`, `data`) the same by default.
> 
> Both list paths now use **`findAll` with `raw: true`** instead of `findAndCountAll`, with **`normalizeRawTimestamps`** so `createdAt`/`updatedAt` stay ISO-8601 on the wire. Paginated totals come from a **per-org in-memory count cache** (15s TTL, cleared on audit writes, with a generation guard so in-flight counts are not cached after invalidation). **`excludeChange`** (optional boolean) drops the large `change` column from rows when set.
> 
> **`limit` is capped at 1000** (was 10000) in Joi, the v2 controller/model, and API docs; requests above that return **400** (breaking for callers using 1001–10000).
> 
> **New composite indexes** on audit tables for org + on-chain confirmation time support ordered pagination without a temp sort; migrations are idempotent for v1 and v2.
> 
> Integration and unit tests cover `excludeChange`, limit bounds, index usage via `EXPLAIN QUERY PLAN`, the count cache, and timestamp normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775e91761930106b7b4c31c7f6dd182a4e8d63b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->