### PR TITLE
fix: compare mirror in-sync gate at whole-second resolution

### DIFF
--- a/src/database/index.js
+++ b/src/database/index.js
@@ -669,14 +669,10 @@ const runBackfillMirror = async () => {
         // mean we can't ask a single MAX() question that both sides answer
         // consistently.
         //
-        // Known limitation: an in-place UPDATE to a non-max-row whose
-        // newly-bumped updatedAt happens to remain below the table's
-        // existing MAX(updatedAt) would not be detected by the gate.
-        // Sequelize-driven UPDATEs always bump updatedAt to NOW(), which
-        // is necessarily greater than any prior MAX, so this requires
-        // raw-SQL manipulation that bypasses the ORM. No such code path
-        // exists in CADT today; if one is added, switch the gate to a
-        // SUM(UNIX_TIMESTAMP(updatedAt)) checksum.
+        // The comparison is done at whole-second resolution and has a
+        // documented same-second sub-second-drift limitation; see
+        // isMirrorInSync in ./mirror-sync-gate.js for the full rationale
+        // and the checksum escape hatch.
         const updatedAtAttr = matchingUpdatedAtAttr(source, mirror);
         if (updatedAtAttr) {
           const inSync = await isMirrorInSync(

--- a/src/database/mirror-sync-gate.js
+++ b/src/database/mirror-sync-gate.js
@@ -51,7 +51,8 @@ export const matchingUpdatedAtAttr = (source, mirror) => {
  * Returns true ONLY when BOTH conditions hold:
  *   1. count(source) === count(mirror)
  *   2. Either both counts are 0 (truly empty on both sides), OR
- *      max(mirror[updatedAtAttr]) >= max(source[updatedAtAttr])
+ *      floor(max(mirror[updatedAtAttr])) >= floor(max(source[updatedAtAttr]))
+ *      where floor() truncates to whole seconds (see resolution note below)
  *
  * Returns false in every other case (including any error), so the
  * caller falls through to the existing full upsert. Crucially, false
@@ -60,15 +61,34 @@ export const matchingUpdatedAtAttr = (source, mirror) => {
  * leave the mirror stale. We deliberately bias toward the
  * cheap-but-fully-correct fall-through.
  *
- * Known limitation - non-max-row UPDATE drift: if a row is updated in
- * source via raw SQL with an updatedAt that's strictly below the
- * table's existing MAX(updatedAt), the gate can't see the change.
- * Sequelize-driven UPDATEs auto-bump updatedAt to NOW() (necessarily
- * greater than any prior MAX), so this only happens via raw SQL that
- * bypasses the ORM or via clock-skew adjustments. No such code path
- * exists in CADT today. If composite drift patterns become a concern,
- * replace this with a SUM(UNIX_TIMESTAMP(updatedAt)) checksum or a
- * per-table hash digest.
+ * Timestamp resolution: the MAX(updatedAt) comparison is done at
+ * whole-second resolution. SQLite retains millisecond precision on
+ * updatedAt, but the mirror stores only whole seconds: Sequelize's mysql
+ * DATE serialization emits "YYYY-MM-DD HH:mm:ss" with no fractional part
+ * (pinned by tests/v2/integration/mirror-datetime-format.spec.js), so
+ * every value is truncated down to its whole second before it reaches
+ * MySQL - independent of the server's fractional-rounding SQL mode. A
+ * freshly-synced mirror therefore reads back at or just behind the source
+ * (e.g. source .899 vs mirror .000). Comparing at millisecond resolution
+ * treated that truncation as drift and forced a full re-upsert of the
+ * whole table on every restart. Flooring both sides to whole seconds
+ * compares like-with-like against the resolution the mirror can hold. (A
+ * fallback path can instead round a sub-second value half-up on a MariaDB
+ * DATETIME(0) column - see src/config/config.js - so the mirror is not
+ * guaranteed to land exactly at floor(source); the whole-second compare
+ * neither introduces nor removes that edge relative to the prior
+ * millisecond compare, and the count check, orphan sweep, and
+ * safe-false-negative bias remain the backstop.)
+ *
+ * Known limitation - sub-second UPDATE drift: an update whose new
+ * updatedAt lands in the same whole second as the mirror's newest row is
+ * not seen by the gate. Sequelize-driven UPDATEs auto-bump updatedAt to
+ * NOW(), so any change in a later whole second than the last synced write
+ * is still detected; only a same-second miss (or raw-SQL writes that
+ * bypass the ORM, which CADT does not do) is invisible, and the next
+ * write crossing a whole-second boundary repairs it. If sub-second drift
+ * detection ever becomes a hard requirement, replace this with a
+ * SUM(UNIX_TIMESTAMP(updatedAt)) checksum or a per-table hash digest.
  *
  * @param {string} [logPrefix=''] - Prepended to every log line so V2 callers
  *   can keep their '[v2]: ' tag without forking the implementation.
@@ -125,15 +145,22 @@ export const isMirrorInSync = async (
       return false;
     }
 
-    if (mirrorMs >= sourceMs) {
+    // Compare at whole-second resolution: the mirror's DATETIME column
+    // cannot represent the sub-second precision SQLite keeps, so a
+    // millisecond comparison reports a just-synced mirror as stale. See
+    // the resolution note in this function's doc comment.
+    const sourceSec = Math.floor(sourceMs / 1000);
+    const mirrorSec = Math.floor(mirrorMs / 1000);
+
+    if (mirrorSec >= sourceSec) {
       logger.debug(
-        `${logPrefix}Mirror backfill: ${name} - in sync, skipping (${sourceCount} rows, max(updatedAt) mirror=${mirrorMs} >= source=${sourceMs})`,
+        `${logPrefix}Mirror backfill: ${name} - in sync, skipping (${sourceCount} rows, max(updatedAt) second mirror=${mirrorSec} >= source=${sourceSec}; ms mirror=${mirrorMs} source=${sourceMs})`,
       );
       return true;
     }
 
     logger.debug(
-      `${logPrefix}Mirror backfill: ${name} - gate failed (mirror max(updatedAt)=${mirrorMs} < source=${sourceMs})`,
+      `${logPrefix}Mirror backfill: ${name} - gate failed (mirror max(updatedAt) second=${mirrorSec} < source=${sourceSec}; ms mirror=${mirrorMs} source=${sourceMs})`,
     );
     return false;
   } catch (error) {

--- a/src/database/v2/index.js
+++ b/src/database/v2/index.js
@@ -682,8 +682,8 @@ const runBackfillMirrorV2 = async () => {
         // the bulk upsert when COUNT(*) matches and the mirror's
         // MAX(updatedAt) is at least as new as source's. Falls through
         // to the full sync on any mismatch so outage-recovery semantics
-        // are preserved. See V1's backfillMirror for the same
-        // correctness invariant and the known non-max-row-UPDATE
+        // are preserved. See isMirrorInSync in ../mirror-sync-gate.js for
+        // the same correctness invariant and the whole-second resolution
         // limitation.
         const updatedAtAttr = matchingUpdatedAtAttr(source, mirror);
         if (updatedAtAttr) {

--- a/tests/integration/mirror-backfill-dedupe.spec.js
+++ b/tests/integration/mirror-backfill-dedupe.spec.js
@@ -196,6 +196,52 @@ describe('Mirror Backfill Dedupe + In-Sync Gate (V1)', function () {
       expect(mirrorRow, 'gate must not delete or modify rows').to.not.be.null;
     });
 
+    it('skips the bulk upsert when the mirror row is the whole-second truncation of a sub-second source row', async function () {
+      // Regression for the sub-second precision false-negative. In
+      // production SQLite stores updatedAt with milliseconds while the
+      // MySQL mirror's DATETIME column truncates to whole seconds, so a
+      // freshly-synced mirror reads back fractionally behind the source.
+      // We reproduce that here by giving the source a sub-second timestamp
+      // and the mirror its whole-second truncation (identical UTC second,
+      // .899 vs .000). The gate must treat the two as in sync and skip the
+      // full re-upsert; before the whole-second comparison this tripped a
+      // needless full-table re-sync on every restart.
+      //
+      // Both timestamps carry the explicit '+00:00' offset so new Date()
+      // parses them as UTC. A bare "YYYY-MM-DD HH:mm:ss" string would be
+      // read as local time, shifting the two sides by the host's offset and
+      // masking the sub-second scenario this test exists to cover.
+      const id = uuidv4();
+      const orgUid = uuidv4();
+
+      await insertProjectInto(sequelize, {
+        id,
+        name: 'Synced',
+        orgUid,
+        when: '2026-01-01 12:00:00.899 +00:00',
+      });
+      await insertProjectInto(sequelizeMirror, {
+        id,
+        name: 'Synced',
+        orgUid,
+        when: '2026-01-01 12:00:00.000 +00:00',
+      });
+
+      const bulkCreateSpy = sinon.spy(ProjectMirror, 'bulkCreate');
+
+      await backfillMirror();
+
+      expect(
+        bulkCreateSpy.called,
+        'a sub-second-only difference (mirror truncated to whole seconds) must not trigger a full re-upsert',
+      ).to.equal(false);
+
+      const mirrorRow = await ProjectMirror.findOne({
+        where: { warehouseProjectId: id },
+      });
+      expect(mirrorRow, 'gate must not delete or modify the row').to.not.be.null;
+    });
+
     it('falls through to the full sync when counts mismatch', async function () {
       // Source has one row, mirror has none. Counts differ -> gate fails
       // -> full sync runs -> mirror gets the row.

--- a/tests/integration/mirror-sync-gate.spec.js
+++ b/tests/integration/mirror-sync-gate.spec.js
@@ -92,6 +92,81 @@ describe('Mirror in-sync gate (isMirrorInSync) — unit', function () {
     expect(result).to.equal(false);
   });
 
+  // Resolution guard: SQLite keeps milliseconds on updatedAt, the MySQL
+  // mirror's DATETIME column truncates to whole seconds. A just-synced
+  // mirror is therefore fractionally behind the source (source .899 vs
+  // mirror .000). The gate compares at whole-second resolution, so this
+  // must count as in sync - NOT as drift that forces a full re-upsert.
+  it('skips when mirror max is the whole-second truncation of a sub-second source max', async function () {
+    const source = makeModel({ count: 3, max: '2026-01-01T12:00:00.899Z' });
+    const mirror = makeModel({ count: 3, max: '2026-01-01T12:00:00.000Z' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(true);
+  });
+
+  // Counterpart to the above: a genuine update advances updatedAt past the
+  // next whole-second boundary, so the gate must still detect real drift
+  // and fall through to the full sync. This pins the comparison at exactly
+  // one-second resolution - not "ignore updatedAt entirely".
+  it('falls through when source is newer by a full second (real drift, not truncation)', async function () {
+    const source = makeModel({ count: 3, max: '2026-01-01T12:00:01.000Z' });
+    const mirror = makeModel({ count: 3, max: '2026-01-01T12:00:00.000Z' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+
+  // Upper edge of the same-second window: a source .999 ms ahead of a
+  // mirror truncated to .000 is still the same whole second, so in sync.
+  it('skips at the top of the same whole second (source .999 vs mirror .000)', async function () {
+    const source = makeModel({ count: 3, max: '2026-01-01T12:00:00.999Z' });
+    const mirror = makeModel({ count: 3, max: '2026-01-01T12:00:00.000Z' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(true);
+  });
+
+  // Just across a whole-second boundary: the wall-clock gap is only 200 ms
+  // but it straddles two whole seconds, so it counts as real drift and
+  // must fall through. Pins that detection is "different whole second",
+  // not "difference >= 1000 ms".
+  it('falls through when source crosses into the next whole second (200ms real drift)', async function () {
+    const source = makeModel({ count: 3, max: '2026-01-01T12:00:01.100Z' });
+    const mirror = makeModel({ count: 3, max: '2026-01-01T12:00:00.900Z' });
+
+    const result = await isMirrorInSync(
+      source,
+      mirror,
+      'projects',
+      ATTR,
+      silentLogger,
+    );
+
+    expect(result).to.equal(false);
+  });
+
   // The documented gap: non-zero count but a null MAX(updatedAt). The gate
   // must NOT misclassify this as "empty / in sync" - it can't compare
   // freshness, so it must fall through to the full sync.

--- a/tests/v2/integration/mirror-backfill-dedupe-v2.spec.js
+++ b/tests/v2/integration/mirror-backfill-dedupe-v2.spec.js
@@ -153,6 +153,46 @@ describe('Mirror Backfill Dedupe + In-Sync Gate (V2)', function () {
       expect(mirrorRow, 'gate must not delete or modify rows').to.not.be.null;
     });
 
+    it('skips the bulk upsert when the mirror row is the whole-second truncation of a sub-second source row', async function () {
+      // Regression for the sub-second precision false-negative. SQLite
+      // keeps milliseconds on updated_at while the MySQL mirror's DATETIME
+      // column truncates to whole seconds, so a freshly-synced mirror reads
+      // back fractionally behind the source. We reproduce that by storing
+      // the sub-second timestamp in source and its whole-second truncation
+      // in the mirror (identical UTC second, .899 vs .000). The gate must
+      // treat the two as in sync and skip the full re-upsert.
+      //
+      // Both timestamps carry the explicit '+00:00' offset so new Date()
+      // parses them as UTC; a bare "YYYY-MM-DD HH:mm:ss" string would be
+      // read as local time and shift the two sides apart.
+      const id = uuidv4();
+
+      await insertProgramInto(sequelizeV2, {
+        id,
+        name: 'Synced',
+        when: '2026-01-01 12:00:00.899 +00:00',
+      });
+      await insertProgramInto(sequelizeV2Mirror, {
+        id,
+        name: 'Synced',
+        when: '2026-01-01 12:00:00.000 +00:00',
+      });
+
+      const bulkCreateSpy = sinon.spy(ProgramV2Mirror, 'bulkCreate');
+
+      await backfillMirrorV2();
+
+      expect(
+        bulkCreateSpy.called,
+        'a sub-second-only difference (mirror truncated to whole seconds) must not trigger a full re-upsert',
+      ).to.equal(false);
+
+      const mirrorRow = await ProgramV2Mirror.findOne({
+        where: { cadTrustProgramId: id },
+      });
+      expect(mirrorRow, 'gate must not delete or modify the row').to.not.be.null;
+    });
+
     it('falls through to the full sync when counts mismatch', async function () {
       // Source has one row, mirror is empty. Gate fails on count; full
       // sync runs; mirror gets the row.


### PR DESCRIPTION
## Summary

The MySQL mirror backfill's in-sync gate (`isMirrorInSync`) compared
`MAX(updatedAt)` at **millisecond** resolution. SQLite retains
milliseconds, but Sequelize's `mysql` `DATE` serialization writes the
mirror with **no fractional part** (`YYYY-MM-DD HH:mm:ss`), so a
freshly-synced mirror reads back truncated to the whole second (e.g.
source `.899` vs mirror `.000`). The gate read that truncation as drift
and forced a full re-upsert of the large tables (`unit`, `audit`) on
**every restart**, even though no rows were missing.

This floors both sides to whole seconds before comparing, matching the
resolution the mirror can actually hold. A genuine update advances
`updatedAt` to `NOW()` and crosses a whole-second boundary, so real drift
is still detected. The accepted trade-off is a same-second miss that
self-heals on the next boundary-crossing write; the `COUNT(*)` check and
orphan sweep remain the backstop, and the `SUM(UNIX_TIMESTAMP(...))`
checksum escape hatch is documented if sub-second detection is ever
required.

The change is in the shared gate used by both the V1 (`backfillMirror`)
and V2 (`backfillMirrorV2`) paths, so one fix covers both. The touched
`src/database/index.js` / `src/database/v2/index.js` lines are
comment-only (call-site notes now defer to the gate's doc comment).

## Test plan

- [x] New unit tests (`tests/integration/mirror-sync-gate.spec.js`):
  same-second truncation is in sync; full-second-newer is drift; `.999`
  upper-edge of the same second; a 200 ms gap that crosses a whole-second
  boundary is drift (pins "different whole second", not a 1000 ms
  tolerance).
- [x] New V1/V2 integration tests
  (`mirror-backfill-dedupe.spec.js`, `mirror-backfill-dedupe-v2.spec.js`)
  drive the real backfill, simulate the mirror's whole-second truncation,
  and assert `bulkCreate` is not called (no needless re-upsert).
- [x] Confirmed the new tests fail against the previous millisecond
  comparison and pass with the fix (genuine regression guards).
- [x] `npm run test:v1` mirror specs (24 passing) and V2 mirror +
  datetime-format specs (12 passing) green.
- [x] `eslint` clean on changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup/reconnect mirror backfill skipping for large tables; bias remains toward full sync on uncertainty, but same-second updates may not trigger a backfill until a later second-boundary write.
> 
> **Overview**
> Fixes a false “out of sync” signal in the shared **`isMirrorInSync`** gate used by V1 and V2 mirror backfill. **`MAX(updatedAt)`** is now compared after flooring both sides to **whole seconds**, so SQLite sub-millisecond timestamps are not treated as newer than MySQL mirror values that only store second precision.
> 
> That stops **needless full-table re-upserts on every restart** when counts already match but the mirror’s newest timestamp is truncated (e.g. source `.899` vs mirror `.000`). Real drift is still detected when the source advances into a **later whole second**; updates confined to the same second can be missed until a later write crosses a second boundary—a trade-off documented in the gate, with count/orphan sweep still as backstops.
> 
> V1/V2 backfill call sites only refresh comments; behavior lives in **`mirror-sync-gate.js`**. Tests cover unit edge cases and V1/V2 integration paths that assert **`bulkCreate`** is skipped for truncation-only differences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14818f4bb3e7a8a44fe6c271a2ac8b74c9474146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->