### PR TITLE
fix: normalize default fee and coin fallback constants

### DIFF
--- a/src/controllers/offer.controller.js
+++ b/src/controllers/offer.controller.js
@@ -97,7 +97,7 @@ export const importOfferFile = async (req, res) => {
     const offerFileBuffer = req.file.buffer;
     const offerFile = offerFileBuffer.toString('utf-8');
     const offerParsed = JSON.parse(offerFile);
-    offerParsed.fee = _.get(CONFIG, 'DEFAULT_FEE', 300000000);
+    offerParsed.fee = _.get(CONFIG, 'DEFAULT_FEE', 3000);
     delete offerParsed.success;
     const offerJSON = JSON.stringify(offerParsed);
 

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -329,8 +329,8 @@ const addMirrorInner = async (storeId, url, forceAddMirror) => {
   }
 
   try {
-    const coinAmount = _.get(CONFIG, 'DEFAULT_COIN_AMOUNT', 300000000);
-    const defaultFee = _.get(CONFIG, 'DEFAULT_FEE', 300000000);
+    const coinAmount = _.get(CONFIG, 'DEFAULT_COIN_AMOUNT', 300);
+    const defaultFee = _.get(CONFIG, 'DEFAULT_FEE', 3000);
 
     // Check wallet balance before creating mirror
     const balanceCheck = await checkWalletBalanceForMirror(
@@ -414,7 +414,7 @@ const removeMirror = async (storeId, coinId) => {
       .timeout(timeout)
       .send({
         id: coinId,
-        fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+        fee: _.get(CONFIG, 'DEFAULT_FEE', 3000),
       });
 
     const data = response.body;
@@ -507,7 +507,7 @@ const unsubscribeFromDataLayerStore = async (storeId) => {
       .timeout(timeout)
       .send({
         id: storeId,
-        fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+        fee: _.get(CONFIG, 'DEFAULT_FEE', 3000),
       });
 
     const data = response.body;
@@ -756,7 +756,7 @@ const pushChangeListToDataLayer = async (
         url,
         storeId,
         changelistLength: changelist.length,
-        fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+        fee: _.get(CONFIG, 'DEFAULT_FEE', 3000),
       });
 
       const response = await superagent
@@ -767,7 +767,7 @@ const pushChangeListToDataLayer = async (
         .send({
           changelist,
           id: storeId,
-          fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+          fee: _.get(CONFIG, 'DEFAULT_FEE', 3000),
         });
 
       const data = response.body;
@@ -931,7 +931,7 @@ const createDataLayerStore = async () => {
       .cert(cert)
       .timeout(timeout)
       .send({
-        fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+        fee: _.get(CONFIG, 'DEFAULT_FEE', 3000),
         verbose: true,
       });
 
@@ -984,7 +984,7 @@ const subscribeToStoreOnDataLayer = async (storeId) => {
       .timeout(timeout)
       .send({
         id: storeId,
-        fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+        fee: _.get(CONFIG, 'DEFAULT_FEE', 3000),
       });
 
     const data = response.body;
@@ -1195,7 +1195,7 @@ const cancelOffer = async (tradeId) => {
       .send({
         trade_id: tradeId,
         secure: true,
-        fee: _.get(CONFIG, 'DEFAULT_FEE', 300000000),
+        fee: _.get(CONFIG, 'DEFAULT_FEE', 3000),
       });
 
     const data = response.body;

--- a/src/models/v2/offer-v2.model.js
+++ b/src/models/v2/offer-v2.model.js
@@ -361,7 +361,7 @@ class OfferV2 {
       const offerParsed = JSON.parse(offerFile);
 
       // Set default fee
-      offerParsed.fee = _.get(CONFIG, 'DEFAULT_FEE', 300000000);
+      offerParsed.fee = _.get(CONFIG, 'DEFAULT_FEE', 3000);
       delete offerParsed.success;
       const offerJSON = JSON.stringify(offerParsed);
 


### PR DESCRIPTION
## Summary
- Align the `DEFAULT_FEE` / `DEFAULT_COIN_AMOUNT` fallback literals in `persistance.js`, `offer.controller.js`, and `offer-v2.model.js` to the canonical defaults (`3000` fee, `300` coin amount).
- Previously these `_.get(CONFIG, ..., 300000000)` fallbacks disagreed with `src/utils/defaultConfig.js` and the matching fallbacks already used in `wallet.js`, `coin-management.js`, and `diagnostics.js`.
- Behavior is unchanged for normal operation (the config loader always merges `defaultConfig`, so the fallback only applies if the key is missing); this purely removes the 5-orders-of-magnitude inconsistency.

## Test plan
- [ ] CI green (lint, integration, live API)
- Static: `node --check` passes on all three changed files; repo-wide search confirms no remaining `300000000` fee/coin fallback literals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Literal-only alignment with existing canonical defaults; no change when merged config is present, but missing-key edge cases would now use correct mojos amounts for DataLayer fees and mirror funding.
> 
> **Overview**
> Aligns **`DEFAULT_FEE`** and **`DEFAULT_COIN_AMOUNT`** `_.get(CONFIG, …)` fallbacks with **`defaultConfig.js`** (`3000` fee, `300` coin amount) instead of the old `300000000` literals.
> 
> Updates fallbacks in **`persistance.js`** (mirrors, unsubscribe, batch updates, store creation, subscribe, cancel offer, mirror balance checks), **`offer.controller.js`** (import offer), and **`offer-v2.model.js`** (import offer) so they match **`wallet.js`**, **`coin-management.js`**, and **`diagnostics.js`**.
> 
> When config is loaded as usual, behavior is unchanged; the fix only matters if those keys are missing from `CONFIG`, where fees and mirror coin amounts would previously have been wrong by several orders of magnitude.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e8d3867896d11e0b040061817b82d48813d40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->