### PR TITLE
fix: mark fallback governance sync ready

### DIFF
--- a/src/models/governance/governance.model.js
+++ b/src/models/governance/governance.model.js
@@ -199,6 +199,7 @@ class Governance extends Model {
         metaValue: JSON.stringify(PickListStub),
         confirmed: true,
       });
+      markGovernanceReady('v1');
       return;
     }
 

--- a/src/models/v2/governance-v2.model.js
+++ b/src/models/v2/governance-v2.model.js
@@ -478,6 +478,7 @@ class GovernanceV2 extends Model {
         meta_value: JSON.stringify(PickListStub),
         confirmed: true,
       });
+      markGovernanceReady('v2');
       return;
     }
 

--- a/tests/integration/orglist-subscription-reconcile-v1.spec.js
+++ b/tests/integration/orglist-subscription-reconcile-v1.spec.js
@@ -579,12 +579,12 @@ describe('orglist-subscription-reconcile (V1)', function () {
     expect(isGovernanceReady('v1')).to.equal(false);
   });
 
-  it('should clear V1 governance readiness when sync does not provide orgList', async function () {
-    markGovernanceReady('v1');
+  it('should mark V1 governance ready after fallback governance sync', async function () {
+    markGovernanceNotReady('v1');
 
     await Governance.sync();
 
-    expect(isGovernanceReady('v1')).to.equal(false);
+    expect(isGovernanceReady('v1')).to.equal(true);
   });
 
   it('should report whether a governance download included orgList', async function () {

--- a/tests/v2/integration/orglist-subscription-reconcile.spec.js
+++ b/tests/v2/integration/orglist-subscription-reconcile.spec.js
@@ -997,12 +997,12 @@ describe('orglist-subscription-reconcile (V2)', function () {
       expect(withOrgList.hasOrgList).to.equal(true);
     });
 
-    it('should clear V2 governance readiness when sync does not provide orgList', async function () {
-      markGovernanceReady('v2');
+    it('should mark V2 governance ready after fallback governance sync', async function () {
+      resetGovernanceReadiness();
 
       await GovernanceV2.sync();
 
-      expect(isGovernanceReady('v2')).to.equal(false);
+      expect(isGovernanceReady('v2')).to.equal(true);
     });
 
     it('should default ONLY_CADT_SUBSCRIPTIONS to true', function () {


### PR DESCRIPTION
## Summary
- Mark v1/v2 fallback governance sync ready after stub governance data is persisted.
- Keep orgList purge gates from staying blocked in simulator/development fallback sync paths.
- Update focused v1/v2 reconcile tests for the fallback readiness contract.

## Test plan
- `eval "$(fnm env)" && fnm use && bash tests/run-tests.sh npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31310 mocha --loader node_modules/extensionless/src/register.js tests/integration/orglist-subscription-reconcile-v1.spec.js --reporter spec --exit --timeout 300000`
- `eval "$(fnm env)" && fnm use && bash tests/run-tests.sh npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js tests/v2/integration/orglist-subscription-reconcile.spec.js --reporter spec --exit --timeout 300000`

## CI context
- Existing failed live/staging checks on PR #1653 failed in the Faucet setup step before CADT tests ran, with wallet funding timeouts and `DataLayerWallet not available`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in simulator/dev governance sync and test expectations; production paths still require orgList before marking ready.
> 
> **Overview**
> In **simulator/development** mode, v1 and v2 `Governance.sync()` / `GovernanceV2.sync()` now call **`markGovernanceReady`** after persisting the stub picklist, instead of leaving readiness cleared when no `orgList` is downloaded.
> 
> That aligns fallback sync with the **`isGovernanceReady`** gate used by **ONLY_CADT_SUBSCRIPTIONS** org-list purge/reconcile tasks, so dev/test runs are not stuck skipping off-orglist cleanup indefinitely.
> 
> V1 and V2 integration tests were updated to assert governance becomes **ready** after fallback sync rather than staying not ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df01622355a3d6e82321df4dfdf4b36d0649881f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->