### PR TITLE
chore: upgrade js-yaml to 5.2.1

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,7 +29,7 @@ create_config_if_not_exists() {
         # Use a temporary .mjs file to properly handle ES module imports with top-level await
         local temp_script=$(mktemp /app/create-config-XXXXXX.mjs)
         cat > "$temp_script" << 'EOF'
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import fs from "fs";
 import { defaultConfig } from "/app/src/utils/defaultConfig.js";
 try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express-joi-validation": "^6.1.0",
         "express-rate-limit": "^8.5.1",
         "joi": "^17.13.4",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^5.2.1",
         "lodash": "^4.18.1",
         "log-update": "^7.0.2",
         "multer": "^2.2.0",
@@ -130,6 +130,7 @@
       "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.6",
@@ -3029,6 +3030,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -3256,6 +3258,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3842,6 +3845,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4557,6 +4561,29 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/croner": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
@@ -5133,6 +5160,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5383,6 +5411,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6590,6 +6619,7 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
       "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -6606,9 +6636,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "funding": [
         {
           "type": "github",
@@ -6624,7 +6654,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {
@@ -7133,6 +7163,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -7757,6 +7810,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9732,6 +9786,7 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "express-joi-validation": "^6.1.0",
     "express-rate-limit": "^8.5.1",
     "joi": "^17.13.4",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.2.1",
     "lodash": "^4.18.1",
     "log-update": "^7.0.2",
     "multer": "^2.2.0",

--- a/scripts/preflight-check.js
+++ b/scripts/preflight-check.js
@@ -16,7 +16,7 @@ import http from 'http';
 import https from 'https';
 import fs from 'fs';
 import path from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 
 // Parse command line arguments
 const args = process.argv.slice(2);

--- a/src/datalayer/fullNode.js
+++ b/src/datalayer/fullNode.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import fs from 'fs';
 import path from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { getChiaRoot } from '../utils/chia-root.js';
 
 export const getChiaConfig = _.memoize(() => {

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 

--- a/src/utils/config-migration.js
+++ b/src/utils/config-migration.js
@@ -1,4 +1,4 @@
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 import { getChiaRoot } from './chia-root.js';

--- a/tests/v1/live-api/helpers/live-api-helpers.js
+++ b/tests/v1/live-api/helpers/live-api-helpers.js
@@ -1,5 +1,5 @@
 import supertest from 'supertest';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 import { getChiaRoot } from '../../../../src/utils/chia-root.js';

--- a/tests/v1/live-api/helpers/mysql-mirror-helpers.js
+++ b/tests/v1/live-api/helpers/mysql-mirror-helpers.js
@@ -12,7 +12,7 @@
  */
 
 import mysql from 'mysql2/promise';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 import { getChiaRoot } from '../../../../src/utils/chia-root.js';

--- a/tests/v2/integration/config-migration.spec.js
+++ b/tests/v2/integration/config-migration.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import fs from 'fs';
 import path from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import os from 'os';
 import { migrateConfigFiles } from '../../../src/utils/config-migration.js';
 import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';

--- a/tests/v2/integration/enable-disable-versions.spec.js
+++ b/tests/v2/integration/enable-disable-versions.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import supertest from 'supertest';
 import fs from 'fs';
 import path from 'path';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
 import { initializeDatabases } from '../../../src/routes/index.js';
 import scheduler from '../../../src/tasks/index.js';

--- a/tests/v2/live-api/helpers/live-api-helpers.js
+++ b/tests/v2/live-api/helpers/live-api-helpers.js
@@ -1,5 +1,5 @@
 import supertest from 'supertest';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 import { getChiaRoot } from '../../../../src/utils/chia-root.js';

--- a/tests/v2/live-api/helpers/mysql-mirror-helpers.js
+++ b/tests/v2/live-api/helpers/mysql-mirror-helpers.js
@@ -7,7 +7,7 @@
  */
 
 import mysql from 'mysql2/promise';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import fs from 'fs';
 import path from 'path';
 import { getChiaRoot } from '../../../../src/utils/chia-root.js';

--- a/tests/v2/utils/v2-test-helpers.js
+++ b/tests/v2/utils/v2-test-helpers.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import yaml from 'js-yaml';
+import * as yaml from 'js-yaml';
 import { prepareV2Db } from '../../../src/database/v2/index.js';
 import datalayer from '../../../src/datalayer/index.js';
 import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';


### PR DESCRIPTION
## Summary
- Upgrade `js-yaml` from 4.x to **5.2.1**
- Replace `import yaml from 'js-yaml'` with `import * as yaml from 'js-yaml'` (v5 has no ESM default export)
- No other API usage changes (`load`/`dump` only; no custom schemas/tags/options)

## Test plan
- [x] Confirmed default import throws under v5; namespace import works
- [x] Config load/dump round-trip preserves values (`null`, bools, numbers, empty strings)
- [x] `tests/v2/integration/config-migration.spec.js` + `enable-disable-versions.spec.js` — 35 passing
- [x] `npm run build` succeeds; Babel emits `_interopRequireWildcard(require("js-yaml"))`
- [ ] CI v1/v2 integration + docker smoke

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config YAML read/write on startup and migration paths depends on this library; behavior should be unchanged but a major-version bump warrants CI/docker smoke coverage.
> 
> **Overview**
> Bumps **`js-yaml`** from **4.x** to **5.2.1** in `package.json` / lockfile and aligns every caller with v5’s ESM surface by switching **`import yaml from 'js-yaml'`** to **`import * as yaml from 'js-yaml'`** (app config load/migration, Chia `config.yaml` read, Docker first-boot config creation, preflight script, and test helpers).
> 
> Call sites still use **`yaml.load`** / **`yaml.dump`** only; no schema or dump options changed. Dev tooling (`cosmiconfig`, `mocha`) keeps a nested **4.3.0** copy in the lockfile while the app resolves **5.2.1** at the top level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8940108872543bd8acdc8081a88179111d9541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->