### PR TITLE
chore(deps): bump joi from 17.13.3 to 17.13.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "express": "^5.2.1",
         "express-joi-validation": "^6.1.0",
         "express-rate-limit": "^8.5.1",
-        "joi": "^17.13.3",
+        "joi": "^17.13.4",
         "js-yaml": "^4.3.0",
         "lodash": "^4.18.1",
         "log-update": "^7.0.2",
@@ -6576,9 +6576,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "express": "^5.2.1",
     "express-joi-validation": "^6.1.0",
     "express-rate-limit": "^8.5.1",
-    "joi": "^17.13.3",
+    "joi": "^17.13.4",
     "js-yaml": "^4.3.0",
     "lodash": "^4.18.1",
     "log-update": "^7.0.2",


### PR DESCRIPTION
## Summary
- Bump `joi` to **17.13.4** (patch within 17.x) to resolve Dependabot alert #155 (medium — uncaught `RangeError` on deeply nested recursive `link()` schemas).
- Stays on joi 17 to satisfy `express-joi-validation@6` peer dependency (`joi: "17"`); avoids the breaking 18.x Dependabot PRs (#1655, #1441).

## Test plan
- [x] `npm ci` succeeds and resolves `joi@17.13.4`
- [ ] CI integration tests pass
- [ ] Docker smoke test passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency bump with no code changes; validation behavior should be unchanged aside from the security fix.
> 
> **Overview**
> Bumps the **`joi`** dependency from **17.13.3** to **17.13.4** in `package.json` and updates **`package-lock.json`** so installs resolve the new patch release.
> 
> This is a **dependency-only** change with no application source edits. The upgrade stays on **joi 17** to remain compatible with **`express-joi-validation@6`** (peer `joi: "17"`), and picks up the patch that fixes an uncaught **`RangeError`** on deeply nested recursive **`link()`** schemas (Dependabot alert #155).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ca34dd6f6732b81bcf36704b95046bc1a29689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->