### PR TITLE
ci: pin default fee and coin amount in live api test jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -220,6 +220,9 @@ jobs:
           # Configure CADT to most verbose logs
           echo "Configuring CADT config.yaml..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           # Set network to testnet to match the Chia network configuration
           # Value must be lowercase - the check uses case-sensitive .includes()
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
@@ -754,6 +757,9 @@ jobs:
           # Configure CADT to most verbose logs
           echo "Configuring CADT config.yaml..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           # Set network to testnet to match the Chia network configuration
           # Value must be lowercase - the check uses case-sensitive .includes()
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
@@ -1281,6 +1287,9 @@ jobs:
           # Configure CADT to most verbose logs
           echo "Configuring CADT config.yaml..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           # Set network to testnet to match the Chia network configuration
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           # Use 127.0.0.1 instead of localhost for more reliable binding in containers
@@ -1746,6 +1755,9 @@ jobs:
           # Configure CADT to most verbose logs
           echo "Configuring CADT config.yaml..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           # Set network to testnet to match the Chia network configuration
           # Value must be lowercase - the check uses case-sensitive .includes()
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
@@ -2273,6 +2285,9 @@ jobs:
           # Configure CADT to most verbose logs
           echo "Configuring CADT config.yaml..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           # Set network to testnet to match the Chia network configuration
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           # Use 127.0.0.1 instead of localhost for more reliable binding in containers
@@ -2703,6 +2718,9 @@ jobs:
           # Configure CADT for READ_ONLY smoke mode
           echo "Configuring CADT config.yaml..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.BIND_ADDRESS = "127.0.0.1"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.DATALAYER_HOST = "https://127.0.0.1:8562"' ~/.chia/mainnet/cadt/config.yaml
@@ -2960,6 +2978,9 @@ jobs:
           # Configure CADT to most verbose logs
           echo "Configuring CADT config.yaml..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           # Set network to testnet to match the Chia network configuration
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           # Use 127.0.0.1 instead of localhost for more reliable binding in containers
@@ -3315,6 +3336,9 @@ jobs:
 
           echo "Configuring CADT config.yaml for sync-only testing..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.BIND_ADDRESS = "127.0.0.1"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.DATALAYER_HOST = "https://127.0.0.1:8562"' ~/.chia/mainnet/cadt/config.yaml
@@ -4524,6 +4548,9 @@ jobs:
 
           echo "Configuring CADT config.yaml for V1 sync-only testing..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.BIND_ADDRESS = "127.0.0.1"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.DATALAYER_HOST = "https://127.0.0.1:8562"' ~/.chia/mainnet/cadt/config.yaml
@@ -5408,6 +5435,9 @@ jobs:
 
           echo "Configuring CADT config.yaml for V1 governance body..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.BIND_ADDRESS = "127.0.0.1"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.DATALAYER_HOST = "https://127.0.0.1:8562"' ~/.chia/mainnet/cadt/config.yaml
@@ -5728,6 +5758,9 @@ jobs:
 
           echo "Configuring CADT config.yaml for V2 governance body..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.BIND_ADDRESS = "127.0.0.1"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.DATALAYER_HOST = "https://127.0.0.1:8562"' ~/.chia/mainnet/cadt/config.yaml
@@ -6048,6 +6081,9 @@ jobs:
 
           echo "Configuring CADT config.yaml for V1+V2 governance body..."
           yq -yi '.APP.LOG_LEVEL = "debug"' ~/.chia/mainnet/cadt/config.yaml
+          # Pin fee and coin amount for deterministic live API test runs
+          yq -yi '.APP.DEFAULT_COIN_AMOUNT = 10' ~/.chia/mainnet/cadt/config.yaml
+          yq -yi '.APP.DEFAULT_FEE = 13' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.BIND_ADDRESS = "127.0.0.1"' ~/.chia/mainnet/cadt/config.yaml
           yq -yi '.APP.DATALAYER_HOST = "https://127.0.0.1:8562"' ~/.chia/mainnet/cadt/config.yaml


### PR DESCRIPTION
## Summary
- Set `DEFAULT_COIN_AMOUNT=10` and `DEFAULT_FEE=13` in the `Configure CADT` step of every live API job (all 12) via `yq`, so all live runs use explicit, identical values rather than the generated config defaults.

## Notes
- Applied uniformly across all live API jobs (v1/v2 live api, cascade delete, staging perf, upgrade, governance body, remote sync, read-only smoke).
- Depends on no code changes; CI-workflow-only.

## Test plan
- [ ] CI green; confirm the `Configure CADT` step's `cat config.yaml` output shows `DEFAULT_COIN_AMOUNT: 10` and `DEFAULT_FEE: 13` in each live job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to test configuration; no application or production code paths are modified.
> 
> **Overview**
> Every live API CI job that resets and rewrites `config.yaml` now **pins** `APP.DEFAULT_COIN_AMOUNT` to **10** and `APP.DEFAULT_FEE` to **13** right after the debug log level step, using the same `yq` pattern already used for other settings.
> 
> The same three-line block (comment + two `yq` calls) is added in **all 12** live-style jobs in `tests.yaml`—v1/v2 live API, cascade delete, staging perf, upgrade, read-only smoke, remote/sync-only, and governance-body variants—so runs no longer rely on whatever defaults the generated config would pick up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5413e6c0ddd618fd5d9e51e4acf9037d59f2e4c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->