### PR TITLE
fix(V2): tolerate legacy AEF cooperative approach keys on sync

### DIFF
--- a/src/tasks/sync-registries-v2.js
+++ b/src/tasks/sync-registries-v2.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { SimpleIntervalJob, Task } from 'toad-scheduler';
 import { OrganizationsV2, AuditV2, StagingV2 } from '../models/v2/index.js';
 import { ModelKeysV2, getV2PrimaryKeyField } from '../utils/v2-model-utils.js';
+import { normalizeLegacyV2FieldNames } from '../utils/v2-legacy-field-names.js';
 import datalayer from '../datalayer';
 import {
   decodeHex,
@@ -620,10 +621,15 @@ const syncOrganizationAuditV2 = async (organization) => {
               const record = JSON.parse(decodeHex(diff.value));
               // Convert snake_case field names from datalayer to camelCase for Sequelize
               // V2 models use underscored: true, which means Sequelize expects camelCase in JS
-              const camelCaseRecord = _.mapKeys(record, (_value, key) => {
-                // Convert snake_case to camelCase
-                return _.camelCase(key);
-              });
+              // normalizeLegacyV2FieldNames maps legacy misspelled AEF keys from
+              // pre-rename on-chain data onto the corrected attributes.
+              const camelCaseRecord = normalizeLegacyV2FieldNames(
+                modelKey,
+                _.mapKeys(record, (_value, key) => {
+                  // Convert snake_case to camelCase
+                  return _.camelCase(key);
+                }),
+              );
               const primaryKeyValue =
                 camelCaseRecord[primaryKeyFieldCamelCase] ||
                 record[primaryKeyField];

--- a/src/utils/v2-legacy-field-names.js
+++ b/src/utils/v2-legacy-field-names.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Legacy field-name compatibility for V2 datalayer ingestion.
+//
+// The AEF T3/T4 cooperative-approach columns were renamed from the misspelled
+// "coopoerative" to "cooperative". Records published to the datalayer before the
+// rename still carry the old key, and on-chain data is immutable, so ingestion
+// must map the old key onto the corrected attribute before upserting.
+const LEGACY_V2_FIELD_RENAMES = {
+  aef_t3_actions: {
+    aefT3ActionsCoopoerativeApproachId: 'aefT3ActionsCooperativeApproachId',
+  },
+  aef_t4_holdings: {
+    aefT4HoldingsCoopoerativeApproachId: 'aefT4HoldingsCooperativeApproachId',
+  },
+};
+
+/**
+ * Returns a copy of a camelCase datalayer record with any legacy misspelled
+ * field keys renamed to their corrected attribute names. The input is not
+ * mutated. Records for models without known renames are returned unchanged.
+ * @param {string} modelKey - datalayer model key (e.g. "aef_t4_holdings")
+ * @param {Object} record - camelCase record produced from a datalayer diff
+ * @returns {Object} record with legacy keys renamed to corrected names
+ */
+export const normalizeLegacyV2FieldNames = (modelKey, record) => {
+  const renames = LEGACY_V2_FIELD_RENAMES[modelKey];
+  if (!renames || record == null || typeof record !== 'object') {
+    return record;
+  }
+
+  const normalized = { ...record };
+  for (const [oldKey, newKey] of Object.entries(renames)) {
+    if (
+      Object.hasOwn(normalized, oldKey) &&
+      !Object.hasOwn(normalized, newKey)
+    ) {
+      normalized[newKey] = normalized[oldKey];
+      delete normalized[oldKey];
+    }
+  }
+
+  return normalized;
+};
+
+export { LEGACY_V2_FIELD_RENAMES };

--- a/tests/v2/integration/orglist-subscription-reconcile.spec.js
+++ b/tests/v2/integration/orglist-subscription-reconcile.spec.js
@@ -605,7 +605,7 @@ describe('orglist-subscription-reconcile (V2)', function () {
       await AefT3ActionsV2.create({
         cadTrustAefT3ActionsId: uuidv4(),
         aefT3ActionsDate: '2024-01-01',
-        aefT3ActionsCoopoerativeApproachId: `coop3-${suffix}`,
+        aefT3ActionsCooperativeApproachId: `coop3-${suffix}`,
         aefT3ActionsAuthorizationId: `auth3-${suffix}`,
         aefT3ActionsFirstTransferringPartyId: `first3-${suffix}`,
         aefT3ActionsPartyItmoRegistryId: `registry3-${suffix}`,
@@ -622,7 +622,7 @@ describe('orglist-subscription-reconcile (V2)', function () {
       });
       await AefT4HoldingsV2.create({
         cadTrustAefT4HoldingsId: uuidv4(),
-        aefT4HoldingsCoopoerativeApproachId: `coop4-${suffix}`,
+        aefT4HoldingsCooperativeApproachId: `coop4-${suffix}`,
         aefT4HoldingsAuthorizationId: `auth4-${suffix}`,
         aefT4HoldingsFirstTransferringPartyId: `first4-${suffix}`,
         aefT4HoldingsPartyItmoRegistryId: `registry4-${suffix}`,
@@ -765,7 +765,7 @@ describe('orglist-subscription-reconcile (V2)', function () {
       await AefT3ActionsV2.create({
         cadTrustAefT3ActionsId: aefT3Id,
         aefT3ActionsDate: '2024-01-01',
-        aefT3ActionsCoopoerativeApproachId: 'coop3-c',
+        aefT3ActionsCooperativeApproachId: 'coop3-c',
         aefT3ActionsAuthorizationId: 'auth3-c',
         aefT3ActionsFirstTransferringPartyId: 'first3-c',
         aefT3ActionsPartyItmoRegistryId: 'registry3-c',
@@ -783,7 +783,7 @@ describe('orglist-subscription-reconcile (V2)', function () {
       const aefT4Id = uuidv4();
       await AefT4HoldingsV2.create({
         cadTrustAefT4HoldingsId: aefT4Id,
-        aefT4HoldingsCoopoerativeApproachId: 'coop4-c',
+        aefT4HoldingsCooperativeApproachId: 'coop4-c',
         aefT4HoldingsAuthorizationId: 'auth4-c',
         aefT4HoldingsFirstTransferringPartyId: 'first4-c',
         aefT4HoldingsPartyItmoRegistryId: 'registry4-c',

--- a/tests/v2/integration/v2-legacy-field-names.spec.js
+++ b/tests/v2/integration/v2-legacy-field-names.spec.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+
+import { normalizeLegacyV2FieldNames } from '../../../src/utils/v2-legacy-field-names.js';
+
+describe('normalizeLegacyV2FieldNames', function () {
+  it('renames the legacy misspelled AEF T3 cooperative approach key', function () {
+    const normalized = normalizeLegacyV2FieldNames('aef_t3_actions', {
+      cadTrustAefT3ActionsId: 't3-id',
+      aefT3ActionsCoopoerativeApproachId: 'T3-CA-001',
+    });
+
+    expect(normalized).to.deep.equal({
+      cadTrustAefT3ActionsId: 't3-id',
+      aefT3ActionsCooperativeApproachId: 'T3-CA-001',
+    });
+  });
+
+  it('renames the legacy misspelled AEF T4 cooperative approach key', function () {
+    const normalized = normalizeLegacyV2FieldNames('aef_t4_holdings', {
+      cadTrustAefT4HoldingsId: 't4-id',
+      aefT4HoldingsCoopoerativeApproachId: 'T4-CA-001',
+    });
+
+    expect(normalized).to.deep.equal({
+      cadTrustAefT4HoldingsId: 't4-id',
+      aefT4HoldingsCooperativeApproachId: 'T4-CA-001',
+    });
+  });
+
+  it('leaves records already using the corrected key unchanged', function () {
+    const record = {
+      cadTrustAefT4HoldingsId: 't4-id',
+      aefT4HoldingsCooperativeApproachId: 'T4-CA-001',
+    };
+
+    expect(
+      normalizeLegacyV2FieldNames('aef_t4_holdings', record),
+    ).to.deep.equal(record);
+  });
+
+  it('does not overwrite an existing corrected key when both are present', function () {
+    const normalized = normalizeLegacyV2FieldNames('aef_t4_holdings', {
+      aefT4HoldingsCoopoerativeApproachId: 'legacy',
+      aefT4HoldingsCooperativeApproachId: 'current',
+    });
+
+    expect(normalized.aefT4HoldingsCooperativeApproachId).to.equal('current');
+  });
+
+  it('does not mutate the input record', function () {
+    const record = {
+      aefT4HoldingsCoopoerativeApproachId: 'T4-CA-001',
+    };
+
+    normalizeLegacyV2FieldNames('aef_t4_holdings', record);
+
+    expect(record).to.have.property('aefT4HoldingsCoopoerativeApproachId');
+    expect(record).to.not.have.property('aefT4HoldingsCooperativeApproachId');
+  });
+
+  it('returns records for unaffected models unchanged', function () {
+    const record = { projectName: 'Test' };
+
+    expect(normalizeLegacyV2FieldNames('project', record)).to.equal(record);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two failing V2 CI jobs on #1692 (`v2 integration tests` and `v2 remote sync tests`), both caused by the AEF T3/T4 `coopoerative` → `cooperative` field rename.

- **Sync ingestion (`v2 remote sync tests`)**: records published to the datalayer before the rename still carry the misspelled `coopoerative` key. On-chain data is immutable, so the corrected column (`allowNull: false`) was left null on ingest and the record failed to upsert on every sync cycle, so the organization never finished syncing. The V2 sync path now maps the legacy key onto the corrected attribute before upsert via a small `normalizeLegacyV2FieldNames` helper.
- **Integration seed (`v2 integration tests`)**: four stale misspelled field names in `orglist-subscription-reconcile.spec.js` were missed in the original rename, causing `notNull Violation: AefT3ActionsV2.aefT3ActionsCooperativeApproachId cannot be null`. Corrected to the new names.

## Test plan

- [x] `npm run test:v2` — 1831 passing, 0 failing (previously 3 failing in `orglist-subscription-reconcile`)
- [x] New unit spec `tests/v2/integration/v2-legacy-field-names.spec.js` covers the legacy-key normalization (rename, idempotency, no-mutation, unaffected models)
- [x] `prettier --check` clean on changed/added files
- [ ] CI `v2 remote sync tests` passes (validates legacy on-chain T4 record now ingests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow ingestion compatibility layer for two AEF models with unit tests; does not change auth, security, or broad sync logic beyond key aliasing before upsert.
> 
> **Overview**
> Fixes V2 sync and integration failures after the AEF T3/T4 **coopoerative** → **cooperative** column rename.
> 
> **Sync ingestion** now runs datalayer INSERT/UPDATE payloads through `normalizeLegacyV2FieldNames` after snake_case → camelCase conversion in `sync-registries-v2.js`. Immutable on-chain rows that still use the misspelled key get mapped onto the required `*CooperativeApproachId` attributes so upserts no longer fail with null violations and orgs can finish syncing.
> 
> Adds `src/utils/v2-legacy-field-names.js` with per-model rename maps for `aef_t3_actions` and `aef_t4_holdings`, plus unit coverage for rename, idempotency, no overwrite when both keys exist, and no input mutation.
> 
> **Integration seeds** in `orglist-subscription-reconcile.spec.js` update four stale `*CoopoerativeApproachId` fields to the corrected names so test fixtures match the models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c141eb1477dfc04f74f704ddc03d11329568393b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->