### PR TITLE
fix(V2): repair stale issuance project methodology schema

### DIFF
--- a/src/database/v2/migrations/20250110120034-rename-issuance-methodology-to-project-methodology-v2.js
+++ b/src/database/v2/migrations/20250110120034-rename-issuance-methodology-to-project-methodology-v2.js
@@ -45,10 +45,11 @@ export default {
         console.log('Note: Index on cad_trust_project_methodology_id may already exist');
       }
     } else if (!hasOldColumn && !hasNewColumn) {
-      // Neither column exists - add the new column (shouldn't happen normally)
+      // If no legacy column exists, existing rows cannot be backfilled safely.
+      // Keep the repair nullable so SQLite can apply it in-place.
       await queryInterface.addColumn('issuance', 'cad_trust_project_methodology_id', {
-        type: Sequelize.STRING,
-        allowNull: false,
+        type: Sequelize.STRING(36),
+        allowNull: true,
         comment: 'Foreign key to project_methodology table',
       });
 

--- a/src/database/v2/migrations/20260629133000-repair-issuance-project-methodology-column-v2.js
+++ b/src/database/v2/migrations/20260629133000-repair-issuance-project-methodology-column-v2.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const OLD_COLUMN = 'cad_trust_methodology_id';
+const NEW_COLUMN = 'cad_trust_project_methodology_id';
+const TABLE = 'issuance';
+
+const getTableInfo = async (queryInterface, Sequelize) => {
+  const dialect = queryInterface.sequelize.getDialect();
+
+  if (dialect === 'mysql' || dialect === 'mariadb') {
+    const [columns] = await queryInterface.sequelize.query(
+      "SELECT COLUMN_NAME as name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'issuance' AND TABLE_SCHEMA = DATABASE()",
+    );
+    return columns;
+  }
+
+  return queryInterface.sequelize.query(
+    "PRAGMA table_info('issuance')",
+    { type: Sequelize.QueryTypes.SELECT },
+  );
+};
+
+const hasIndexOnColumn = async (queryInterface) => {
+  try {
+    const indexes = await queryInterface.showIndex(TABLE);
+    return indexes.some((index) => {
+      return (index.fields || []).some((field) => {
+        if (typeof field === 'string') {
+          return field === NEW_COLUMN;
+        }
+        return field?.attribute === NEW_COLUMN || field?.name === NEW_COLUMN;
+      });
+    });
+  } catch {
+    return false;
+  }
+};
+
+const addIndexIfMissing = async (queryInterface) => {
+  if (await hasIndexOnColumn(queryInterface)) {
+    return;
+  }
+
+  try {
+    await queryInterface.addIndex(TABLE, [NEW_COLUMN]);
+  } catch (error) {
+    const message = error?.message || '';
+    if (!/already exists|duplicate/i.test(message)) {
+      throw error;
+    }
+  }
+};
+
+export default {
+  async up(queryInterface, Sequelize) {
+    const tableInfo = await getTableInfo(queryInterface, Sequelize);
+    if (tableInfo.length === 0) {
+      return;
+    }
+
+    const hasOldColumn = tableInfo.some((col) => col.name === OLD_COLUMN);
+    const hasNewColumn = tableInfo.some((col) => col.name === NEW_COLUMN);
+
+    if (hasNewColumn) {
+      await addIndexIfMissing(queryInterface);
+      return;
+    }
+
+    if (hasOldColumn) {
+      try {
+        await queryInterface.removeIndex(TABLE, [OLD_COLUMN]);
+      } catch {
+        // The legacy index may not exist.
+      }
+
+      await queryInterface.renameColumn(TABLE, OLD_COLUMN, NEW_COLUMN);
+      await addIndexIfMissing(queryInterface);
+      return;
+    }
+
+    // No legacy column means there is no reliable value to backfill for any
+    // existing rows. New writes still provide this required field via the model.
+    await queryInterface.addColumn(TABLE, NEW_COLUMN, {
+      type: Sequelize.STRING(36),
+      allowNull: true,
+      comment: 'Foreign key to project_methodology table',
+    });
+    await addIndexIfMissing(queryInterface);
+  },
+
+  async down() {
+    // Corrective migration: keep the repaired schema on rollback.
+  },
+};

--- a/src/database/v2/migrations/index.js
+++ b/src/database/v2/migrations/index.js
@@ -52,6 +52,9 @@ import AddAuditSyncIndexesV2 from './20260301120000-add-audit-sync-indexes-v2.js
 // V2 Audit list endpoint: composite index covering per-org time-ordered pagination
 import AddAuditListIndexV2 from './20260615120000-add-audit-list-index-v2.js';
 
+// V2 corrective migration: repair stale issuance schemas missing project methodology
+import RepairIssuanceProjectMethodologyColumnV2 from './20260629133000-repair-issuance-project-methodology-column-v2.js';
+
 export const migrations = [
   {
     migration: CreateStagingV2,
@@ -196,5 +199,9 @@ export const migrations = [
   {
     migration: AddAuditListIndexV2,
     name: '20260615120000-add-audit-list-index-v2',
+  },
+  {
+    migration: RepairIssuanceProjectMethodologyColumnV2,
+    name: '20260629133000-repair-issuance-project-methodology-column-v2',
   },
 ];

--- a/tests/v2/integration/database-schema-check.spec.js
+++ b/tests/v2/integration/database-schema-check.spec.js
@@ -40,4 +40,20 @@ describe('Database Schema Check', function () {
     // This test always passes - it's just for debugging
     expect(true).to.be.true;
   });
+
+  it('should include project methodology identifiers in the SQLite schema', async function () {
+    const [projectMethodologyColumns] = await sequelizeV2.query(
+      `PRAGMA table_info(project_methodology)`,
+    );
+    const [issuanceColumns] = await sequelizeV2.query(
+      `PRAGMA table_info(issuance)`,
+    );
+
+    expect(projectMethodologyColumns.map((col) => col.name)).to.include(
+      'cad_trust_project_methodology_id',
+    );
+    expect(issuanceColumns.map((col) => col.name)).to.include(
+      'cad_trust_project_methodology_id',
+    );
+  });
 });

--- a/tests/v2/integration/issuance-schema-repair-v2.spec.js
+++ b/tests/v2/integration/issuance-schema-repair-v2.spec.js
@@ -1,0 +1,179 @@
+import { expect } from 'chai';
+import { Sequelize } from 'sequelize';
+import RepairIssuanceProjectMethodologyColumnV2 from '../../../src/database/v2/migrations/20260629133000-repair-issuance-project-methodology-column-v2.js';
+
+const getColumnNames = async (sequelize) => {
+  const columns = await sequelize.query(
+    "PRAGMA table_info('issuance')",
+    { type: Sequelize.QueryTypes.SELECT },
+  );
+  return columns.map((column) => column.name);
+};
+
+const hasProjectMethodologyIndex = async (sequelize) => {
+  const indexes = await sequelize.getQueryInterface().showIndex('issuance');
+  return indexes.some((index) => {
+    return (index.fields || []).some((field) => {
+      if (typeof field === 'string') {
+        return field === 'cad_trust_project_methodology_id';
+      }
+      return (
+        field?.attribute === 'cad_trust_project_methodology_id' ||
+        field?.name === 'cad_trust_project_methodology_id'
+      );
+    });
+  });
+};
+
+const createIssuanceTable = async (sequelize, extraColumns = {}) => {
+  await sequelize.getQueryInterface().createTable('issuance', {
+    cad_trust_issuance_id: {
+      type: Sequelize.STRING(36),
+      primaryKey: true,
+      allowNull: false,
+    },
+    issuance_id: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    issuance_date: {
+      type: Sequelize.DATEONLY,
+      allowNull: true,
+    },
+    cad_trust_verification_id: {
+      type: Sequelize.STRING(36),
+      allowNull: false,
+    },
+    ...extraColumns,
+    cad_trust_location_id: {
+      type: Sequelize.STRING(36),
+      allowNull: true,
+    },
+    created_at: {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    },
+    updated_at: {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+    },
+  });
+};
+
+describe('V2 issuance schema repair migration', function () {
+  let sequelize;
+
+  beforeEach(async function () {
+    sequelize = new Sequelize({
+      dialect: 'sqlite',
+      storage: ':memory:',
+      logging: false,
+    });
+  });
+
+  afterEach(async function () {
+    await sequelize.close();
+  });
+
+  it('renames legacy issuance methodology column and preserves values', async function () {
+    await createIssuanceTable(sequelize, {
+      cad_trust_methodology_id: {
+        type: Sequelize.STRING(36),
+        allowNull: false,
+      },
+    });
+    await sequelize.query(
+      `INSERT INTO issuance (
+        cad_trust_issuance_id,
+        issuance_id,
+        cad_trust_verification_id,
+        cad_trust_methodology_id,
+        created_at,
+        updated_at
+      ) VALUES (
+        'issuance-1',
+        'ISS-1',
+        'verification-1',
+        'project-methodology-1',
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      )`,
+    );
+
+    await RepairIssuanceProjectMethodologyColumnV2.up(
+      sequelize.getQueryInterface(),
+      Sequelize,
+    );
+
+    const columns = await getColumnNames(sequelize);
+    expect(columns).to.include('cad_trust_project_methodology_id');
+    expect(columns).to.not.include('cad_trust_methodology_id');
+
+    const rows = await sequelize.query(
+      'SELECT cad_trust_project_methodology_id FROM issuance',
+      { type: Sequelize.QueryTypes.SELECT },
+    );
+    expect(rows[0].cad_trust_project_methodology_id).to.equal('project-methodology-1');
+    expect(await hasProjectMethodologyIndex(sequelize)).to.equal(true);
+  });
+
+  it('adds the missing issuance project methodology column to stale SQLite schemas', async function () {
+    await createIssuanceTable(sequelize);
+    await sequelize.query(
+      `INSERT INTO issuance (
+        cad_trust_issuance_id,
+        issuance_id,
+        cad_trust_verification_id,
+        created_at,
+        updated_at
+      ) VALUES (
+        'issuance-1',
+        'ISS-1',
+        'verification-1',
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      )`,
+    );
+
+    await RepairIssuanceProjectMethodologyColumnV2.up(
+      sequelize.getQueryInterface(),
+      Sequelize,
+    );
+
+    const columns = await getColumnNames(sequelize);
+    expect(columns).to.include('cad_trust_project_methodology_id');
+
+    const rows = await sequelize.query(
+      'SELECT cad_trust_project_methodology_id FROM issuance',
+      { type: Sequelize.QueryTypes.SELECT },
+    );
+    expect(rows[0].cad_trust_project_methodology_id).to.equal(null);
+    expect(await hasProjectMethodologyIndex(sequelize)).to.equal(true);
+  });
+
+  it('is idempotent when the issuance project methodology column already exists', async function () {
+    await createIssuanceTable(sequelize, {
+      cad_trust_project_methodology_id: {
+        type: Sequelize.STRING(36),
+        allowNull: false,
+      },
+    });
+
+    await RepairIssuanceProjectMethodologyColumnV2.up(
+      sequelize.getQueryInterface(),
+      Sequelize,
+    );
+    await RepairIssuanceProjectMethodologyColumnV2.up(
+      sequelize.getQueryInterface(),
+      Sequelize,
+    );
+
+    const columns = await getColumnNames(sequelize);
+    expect(
+      columns.filter((name) => name === 'cad_trust_project_methodology_id'),
+    ).to.have.length(1);
+    expect(await hasProjectMethodologyIndex(sequelize)).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add an idempotent V2 corrective migration for SQLite issuance schemas missing `cad_trust_project_methodology_id`.
- Make the older issuance methodology rename migration safe when it encounters a stale schema with neither column.
- Add regression coverage for legacy rename, missing-column repair, idempotency, index repair, and fresh SQLite schema assertions.

## Test plan
- `eval \"$(fnm env)\" && fnm use && bash tests/run-tests.sh npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js tests/v2/integration/issuance-schema-repair-v2.spec.js tests/v2/integration/database-schema-check.spec.js --reporter spec --exit --timeout 300000`
- `eval \"$(fnm env)\" && fnm use && npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migrations on `issuance` can leave legacy rows with NULL project methodology FKs until backfilled; application layer still enforces required values on new writes.
> 
> **Overview**
> Adds an **idempotent corrective V2 migration** so `issuance` always ends up with `cad_trust_project_methodology_id` and an index—whether the DB still has `cad_trust_methodology_id`, is missing both columns, or is already correct.
> 
> The older **rename migration** is adjusted for the “neither column” path: it adds `cad_trust_project_methodology_id` as **nullable** `STRING(36)` instead of `NOT NULL`, so SQLite can repair in place without inventing backfill values for existing rows.
> 
> **Tests** cover legacy rename with data preserved, missing-column repair, idempotency/index repair, and a schema check that `project_methodology` and `issuance` expose the expected column after migrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8ed81deb4cef8fe698bdc73a6ff0995e291cf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->