### PR TITLE
fix: proxy websocket upgrades in nginx sample

### DIFF
--- a/docs/nginx/datalayer.conf
+++ b/docs/nginx/datalayer.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
     listen 80 default_server;
     server_name _;
@@ -16,10 +21,13 @@ server {
     # 2. Root path proxies everything else to CADT API at port 31310
     location / {
         proxy_pass http://localhost:31310;
+        proxy_http_version 1.1;
 
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
     }
 }


### PR DESCRIPTION
## Summary
- Add WebSocket upgrade handling to the documented nginx reverse proxy sample.
- Keep normal CADT HTTP API traffic on the same catch-all proxy path while allowing Socket.IO clients under `/v1/ws` and `/v2/ws` to connect through nginx.

## Test plan
- Reviewed the generated diff for `docs/nginx/datalayer.conf`.
- `nginx -t` not run locally because nginx is not installed in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only nginx sample change with no application or auth logic touched; misconfiguration risk is limited to deployments that copy this sample verbatim.
> 
> **Overview**
> Updates the documented nginx reverse-proxy sample so **WebSocket/Socket.IO traffic** can pass through the same catch-all proxy to CADT on port 31310, instead of breaking on upgrade requests.
> 
> Adds a **`map`** on `$http_upgrade` to set `Connection` to `upgrade` or `close`, sets **`proxy_http_version 1.1`**, and forwards **`Upgrade`** and **`Connection`** on the root `location /` block. Static `/data/` caching is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0f89f867248cefe83d3d3d14854db315abc421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->