### PR TITLE
fix: prevent reconcile singleton subscription dead loop

### DIFF
--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -18,7 +18,6 @@ import {
   getRoot,
   getLocalRoot,
   getSubscriptions,
-  getDataLayerStoreSyncStatus,
   pushChangeListToDataLayer,
 } from '../../datalayer/persistance.js';
 import {
@@ -990,7 +989,8 @@ class Organization extends Model {
    * @throws Error on failure. call in a try block
    */
   static async reconcileOrganization(organization, { skipOnUnsynced = false } = {}) {
-    if (USE_SIMULATOR) {
+    const { USE_SIMULATOR: useSimulator } = getConfig().APP;
+    if (useSimulator) {
       return;
     }
 
@@ -1069,7 +1069,7 @@ class Organization extends Model {
 
     let orgStatusErr;
     try {
-      const orgSyncStatus = await getDataLayerStoreSyncStatus(orgUid);
+      const orgSyncStatus = await datalayer.getDataLayerStoreSyncStatus(orgUid);
       if (!isDlStoreSynced(orgSyncStatus?.sync_status)) {
         orgStatusErr = `org store ${orgUid} not yet synced`;
       }
@@ -1081,22 +1081,55 @@ class Organization extends Model {
       return;
     }
 
-    // Check the singleton (data model version) store before the blocking fetch inside
-    // subscribeToOrganization so that an unsynced singleton doesn't stall the background task.
-    if (dataModelVersionStoreId) {
-      let singletonStatusErr;
-      try {
-        const singletonSyncStatus = await getDataLayerStoreSyncStatus(dataModelVersionStoreId);
-        if (!isDlStoreSynced(singletonSyncStatus?.sync_status)) {
-          singletonStatusErr = `singleton store ${dataModelVersionStoreId} for org ${orgUid} not yet synced`;
-        }
-      } catch (error) {
-        singletonStatusErr = `could not check sync status for singleton store ${dataModelVersionStoreId}: ${error.message}`;
+    let orgStoreData;
+    let orgDataErr;
+    try {
+      orgStoreData = await datalayer.getCurrentStoreData(orgUid);
+      if (!orgStoreData) {
+        orgDataErr = `could not get current data for org store ${orgUid}`;
       }
-      if (singletonStatusErr) {
-        skipOrThrow(singletonStatusErr);
-        return;
+    } catch (error) {
+      orgDataErr = `could not get current data for org store ${orgUid}: ${error.message}`;
+    }
+    if (orgDataErr) {
+      skipOrThrow(orgDataErr);
+      return;
+    }
+
+    // Subscribe to and check the singleton store before the blocking fetch inside
+    // subscribeToOrganization so an unsynced singleton doesn't stall the background task.
+    const singletonStoreId = orgStoreData?.registryId || dataModelVersionStoreId;
+    if (!singletonStoreId) {
+      skipOrThrow(`could not determine singleton store for org ${orgUid}`);
+      return;
+    }
+
+    let singletonSubscribeErr;
+    try {
+      const singletonSubscribed = await datalayer.subscribeToStoreOnDataLayer(singletonStoreId);
+      if (!singletonSubscribed) {
+        singletonSubscribeErr = `could not subscribe to singleton store ${singletonStoreId} for org ${orgUid}`;
       }
+    } catch (error) {
+      singletonSubscribeErr = `could not subscribe to singleton store ${singletonStoreId} for org ${orgUid}: ${error.message}`;
+    }
+    if (singletonSubscribeErr) {
+      skipOrThrow(singletonSubscribeErr);
+      return;
+    }
+
+    let singletonStatusErr;
+    try {
+      const singletonSyncStatus = await datalayer.getDataLayerStoreSyncStatus(singletonStoreId);
+      if (!isDlStoreSynced(singletonSyncStatus?.sync_status)) {
+        singletonStatusErr = `singleton store ${singletonStoreId} for org ${orgUid} not yet synced`;
+      }
+    } catch (error) {
+      singletonStatusErr = `could not check sync status for singleton store ${singletonStoreId}: ${error.message}`;
+    }
+    if (singletonStatusErr) {
+      skipOrThrow(singletonStatusErr);
+      return;
     }
 
     logger.debug(
@@ -1157,7 +1190,7 @@ class Organization extends Model {
     }
 
     // note that we only update the data model version store hash here because the other two store hashes are updated elsewhere
-    const dataModelVersionStoreSyncStatus = await getDataLayerStoreSyncStatus(
+    const dataModelVersionStoreSyncStatus = await datalayer.getDataLayerStoreSyncStatus(
       datalayerDataModelVersionStoreId,
     );
 
@@ -1775,7 +1808,7 @@ class Organization extends Model {
           }
 
           try {
-            const syncStatus = await getDataLayerStoreSyncStatus(organization.orgUid);
+            const syncStatus = await datalayer.getDataLayerStoreSyncStatus(organization.orgUid);
             if (!isDlStoreSynced(syncStatus?.sync_status)) {
               logger.info(
                 `[v1]: syncOrganizationMeta: org store ${organization.orgUid} not yet synced, skipping this run.`,

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -1441,11 +1441,12 @@ class OrganizationsV2 extends Model {
    */
   static async getRegistryStoreIdFromSingleton(dataModelVersionStoreId, requiredVersion = 'v2') {
     loggerV2.debug(`[v2]: Getting registry store ID from singleton ${dataModelVersionStoreId}, required version: ${requiredVersion}`);
+    const { USE_SIMULATOR: useSimulator } = getConfig().APP;
 
     // Get singleton data - use getStoreDataPromise in simulator mode, getSubscribedStoreData otherwise
     let singletonData = null;
 
-    if (USE_SIMULATOR) {
+    if (useSimulator) {
       // In simulator mode, use getStoreDataPromise directly (no subscription needed)
       const storeData = await getStoreDataPromise(dataModelVersionStoreId);
       if (storeData && storeData.keys_values) {
@@ -1508,6 +1509,7 @@ class OrganizationsV2 extends Model {
       loggerV2.info('[v2]: cannot subscribe to a home organization while its pending.');
       throw new Error('Cannot subscribe to PENDING organization');
     }
+    const { USE_SIMULATOR: useSimulator } = getConfig().APP;
 
     loggerV2.debug(`[v2]: Running the organization subscription process on organization ${orgUid}`);
 
@@ -1524,7 +1526,7 @@ class OrganizationsV2 extends Model {
     loggerV2.debug(`[v2]: Determining datamodel version singleton id for org ${orgUid}`);
     let orgStoreData = null;
 
-    if (USE_SIMULATOR) {
+    if (useSimulator) {
       // In simulator mode, use getStoreDataPromise directly
       const storeData = await getStoreDataPromise(orgUid);
       if (storeData && storeData.keys_values) {
@@ -1582,7 +1584,7 @@ class OrganizationsV2 extends Model {
       await datalayer.subscribeToStoreOnDataLayer(registryStoreId);
     // In simulator mode, subscribeToStoreOnDataLayer returns undefined (no-op)
     // In production mode, it returns true/false
-    if (!USE_SIMULATOR && !subscribedToRegistryStore) {
+    if (!useSimulator && !subscribedToRegistryStore) {
       throw new Error(
         `Failed to subscribe to or validate subscription for registry store ${registryStoreId}`,
       );
@@ -1952,16 +1954,20 @@ class OrganizationsV2 extends Model {
    *   throwing, never silently skipping — otherwise a datalayer hiccup causes
    *   data deletion without reconciliation.
    * @returns {Promise<void>}
-   * @throws When `skipOnUnsynced` is false and any of: the org store subscribe
-   *   fails, the org or singleton store is unsynced, or a sync-status RPC fails.
+   * @throws When `skipOnUnsynced` is false and any of: the org or singleton
+   *   store subscribe fails, org-store data is unavailable, either store is
+   *   unsynced, or a sync-status RPC fails.
    */
   static async reconcileOrganization(organization, { skipOnUnsynced = false } = {}) {
     const { org_uid, is_home, data_model_version_store_id } = organization;
+    // Tests override config at call time; module-level callers keep their
+    // import-time behavior.
+    const { USE_SIMULATOR: useSimulator } = getConfig().APP;
 
     loggerV2.info(`[v2]: Reconciling organization ${org_uid}`);
 
     // Validate store ownership if home org (skip in simulator mode)
-    if (is_home && !USE_SIMULATOR) {
+    if (is_home && !useSimulator) {
       try {
         await assertStoreIsOwned(org_uid);
       } catch {
@@ -1990,7 +1996,8 @@ class OrganizationsV2 extends Model {
     // errors, so guard on both.  Without the falsy-return check, the dominant
     // datalayer-unreachable failure would slip past the try/catch and the
     // subsequent "not yet synced" skip log would be misleading.
-    if (!USE_SIMULATOR) {
+    let orgData;
+    if (!useSimulator) {
       let subscribeErr;
       try {
         const subscribed = await datalayer.subscribeToStoreOnDataLayer(org_uid);
@@ -2019,20 +2026,52 @@ class OrganizationsV2 extends Model {
         return;
       }
 
-      if (data_model_version_store_id) {
-        let singletonStatusErr;
-        try {
-          const singletonSyncStatus = await datalayer.getDataLayerStoreSyncStatus(data_model_version_store_id);
-          if (!isDlStoreSynced(singletonSyncStatus?.sync_status)) {
-            singletonStatusErr = `singleton store ${data_model_version_store_id} for org ${org_uid} not yet synced`;
-          }
-        } catch (error) {
-          singletonStatusErr = `could not check sync status for singleton store ${data_model_version_store_id}: ${error.message}`;
+      let orgDataErr;
+      try {
+        orgData = await datalayer.getCurrentStoreData(org_uid);
+        if (!orgData) {
+          orgDataErr = `could not get current data for org store ${org_uid}`;
         }
-        if (singletonStatusErr) {
-          skipOrThrow(singletonStatusErr);
-          return;
+      } catch (error) {
+        orgDataErr = `could not get current data for org store ${org_uid}: ${error.message}`;
+      }
+      if (orgDataErr) {
+        skipOrThrow(orgDataErr);
+        return;
+      }
+
+      const singletonStoreId = orgData?.registryId || data_model_version_store_id;
+      if (!singletonStoreId) {
+        skipOrThrow(`could not determine singleton store for org ${org_uid}`);
+        return;
+      }
+
+      let singletonSubscribeErr;
+      try {
+        const singletonSubscribed = await datalayer.subscribeToStoreOnDataLayer(singletonStoreId);
+        if (!singletonSubscribed) {
+          singletonSubscribeErr = `could not subscribe to singleton store ${singletonStoreId} for org ${org_uid}`;
         }
+      } catch (error) {
+        singletonSubscribeErr = `could not subscribe to singleton store ${singletonStoreId} for org ${org_uid}: ${error.message}`;
+      }
+      if (singletonSubscribeErr) {
+        skipOrThrow(singletonSubscribeErr);
+        return;
+      }
+
+      let singletonStatusErr;
+      try {
+        const singletonSyncStatus = await datalayer.getDataLayerStoreSyncStatus(singletonStoreId);
+        if (!isDlStoreSynced(singletonSyncStatus?.sync_status)) {
+          singletonStatusErr = `singleton store ${singletonStoreId} for org ${org_uid} not yet synced`;
+        }
+      } catch (error) {
+        singletonStatusErr = `could not check sync status for singleton store ${singletonStoreId}: ${error.message}`;
+      }
+      if (singletonStatusErr) {
+        skipOrThrow(singletonStatusErr);
+        return;
       }
     }
 
@@ -2040,8 +2079,7 @@ class OrganizationsV2 extends Model {
     const storeIds = await OrganizationsV2.subscribeToOrganization(org_uid);
 
     // Get current data from datalayer
-    let orgData;
-    if (USE_SIMULATOR) {
+    if (useSimulator) {
       // In simulator mode, use getStoreDataPromise directly
       const storeData = await getStoreDataPromise(org_uid);
       if (storeData && storeData.keys_values) {
@@ -2054,8 +2092,7 @@ class OrganizationsV2 extends Model {
         throw new Error(`Failed to get organization data for ${org_uid} in simulator mode`);
       }
     } else {
-      // In production mode, use getCurrentStoreData
-      orgData = await datalayer.getCurrentStoreData(org_uid);
+      // Production pre-checks already fetched current org-store data.
       if (!orgData) {
         throw new Error(`Failed to get organization data for ${org_uid}`);
       }
@@ -2098,7 +2135,7 @@ class OrganizationsV2 extends Model {
 
     // Update data_model_version_store_hash if store is synced
     // Skip in simulator mode as there's no real datalayer
-    if (!USE_SIMULATOR) {
+    if (!useSimulator) {
       const dataModelVersionStoreSyncStatus = await datalayer.getDataLayerStoreSyncStatus(
         storeIds.dataModelVersionStoreId,
       );

--- a/tests/v2/integration/reconcile-unsynced-stores.spec.js
+++ b/tests/v2/integration/reconcile-unsynced-stores.spec.js
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
 import { OrganizationsV2 } from '../../../src/models/v2/index.js';
 import { Organization } from '../../../src/models/organizations/organizations.model.js';
 import { prepareDb } from '../../../src/database/index.js';
 import TaskManager from '../../../src/tasks/index.js';
+import { withConfigOverride } from '../utils/v2-test-helpers.js';
 
 /**
  * Reconcile Unsynced Stores Tests
@@ -12,10 +14,9 @@ import TaskManager from '../../../src/tasks/index.js';
  * complete quickly in the test environment (simulator mode).
  *
  * The sync pre-check guards (subscribe → getDataLayerStoreSyncStatus →
- * skip if unsynced) are wrapped in `if (!USE_SIMULATOR)` so they only
- * run in production.  The production-mode paths are exercised by the
- * live integration tests; these unit tests cover the simulator fast-path
- * and method-contract assertions.
+ * skip if unsynced) only run outside simulator mode. V1 returns early
+ * at the start of reconcileOrganization; V2 wraps the pre-check block in
+ * `if (!USE_SIMULATOR)`.
  *
  * The `{ skipOnUnsynced }` option controls whether the pre-check path
  * silently returns (background tasks: true) or throws (request-path
@@ -23,11 +24,13 @@ import TaskManager from '../../../src/tasks/index.js';
  * Throwing on the default matters because request-path callers run
  * destructive writes (reset registry_hash, delete audit records) after
  * reconcile and must not proceed on stale state.  Option semantics are
- * verified here by signature checks; the production throw/skip behavior
- * is covered by live tests.
+ * verified here by signature checks and focused production-mode stubs.
  */
 describe('Reconcile Unsynced Stores', function () {
   this.timeout(30000);
+
+  let originalUseSimulator;
+  let originalUseDevMode;
 
   before(async function () {
     await prepareDb();
@@ -35,9 +38,36 @@ describe('Reconcile Unsynced Stores', function () {
     TaskManager.stopAll();
   });
 
+  beforeEach(function () {
+    originalUseSimulator = process.env.USE_SIMULATOR;
+    originalUseDevMode = process.env.USE_DEVELOPMENT_MODE;
+  });
+
   afterEach(async function () {
+    sinon.restore();
+    if (originalUseSimulator !== undefined) {
+      process.env.USE_SIMULATOR = originalUseSimulator;
+    } else {
+      delete process.env.USE_SIMULATOR;
+    }
+    if (originalUseDevMode !== undefined) {
+      process.env.USE_DEVELOPMENT_MODE = originalUseDevMode;
+    } else {
+      delete process.env.USE_DEVELOPMENT_MODE;
+    }
     await OrganizationsV2.destroy({ where: {} });
   });
+
+  const withProductionConfig = async (testFn) => {
+    delete process.env.USE_SIMULATOR;
+    delete process.env.USE_DEVELOPMENT_MODE;
+
+    // Reconcile reads USE_SIMULATOR at call time; tests still stub downstream
+    // subscription helpers whose modules keep the import-time simulator mode.
+    return await withConfigOverride(testFn, {
+      APP: { USE_SIMULATOR: false, USE_DEVELOPMENT_MODE: false },
+    });
+  };
 
   // ─────────────────────────────────────────────────────────
   // V1 reconcileOrganization
@@ -96,6 +126,613 @@ describe('Reconcile Unsynced Stores', function () {
       }
       expect(threw).to.be.false;
     });
+
+    it('returns cleanly when the singleton subscribe returns falsy and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-subscribe-org-v1';
+      const singletonStoreId = 'reconcile-subscribe-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).resolves(false);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        await Organization.reconcileOrganization(
+          {
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        const orgSubscribe = subscribeStub
+          .getCalls()
+          .find((call) => call.args[0] === orgUid);
+        const singletonSubscribe = subscribeStub
+          .getCalls()
+          .find((call) => call.args[0] === singletonStoreId);
+
+        expect(orgSubscribe, 'org-store subscribe must run').to.exist;
+        expect(singletonSubscribe, 'singleton-store subscribe must run').to.exist;
+        expect(orgSubscribe.calledBefore(singletonSubscribe)).to.equal(
+          true,
+          'singleton subscribe must run after the org pre-check',
+        );
+        const singletonStatusCalled = syncStatusStub
+          .getCalls()
+          .some((call) => call.args[0] === singletonStoreId);
+        expect(singletonStatusCalled).to.equal(
+          false,
+          'singleton status check must be skipped when singleton subscribe fails',
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe fails',
+        );
+      });
+    });
+
+    it('returns cleanly when the singleton subscribe throws and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-subscribe-throw-org-v1';
+      const singletonStoreId = 'reconcile-subscribe-throw-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).rejects(new Error('datalayer unavailable'));
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        await Organization.reconcileOrganization(
+          {
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        const singletonStatusCalled = syncStatusStub
+          .getCalls()
+          .some((call) => call.args[0] === singletonStoreId);
+        expect(singletonStatusCalled).to.equal(
+          false,
+          'singleton status check must be skipped when singleton subscribe throws',
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe throws',
+        );
+      });
+    });
+
+    it('throws when the singleton subscribe returns falsy and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-throw-org-v1';
+      const singletonStoreId = 'reconcile-throw-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).resolves(false);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await Organization.reconcileOrganization({
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not subscribe to singleton store ${singletonStoreId} for org ${orgUid}`,
+        );
+        const singletonStatusCalled = syncStatusStub
+          .getCalls()
+          .some((call) => call.args[0] === singletonStoreId);
+        expect(singletonStatusCalled).to.equal(
+          false,
+          'singleton status check must be skipped when singleton subscribe fails',
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe fails',
+        );
+      });
+    });
+
+    it('throws when the singleton subscribe throws and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-throw-error-org-v1';
+      const singletonStoreId = 'reconcile-throw-error-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).rejects(new Error('datalayer unavailable'));
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await Organization.reconcileOrganization({
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not subscribe to singleton store ${singletonStoreId} for org ${orgUid}: datalayer unavailable`,
+        );
+        const singletonStatusCalled = syncStatusStub
+          .getCalls()
+          .some((call) => call.args[0] === singletonStoreId);
+        expect(singletonStatusCalled).to.equal(
+          false,
+          'singleton status check must be skipped when singleton subscribe throws',
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe throws',
+        );
+      });
+    });
+
+    it('returns cleanly when org store data is unavailable and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-org-data-missing-v1';
+      const singletonStoreId = 'org-data-missing-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves(null);
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        await Organization.reconcileOrganization(
+          {
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('throws when org store data fetch fails and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-org-data-error-v1';
+      const singletonStoreId = 'org-data-error-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .rejects(new Error('datalayer unavailable'));
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await Organization.reconcileOrganization({
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not get current data for org store ${orgUid}: datalayer unavailable`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('returns cleanly when no singleton id can be determined and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-missing-singleton-skip-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ name: 'org data without registryId' });
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        await Organization.reconcileOrganization(
+          {
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: null,
+            isHome: false,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        expect(subscribeStub.calledOnceWithExactly(orgUid)).to.equal(true);
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('throws when no singleton id can be determined and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-missing-singleton-throw-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ name: 'org data without registryId' });
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await Organization.reconcileOrganization({
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: null,
+            isHome: false,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not determine singleton store for org ${orgUid}`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('returns cleanly when the singleton store is unsynced and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-unsynced-skip-org-v1';
+      const singletonStoreId = 'reconcile-unsynced-skip-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon.stub(datalayerModule.default, 'subscribeToStoreOnDataLayer').resolves(true);
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        syncStatusStub
+          .withArgs(singletonStoreId)
+          .resolves({ sync_status: { generation: 0, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        await Organization.reconcileOrganization(
+          {
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('throws when the singleton store is unsynced and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-unsynced-throw-org-v1';
+      const singletonStoreId = 'reconcile-unsynced-throw-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon.stub(datalayerModule.default, 'subscribeToStoreOnDataLayer').resolves(true);
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        syncStatusStub
+          .withArgs(singletonStoreId)
+          .resolves({ sync_status: { generation: 0, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+        const subscribeToOrganizationStub = sinon.stub(
+          Organization,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await Organization.reconcileOrganization({
+            orgUid,
+            name: 'V1 Org',
+            registryId: 'registry-v1',
+            dataModelVersionStoreId: singletonStoreId,
+            isHome: false,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `singleton store ${singletonStoreId} for org ${orgUid} not yet synced`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('falls back to the database singleton id when org store data has no registryId', async function () {
+      const orgUid = 'reconcile-fallback-org-v1';
+      const singletonStoreId = 'fallback-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .resolves(true);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        syncStatusStub
+          .withArgs(singletonStoreId)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ name: 'org data without registryId' });
+
+        const subscribeToOrganizationStub = sinon
+          .stub(Organization, 'subscribeToOrganization')
+          .rejects(new Error('stop after fallback pre-checks'));
+
+        let error = null;
+        try {
+          await Organization.reconcileOrganization(
+            {
+              orgUid,
+              name: 'V1 Org',
+              registryId: 'registry-v1',
+              dataModelVersionStoreId: singletonStoreId,
+              isHome: false,
+            },
+            { skipOnUnsynced: true },
+          );
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(subscribeToOrganizationStub.calledOnceWithExactly(orgUid)).to.equal(true);
+        expect(subscribeStub.calledWith(singletonStoreId)).to.equal(
+          true,
+          'singleton pre-check must fall back to the database singleton id',
+        );
+        expect(syncStatusStub.calledWith(singletonStoreId)).to.equal(true);
+      });
+    });
+
+    it('reaches subscribeToOrganization after org-derived singleton pre-checks pass', async function () {
+      const orgUid = 'reconcile-happy-org-v1';
+      const staleSingletonStoreId = 'stale-singleton-v1';
+      const singletonStoreId = 'org-derived-singleton-v1';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .resolves(true);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        syncStatusStub
+          .withArgs(singletonStoreId)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon
+          .stub(Organization, 'subscribeToOrganization')
+          .rejects(new Error('stop after pre-checks'));
+
+        let error = null;
+        try {
+          await Organization.reconcileOrganization(
+            {
+              orgUid,
+              name: 'V1 Org',
+              registryId: 'registry-v1',
+              dataModelVersionStoreId: staleSingletonStoreId,
+              isHome: false,
+            },
+            { skipOnUnsynced: true },
+          );
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(subscribeToOrganizationStub.calledOnceWithExactly(orgUid)).to.equal(true);
+        expect(subscribeStub.calledWith(singletonStoreId)).to.equal(
+          true,
+          'singleton pre-check must use the org-store-derived singleton id',
+        );
+        expect(subscribeStub.calledWith(staleSingletonStoreId)).to.equal(false);
+      });
+    });
   });
 
   // ─────────────────────────────────────────────────────────
@@ -145,6 +782,617 @@ describe('Reconcile Unsynced Stores', function () {
       }
       expect(Date.now() - start).to.be.below(1000, 'simulator mode should fail fast for unknown store');
       expect(error).to.exist;
+    });
+
+    it('subscribes to the singleton store before checking singleton sync status', async function () {
+      const orgUid = 'reconcile-subscribe-org-v2';
+      const singletonStoreId = 'reconcile-subscribe-singleton-v2';
+
+      await withProductionConfig(
+        async () => {
+          const datalayerModule = await import('../../../src/datalayer/index.js');
+          let singletonSubscribeResolved = false;
+          let singletonStatusSawResolvedSubscribe = false;
+          const subscribeStub = sinon
+            .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+            .callsFake(async (storeId) => {
+              if (storeId === singletonStoreId) {
+                await Promise.resolve();
+                singletonSubscribeResolved = true;
+              }
+              return true;
+            });
+          const syncStatusStub = sinon
+            .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+            .callsFake(async (storeId) => {
+              if (storeId === singletonStoreId) {
+                singletonStatusSawResolvedSubscribe = singletonSubscribeResolved;
+                return { sync_status: { generation: 0, target_generation: 1 } };
+              }
+              return { sync_status: { generation: 1, target_generation: 1 } };
+            });
+          sinon
+            .stub(datalayerModule.default, 'getCurrentStoreData')
+            .withArgs(orgUid)
+            .resolves({ registryId: singletonStoreId });
+
+          const subscribeToOrganizationStub = sinon.stub(
+            OrganizationsV2,
+            'subscribeToOrganization',
+          );
+
+          await OrganizationsV2.reconcileOrganization(
+            {
+              org_uid: orgUid,
+              is_home: false,
+              data_model_version_store_id: singletonStoreId,
+            },
+            { skipOnUnsynced: true },
+          );
+
+          const orgSubscribe = subscribeStub
+            .getCalls()
+            .find((call) => call.args[0] === orgUid);
+          const singletonSubscribe = subscribeStub
+            .getCalls()
+            .find((call) => call.args[0] === singletonStoreId);
+          const orgStatus = syncStatusStub
+            .getCalls()
+            .find((call) => call.args[0] === orgUid);
+          const singletonStatus = syncStatusStub
+            .getCalls()
+            .find((call) => call.args[0] === singletonStoreId);
+
+          expect(orgSubscribe, 'org-store subscribe must run').to.exist;
+          expect(orgStatus, 'org-store status check must run').to.exist;
+          expect(singletonSubscribe, 'singleton-store subscribe must run').to.exist;
+          expect(singletonStatus, 'singleton-store status check must run').to.exist;
+          expect(orgSubscribe.calledBefore(orgStatus)).to.equal(
+            true,
+            'org subscribe must run before org status check',
+          );
+          expect(orgStatus.calledBefore(singletonSubscribe)).to.equal(
+            true,
+            'singleton subscribe must run after the org is synced',
+          );
+          expect(singletonSubscribe.calledBefore(singletonStatus)).to.equal(
+            true,
+            'singleton subscribe must run before singleton status check',
+          );
+          expect(singletonStatusSawResolvedSubscribe).to.equal(
+            true,
+            'singleton subscribe must resolve before singleton status check',
+          );
+          expect(subscribeToOrganizationStub.called).to.equal(
+            false,
+            'subscribeToOrganization must not run while singleton store is unsynced',
+          );
+        },
+      );
+    });
+
+    it('returns cleanly when the singleton subscribe returns falsy and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-subscribe-false-org-v2';
+      const singletonStoreId = 'reconcile-subscribe-false-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).resolves(false);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        await OrganizationsV2.reconcileOrganization(
+          {
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: singletonStoreId,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        const singletonStatusCalled = syncStatusStub
+          .getCalls()
+          .some((call) => call.args[0] === singletonStoreId);
+        expect(singletonStatusCalled).to.equal(
+          false,
+          'singleton status check must be skipped when singleton subscribe fails',
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe fails',
+        );
+      });
+    });
+
+    it('throws when the singleton subscribe returns falsy and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-subscribe-false-throw-org-v2';
+      const singletonStoreId = 'reconcile-subscribe-false-throw-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).resolves(false);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await OrganizationsV2.reconcileOrganization({
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: singletonStoreId,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not subscribe to singleton store ${singletonStoreId} for org ${orgUid}`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe fails',
+        );
+      });
+    });
+
+    it('returns cleanly when the singleton subscribe throws and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-subscribe-throw-org-v2';
+      const singletonStoreId = 'reconcile-subscribe-throw-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).rejects(new Error('datalayer unavailable'));
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        await OrganizationsV2.reconcileOrganization(
+          {
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: singletonStoreId,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        const singletonStatusCalled = syncStatusStub
+          .getCalls()
+          .some((call) => call.args[0] === singletonStoreId);
+        expect(singletonStatusCalled).to.equal(
+          false,
+          'singleton status check must be skipped when singleton subscribe throws',
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe throws',
+        );
+      });
+    });
+
+    it('throws when the singleton subscribe throws and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-subscribe-error-throw-org-v2';
+      const singletonStoreId = 'reconcile-subscribe-error-throw-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon.stub(
+          datalayerModule.default,
+          'subscribeToStoreOnDataLayer',
+        );
+        subscribeStub.withArgs(orgUid).resolves(true);
+        subscribeStub.withArgs(singletonStoreId).rejects(new Error('datalayer unavailable'));
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await OrganizationsV2.reconcileOrganization({
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: singletonStoreId,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not subscribe to singleton store ${singletonStoreId} for org ${orgUid}: datalayer unavailable`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run when singleton subscribe throws',
+        );
+      });
+    });
+
+    it('throws when the singleton store is unsynced and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-unsynced-throw-org-v2';
+      const singletonStoreId = 'reconcile-unsynced-throw-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .resolves(true);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        syncStatusStub
+          .withArgs(singletonStoreId)
+          .resolves({ sync_status: { generation: 0, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await OrganizationsV2.reconcileOrganization({
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: singletonStoreId,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `singleton store ${singletonStoreId} for org ${orgUid} not yet synced`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(
+          false,
+          'subscribeToOrganization must not run while singleton store is unsynced',
+        );
+      });
+    });
+
+    it('returns cleanly when org store data is unavailable and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-org-data-missing-v2';
+      const singletonStoreId = 'org-data-missing-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves(null);
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        await OrganizationsV2.reconcileOrganization(
+          {
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: singletonStoreId,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('throws when org store data fetch fails and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-org-data-error-v2';
+      const singletonStoreId = 'org-data-error-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .rejects(new Error('datalayer unavailable'));
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await OrganizationsV2.reconcileOrganization({
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: singletonStoreId,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not get current data for org store ${orgUid}: datalayer unavailable`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('returns cleanly when no singleton id can be determined and skipOnUnsynced is true', async function () {
+      const orgUid = 'reconcile-missing-singleton-skip-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ name: 'org data without registryId' });
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        await OrganizationsV2.reconcileOrganization(
+          {
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: null,
+          },
+          { skipOnUnsynced: true },
+        );
+
+        expect(subscribeStub.calledOnceWithExactly(orgUid)).to.equal(true);
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('throws when no singleton id can be determined and skipOnUnsynced is false', async function () {
+      const orgUid = 'reconcile-missing-singleton-throw-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .withArgs(orgUid)
+          .resolves(true);
+        sinon
+          .stub(datalayerModule.default, 'getDataLayerStoreSyncStatus')
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ name: 'org data without registryId' });
+        const subscribeToOrganizationStub = sinon.stub(
+          OrganizationsV2,
+          'subscribeToOrganization',
+        );
+
+        let error = null;
+        try {
+          await OrganizationsV2.reconcileOrganization({
+            org_uid: orgUid,
+            is_home: false,
+            data_model_version_store_id: null,
+          });
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(error.message).to.include(
+          `could not determine singleton store for org ${orgUid}`,
+        );
+        expect(subscribeToOrganizationStub.called).to.equal(false);
+      });
+    });
+
+    it('falls back to the database singleton id when org store data has no registryId', async function () {
+      const orgUid = 'reconcile-fallback-org-v2';
+      const singletonStoreId = 'fallback-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .resolves(true);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        syncStatusStub
+          .withArgs(singletonStoreId)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ name: 'org data without registryId' });
+
+        const subscribeToOrganizationStub = sinon
+          .stub(OrganizationsV2, 'subscribeToOrganization')
+          .rejects(new Error('stop after fallback pre-checks'));
+
+        let error = null;
+        try {
+          await OrganizationsV2.reconcileOrganization(
+            {
+              org_uid: orgUid,
+              is_home: false,
+              data_model_version_store_id: singletonStoreId,
+            },
+            { skipOnUnsynced: true },
+          );
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(subscribeToOrganizationStub.calledOnceWithExactly(orgUid)).to.equal(true);
+        expect(subscribeStub.calledWith(singletonStoreId)).to.equal(
+          true,
+          'singleton pre-check must fall back to the database singleton id',
+        );
+        expect(syncStatusStub.calledWith(singletonStoreId)).to.equal(true);
+      });
+    });
+
+    it('reaches subscribeToOrganization after org-derived singleton pre-checks pass', async function () {
+      const orgUid = 'reconcile-happy-org-v2';
+      const staleSingletonStoreId = 'stale-singleton-v2';
+      const singletonStoreId = 'org-derived-singleton-v2';
+
+      await withProductionConfig(async () => {
+        const datalayerModule = await import('../../../src/datalayer/index.js');
+        const subscribeStub = sinon
+          .stub(datalayerModule.default, 'subscribeToStoreOnDataLayer')
+          .resolves(true);
+
+        const syncStatusStub = sinon.stub(
+          datalayerModule.default,
+          'getDataLayerStoreSyncStatus',
+        );
+        syncStatusStub
+          .withArgs(orgUid)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        syncStatusStub
+          .withArgs(singletonStoreId)
+          .resolves({ sync_status: { generation: 1, target_generation: 1 } });
+        sinon
+          .stub(datalayerModule.default, 'getCurrentStoreData')
+          .withArgs(orgUid)
+          .resolves({ registryId: singletonStoreId });
+
+        const subscribeToOrganizationStub = sinon
+          .stub(OrganizationsV2, 'subscribeToOrganization')
+          .rejects(new Error('stop after pre-checks'));
+
+        let error = null;
+        try {
+          await OrganizationsV2.reconcileOrganization(
+            {
+              org_uid: orgUid,
+              is_home: false,
+              data_model_version_store_id: staleSingletonStoreId,
+            },
+            { skipOnUnsynced: true },
+          );
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.exist;
+        expect(subscribeToOrganizationStub.calledOnceWithExactly(orgUid)).to.equal(true);
+        expect(subscribeStub.calledWith(singletonStoreId)).to.equal(
+          true,
+          'singleton pre-check must use the org-store-derived singleton id',
+        );
+        expect(subscribeStub.calledWith(staleSingletonStoreId)).to.equal(false);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Subscribe to the resolved data-model-version singleton store before checking its sync status during V1/V2 organization reconcile.
- Resolve the singleton id from live org-store data first, with DB fallback, and preserve skip-vs-throw behavior for background versus request paths.
- Add focused V1/V2 regression coverage for subscribe failures, unsynced stores, missing org data, missing singleton ids, and stale DB singleton ids.

## Test plan
- `npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js 'tests/v2/integration/reconcile-unsynced-stores.spec.js' --reporter spec --exit --timeout 300000`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core org reconciliation used by background tasks and request-path resync; behavior changes when singleton ids are stale or stores are unsynced, though skip/throw semantics are preserved and heavily tested.
> 
> **Overview**
> **V1 and V2 `reconcileOrganization`** now load current org-store data, resolve the data-model-version singleton from live `registryId` (with DB fallback), **subscribe to that singleton**, and only then check its sync status—before the blocking `subscribeToOrganization` path. That replaces checking sync on the DB singleton id alone, which could leave the singleton unsubscribed and stall or loop background reconcile.
> 
> Sync-status calls go through **`datalayer.getDataLayerStoreSyncStatus`**; **`USE_SIMULATOR`** is read at reconcile time so tests can override config. V2 reuses the org data fetched during pre-checks instead of calling `getCurrentStoreData` again in production.
> 
> **`reconcile-unsynced-stores.spec.js`** adds production-mode stubs for subscribe failures, missing org data, missing singleton ids, unsynced singletons, stale DB singleton ids, and `skipOnUnsynced` skip vs throw behavior for both models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5907d49b756850ac3bb837187a0d57455fa7da44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->