### PR TITLE
fix(V2): normalize API timestamp casing

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -1199,8 +1199,8 @@ Response
       "action": "INSERT",
       "committed": false,
       "failed_commit": false,
-      "created_at": "2022-03-11T05:17:55.427Z",
-      "updated_at": "2022-03-11T05:17:55.427Z",
+      "createdAt": "2022-03-11T05:17:55.427Z",
+      "updatedAt": "2022-03-11T05:17:55.427Z",
       "diff": {
         "original": {},
         "change": {
@@ -1427,24 +1427,24 @@ Response
     "meta_key": "glossary",
     "meta_value": "{\"Project Statuses\":[...],\"Unit Statuses\":[...]}",
     "confirmed": true,
-    "created_at": "2022-03-13T03:08:15.156Z",
-    "updated_at": "2022-03-13T03:08:15.156Z"
+    "createdAt": "2022-03-13T03:08:15.156Z",
+    "updatedAt": "2022-03-13T03:08:15.156Z"
   },
   {
     "id": 2,
     "meta_key": "pickList",
     "meta_value": "{\"projectSector\":[...],\"unitType\":[...]}",
     "confirmed": true,
-    "created_at": "2022-03-13T03:08:15.156Z",
-    "updated_at": "2022-03-13T03:08:15.156Z"
+    "createdAt": "2022-03-13T03:08:15.156Z",
+    "updatedAt": "2022-03-13T03:08:15.156Z"
   },
   {
     "id": 3,
     "meta_key": "orgList",
     "meta_value": "[{\"orgUid\":\"723a2f97abd8a45826d97c1bdf6f38b11f6207a9a8cb80b18608505efd5ccc27\"}]",
     "confirmed": true,
-    "created_at": "2022-03-13T03:08:15.156Z",
-    "updated_at": "2022-03-13T03:08:15.156Z"
+    "createdAt": "2022-03-13T03:08:15.156Z",
+    "updatedAt": "2022-03-13T03:08:15.156Z"
   }
 ]
 ```

--- a/src/routes/v2/index.js
+++ b/src/routes/v2/index.js
@@ -29,8 +29,54 @@ import { AuditV2Router } from './resources/audit-v2.js';
 import { OfferV2Router } from './resources/offer-v2.js';
 import { FilestoreV2Router } from './resources/filestore-v2.js';
 import { buildHealthDiskSpacePayload } from '../../utils/disk-space.js';
+import { normalizeApiTimestampFields } from '../../utils/helpers.js';
 
 const V2Router = express.Router();
+
+const TIMESTAMP_NORMALIZED_PREFIXES = [
+  '/methodology',
+  '/program',
+  '/project',
+  '/validation',
+  '/verification',
+  '/issuance',
+  '/unit',
+  '/location',
+  '/estimation',
+  '/rating',
+  '/co-benefit',
+  '/project-methodology',
+  '/stakeholder',
+  '/stakeholder-projects',
+  '/label',
+  '/unit-label',
+  '/aef-t1-submission',
+  '/aef-t5-authorized-entities',
+  '/aef-t2-authorizations',
+  '/aef-t3-actions',
+  '/aef-t4-holdings',
+  '/staging',
+  '/audit',
+];
+
+const TIMESTAMP_NORMALIZED_EXACT_ROUTES = [
+  '/governance',
+];
+
+V2Router.use((req, res, next) => {
+  const shouldNormalizeTimestamps =
+    TIMESTAMP_NORMALIZED_EXACT_ROUTES.includes(req.path)
+    || TIMESTAMP_NORMALIZED_PREFIXES.some(
+      (route) => req.path === route || req.path.startsWith(`${route}/`),
+    );
+  if (!shouldNormalizeTimestamps) {
+    return next();
+  }
+
+  const json = res.json.bind(res);
+  res.json = (body) => json(normalizeApiTimestampFields(body));
+  next();
+});
 
 V2Router.get('/health', (req, res) => {
   // Non-blocking: see bare /health in src/middleware.js. The shared

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -70,6 +70,51 @@ export const normalizeRawTimestamps = (rows, fields) => {
   return rows;
 };
 
+export const normalizeApiTimestampFields = (value) => {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeApiTimestampFields(item));
+  }
+
+  if (value instanceof Date || value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  if (typeof value.toJSON === 'function' && value.dataValues) {
+    return normalizeApiTimestampFields(value.toJSON());
+  }
+
+  if (Object.prototype.toString.call(value) !== '[object Object]') {
+    return value;
+  }
+
+  const normalized = { ...value };
+  if (Array.isArray(normalized.data)) {
+    normalized.data = normalized.data.map((item) => normalizeApiTimestampFields(item));
+  }
+
+  if (normalized.data?.dataValues) {
+    normalized.data = normalizeApiTimestampFields(normalized.data);
+  }
+
+  for (const [key, item] of Object.entries(value)) {
+    if (item?.dataValues) {
+      normalized[key] = normalizeApiTimestampFields(item);
+    }
+  }
+
+  if (normalized.createdAt === undefined && normalized.created_at !== undefined) {
+    normalized.createdAt = normalized.created_at;
+  }
+  if (normalized.updatedAt === undefined && normalized.updated_at !== undefined) {
+    normalized.updatedAt = normalized.updated_at;
+  }
+
+  delete normalized.created_at;
+  delete normalized.updated_at;
+
+  return normalized;
+};
+
 /**
  *
  * @param userColumns {string[]}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -88,16 +88,19 @@ export const normalizeApiTimestampFields = (value) => {
   }
 
   const normalized = { ...value };
-  if (Array.isArray(normalized.data)) {
-    normalized.data = normalized.data.map((item) => normalizeApiTimestampFields(item));
-  }
-
-  if (normalized.data?.dataValues) {
-    normalized.data = normalizeApiTimestampFields(normalized.data);
-  }
-
   for (const [key, item] of Object.entries(value)) {
-    if (item?.dataValues) {
+    if (key === 'diff') {
+      continue;
+    }
+
+    if (
+      Array.isArray(item)
+      || item?.dataValues
+      || (
+        Object.prototype.toString.call(item) === '[object Object]'
+        && (item.created_at !== undefined || item.updated_at !== undefined)
+      )
+    ) {
       normalized[key] = normalizeApiTimestampFields(item);
     }
   }

--- a/tests/integration/helpers-normalize-timestamps.spec.js
+++ b/tests/integration/helpers-normalize-timestamps.spec.js
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
-import { normalizeRawTimestamps } from '../../src/utils/helpers.js';
+import {
+  normalizeApiTimestampFields,
+  normalizeRawTimestamps,
+} from '../../src/utils/helpers.js';
 
 describe('normalizeRawTimestamps', function () {
   it('converts a SQLite datetime string to ISO-8601', function () {
@@ -37,5 +40,64 @@ describe('normalizeRawTimestamps', function () {
     expect(rows[0].createdAt).to.equal('2026-01-01T00:00:00.000Z');
     expect(rows[1].createdAt).to.equal('2026-02-02T00:00:00.000Z');
     expect(rows[0].other).to.equal('keep');
+  });
+});
+
+describe('normalizeApiTimestampFields', function () {
+  it('removes snake_case timestamp aliases when camelCase timestamps exist', function () {
+    const response = normalizeApiTimestampFields({
+      data: [{
+        cadTrustProjectMethodologyId: 'pm-1',
+        createdAt: '2026-07-15T16:17:01.227Z',
+        updatedAt: '2026-07-15T16:17:01.227Z',
+        created_at: '2026-07-15T16:17:01.227Z',
+        updated_at: '2026-07-15T16:17:01.227Z',
+      }],
+    });
+
+    expect(response.data[0]).to.include({
+      createdAt: '2026-07-15T16:17:01.227Z',
+      updatedAt: '2026-07-15T16:17:01.227Z',
+    });
+    expect(response.data[0]).to.not.have.property('created_at');
+    expect(response.data[0]).to.not.have.property('updated_at');
+  });
+
+  it('promotes snake_case-only timestamps to camelCase', function () {
+    const response = normalizeApiTimestampFields({
+      cadTrustProjectId: 'project-1',
+      created_at: '2026-07-15T16:17:01.121Z',
+      updated_at: '2026-07-15T16:17:01.121Z',
+    });
+
+    expect(response).to.include({
+      cadTrustProjectId: 'project-1',
+      createdAt: '2026-07-15T16:17:01.121Z',
+      updatedAt: '2026-07-15T16:17:01.121Z',
+    });
+    expect(response).to.not.have.property('created_at');
+    expect(response).to.not.have.property('updated_at');
+  });
+
+  it('does not rewrite nested arbitrary JSON payloads', function () {
+    const response = normalizeApiTimestampFields({
+      id: 1,
+      created_at: '2026-07-15T16:17:01.121Z',
+      diff: {
+        original: {
+          created_at: '2024-01-01T00:00:00.000Z',
+          updated_at: '2024-01-01T00:00:00.000Z',
+        },
+      },
+    });
+
+    expect(response).to.include({
+      createdAt: '2026-07-15T16:17:01.121Z',
+    });
+    expect(response).to.not.have.property('created_at');
+    expect(response.diff.original).to.include({
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+    });
   });
 });

--- a/tests/v2/integration/audit-v2.spec.js
+++ b/tests/v2/integration/audit-v2.spec.js
@@ -820,9 +820,10 @@ describe('Phase 17.5: AuditV2 Comprehensive Integration Tests', function () {
       expect(response.body.data).to.have.length(1);
       expect(response.body.data[0]).to.have.property('change', '{"test": "data1"}');
       // raw:true must not regress the timestamp wire format away from ISO-8601
-      expect(response.body.data[0].created_at).to.match(
+      expect(response.body.data[0].createdAt).to.match(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
       );
+      expect(response.body.data[0]).to.not.have.property('created_at');
     });
 
     it('should omit the change column when excludeChange=true', async function () {

--- a/tests/v2/integration/project-methodology-v2.spec.js
+++ b/tests/v2/integration/project-methodology-v2.spec.js
@@ -550,6 +550,33 @@ describe('Project-Methodology V2 Join Table Integration Tests', function () {
     });
   });
 
+  describe('GET /v2/project-methodology/:cadTrustProjectMethodologyId', function () {
+    it('should return timestamp fields in camelCase only', async function () {
+      const newMethodology = await MethodologyV2.create({
+        cadTrustMethodologyId: uuidv4(),
+        methodologyName: 'Test Methodology for Timestamp API Test',
+        methodologyCode: 'TEST-METH-TIMESTAMP-001',
+        methodologyType: 'Methodology for timestamp API test',
+      });
+
+      const projectMethodology = await ProjectMethodologyV2.create({
+        cadTrustProjectMethodologyId: uuidv4(),
+        cadTrustProjectId: testProjectId,
+        cadTrustMethodologyId: newMethodology.cadTrustMethodologyId,
+        projectMethodologyDate: '2024-01-01',
+      });
+
+      const response = await supertest(app)
+        .get(`/v2/project-methodology/${projectMethodology.cadTrustProjectMethodologyId}`)
+        .expect(200);
+
+      expect(response.body.createdAt).to.exist;
+      expect(response.body.updatedAt).to.exist;
+      expect(response.body).to.not.have.property('created_at');
+      expect(response.body).to.not.have.property('updated_at');
+    });
+  });
+
   describe('POST /v2/project-methodology (Create)', function () {
     it('should create a new project-methodology relationship via API', async function () {
       // Create a new methodology for this test to avoid conflicts with previous tests

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -741,6 +741,10 @@ describe('V2 Project API - Basic CRUD Tests', function () {
       expect(response.body.data[0].projectSector).to.deep.equal(['Agriculture']);
       expect(response.body.data[0].program).to.exist;
       expect(response.body.data[0].program.programName).to.equal('Test Program for Project');
+      expect(response.body.data[0].program.createdAt).to.exist;
+      expect(response.body.data[0].program.updatedAt).to.exist;
+      expect(response.body.data[0].program).to.not.have.property('created_at');
+      expect(response.body.data[0].program).to.not.have.property('updated_at');
     });
   });
 
@@ -775,6 +779,10 @@ describe('V2 Project API - Basic CRUD Tests', function () {
       expect(response.body.projectSector).to.deep.equal(['Energy industries (renewable-/ non renewable sources)']);
       expect(response.body.program).to.exist;
       expect(response.body.program.programName).to.equal('Test Program for Project');
+      expect(response.body.program.createdAt).to.exist;
+      expect(response.body.program.updatedAt).to.exist;
+      expect(response.body.program).to.not.have.property('created_at');
+      expect(response.body.program).to.not.have.property('updated_at');
     });
   });
 


### PR DESCRIPTION
## Summary
- Normalize timestamp fields in selected V2 resource responses to `createdAt` / `updatedAt`.
- Preserve nested payloads such as staging diffs while removing top-level snake_case timestamp aliases.
- Update V2 API docs and regression coverage for timestamp response shape.

## Test plan
- `npx cross-env NODE_ENV=test USE_SIMULATOR=true mocha --loader node_modules/extensionless/src/register.js tests/integration/helpers-normalize-timestamps.spec.js --reporter spec --exit --timeout 300000`
- `npx cross-env NODE_ENV=test USE_SIMULATOR=true CW_PORT=31311 mocha --loader node_modules/extensionless/src/register.js tests/v2/integration/project-methodology-v2.spec.js --reporter spec --exit --timeout 300000`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad response-shaping middleware on many V2 GET routes is a client-visible contract change; clients depending on snake_case timestamps on those endpoints will break, though nested `diff` is preserved.
> 
> **Overview**
> V2 JSON responses on selected climate-data routes now expose **`createdAt` / `updatedAt` only**, dropping duplicate **`created_at` / `updated_at`** fields that could appear alongside Sequelize/raw query output.
> 
> A new **`normalizeApiTimestampFields`** helper walks response payloads (arrays, nested includes, Sequelize `toJSON`), promotes snake_case timestamps when camelCase is missing, and **does not rewrite `diff`** (e.g. staging change blobs). **`src/routes/v2/index.js`** installs middleware on listed resource prefixes (methodology, project, staging, audit, governance, AEF tables, etc.) that runs normalization on **`res.json`** before send.
> 
> **`docs/cadt_rpc_api_v2.md`** example responses are updated to match. Unit and integration tests cover the helper and audit/project/project-methodology wire shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a0ae6f82d9128f6ba385e0cb8b1036171ddd4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->