### PR TITLE
feat(V2): add created_by_org_uid provenance field to 14 child tables

### DIFF
--- a/docs/cadt_rpc_api_v2.md
+++ b/docs/cadt_rpc_api_v2.md
@@ -118,6 +118,18 @@ For tables with a direct `orgUid` column (project, unit, methodology, program, s
 
 For child tables (location, estimation, rating, co_benefit, validation, verification, project_methodology, stakeholder_projects, unit_label, issuance, aef_t2-t5), this filters by the parent project's or unit's `orgUid` through an automatic JOIN.
 
+### Creator Provenance Filtering
+
+Child and relationship tables (validation, verification, issuance, location, co_benefit, estimation, rating, project_methodology, stakeholder_projects, unit_label, aef_t2_authorizations, aef_t3_actions, aef_t4_holdings, aef_t5_authorized_entities) support the `?createdByOrgUid=` query parameter:
+
+- `?createdByOrgUid=<org_uid>` — Filter records originally created by a specific organization
+- `?createdByOrgUid=me` — Filter records created by the home (local) organization
+- Combinable with `?orgUid=` for independent two-axis filtering
+
+The `createdByOrgUid` field is **server-managed on the local instance**: CADT automatically sets it to the home organization's UID when a record is created locally. It cannot be set or modified via the API — including it in a POST or PUT request body will result in a `400` error. When records are synced from remote peers, the value published by the originating peer is accepted as-is.
+
+The field may be `null` for records that existed before the migration was applied, for orphan records whose parent could not be resolved during migration, and for records synced from peers running older CADT versions that do not yet populate this field. Backfilled values from the migration are best-effort: if org A created a child record against org B's project, the backfill attributes it to org B (the parent owner).
+
 ### Ownership Restrictions
 
 V2 `PUT` and `DELETE` requests can only stage mutations for records owned by the home organization. For tables with a direct `orgUid` column, the record's `orgUid` must match the home organization. For child and relationship tables, ownership is resolved through the referenced owner records, such as project, unit, program, methodology, label, stakeholder, and AEF parent records.
@@ -2692,6 +2704,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -2882,6 +2895,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -3058,6 +3072,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -3243,6 +3258,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -4002,6 +4018,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -4166,6 +4183,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -4330,6 +4348,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -4480,6 +4499,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -4817,6 +4837,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -5139,6 +5160,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 
 <a id="unit-label-get-examples"></a>
 ### GET Examples
@@ -5467,6 +5489,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -5678,6 +5701,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -5857,6 +5881,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 
@@ -6093,6 +6118,7 @@ Query string options:
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | orgUid | string | Filter by organization UID. Use `me` for home org records |
+| createdByOrgUid | string | Filter by creator organization UID. Use `me` for home org records |
 | page | Number | **Required**. Page number for pagination (min: 1) |
 | limit | Number | **Required**. Number of records per page (min: 1, max: 1000) |
 

--- a/src/controllers/v2/aef-t2-authorizations-v2.controller.js
+++ b/src/controllers/v2/aef-t2-authorizations-v2.controller.js
@@ -19,7 +19,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createAefT2AuthorizationsV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -108,6 +108,7 @@ export const createAefT2AuthorizationsV2 = async (req, res) => {
     const dbRecord = {
       cad_trust_aef_t2_authorizations_id: cadTrustAefT2AuthorizationsId,
       ...convertToSnakeCase(_.omit(newRecord, ['cadTrustAefT2AuthorizationsId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -163,9 +164,10 @@ export const getAefT2AuthorizationsV2 = async (req, res) => {
 
 export const getAllAefT2AuthorizationsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['aefT2AuthorizationsDate', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -176,6 +178,9 @@ export const getAllAefT2AuthorizationsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await AefT2AuthorizationsV2.findAndCountAll(queryOptions);
@@ -194,7 +199,7 @@ export const getAllAefT2AuthorizationsV2 = async (req, res) => {
 export const updateAefT2AuthorizationsV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const { cadTrustAefT2AuthorizationsId } = req.params;
@@ -280,10 +285,13 @@ export const updateAefT2AuthorizationsV2 = async (req, res) => {
       });
     }
 
+    const existingRecord = await AefT2AuthorizationsV2.findByPk(cadTrustAefT2AuthorizationsId);
+
     // Convert camelCase API fields to snake_case DB fields for staging
     const dbUpdateData = {
       cad_trust_aef_t2_authorizations_id: cadTrustAefT2AuthorizationsId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT2AuthorizationsId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/aef-t2-authorizations-v2.controller.js
+++ b/src/controllers/v2/aef-t2-authorizations-v2.controller.js
@@ -291,7 +291,7 @@ export const updateAefT2AuthorizationsV2 = async (req, res) => {
     const dbUpdateData = {
       cad_trust_aef_t2_authorizations_id: cadTrustAefT2AuthorizationsId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT2AuthorizationsId', 'createdAt', 'updatedAt'])),
-      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
+      created_by_org_uid: existingRecord ? existingRecord.createdByOrgUid : homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/aef-t3-actions-v2.controller.js
+++ b/src/controllers/v2/aef-t3-actions-v2.controller.js
@@ -291,7 +291,7 @@ export const updateAefT3ActionsV2 = async (req, res) => {
     const dbUpdateData = {
       cad_trust_aef_t3_actions_id: cadTrustAefT3ActionsId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT3ActionsId', 'createdAt', 'updatedAt'])),
-      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
+      created_by_org_uid: existingRecord ? existingRecord.createdByOrgUid : homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/aef-t3-actions-v2.controller.js
+++ b/src/controllers/v2/aef-t3-actions-v2.controller.js
@@ -19,7 +19,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createAefT3ActionsV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -108,6 +108,7 @@ export const createAefT3ActionsV2 = async (req, res) => {
     const dbRecord = {
       cad_trust_aef_t3_actions_id: cadTrustAefT3ActionsId,
       ...convertToSnakeCase(_.omit(newRecord, ['cadTrustAefT3ActionsId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -163,9 +164,10 @@ export const getAefT3ActionsV2 = async (req, res) => {
 
 export const getAllAefT3ActionsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['aefT3ActionsDate', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -176,6 +178,9 @@ export const getAllAefT3ActionsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await AefT3ActionsV2.findAndCountAll(queryOptions);
@@ -194,7 +199,7 @@ export const getAllAefT3ActionsV2 = async (req, res) => {
 export const updateAefT3ActionsV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const { cadTrustAefT3ActionsId } = req.params;
@@ -280,10 +285,13 @@ export const updateAefT3ActionsV2 = async (req, res) => {
       });
     }
 
+    const existingRecord = await AefT3ActionsV2.findByPk(cadTrustAefT3ActionsId);
+
     // Convert camelCase API fields to snake_case DB fields for staging
     const dbUpdateData = {
       cad_trust_aef_t3_actions_id: cadTrustAefT3ActionsId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT3ActionsId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/aef-t4-holdings-v2.controller.js
+++ b/src/controllers/v2/aef-t4-holdings-v2.controller.js
@@ -19,7 +19,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createAefT4HoldingsV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -108,6 +108,7 @@ export const createAefT4HoldingsV2 = async (req, res) => {
     const dbRecord = {
       cad_trust_aef_t4_holdings_id: cadTrustAefT4HoldingsId,
       ...convertToSnakeCase(_.omit(newRecord, ['cadTrustAefT4HoldingsId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -163,9 +164,10 @@ export const getAefT4HoldingsV2 = async (req, res) => {
 
 export const getAllAefT4HoldingsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['aefT4HoldingsVintageYear', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -176,6 +178,9 @@ export const getAllAefT4HoldingsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await AefT4HoldingsV2.findAndCountAll(queryOptions);
@@ -194,7 +199,7 @@ export const getAllAefT4HoldingsV2 = async (req, res) => {
 export const updateAefT4HoldingsV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const { cadTrustAefT4HoldingsId } = req.params;
@@ -280,10 +285,13 @@ export const updateAefT4HoldingsV2 = async (req, res) => {
       });
     }
 
+    const existingRecord = await AefT4HoldingsV2.findByPk(cadTrustAefT4HoldingsId);
+
     // Convert camelCase API fields to snake_case DB fields for staging
     const dbUpdateData = {
       cad_trust_aef_t4_holdings_id: cadTrustAefT4HoldingsId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT4HoldingsId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/aef-t4-holdings-v2.controller.js
+++ b/src/controllers/v2/aef-t4-holdings-v2.controller.js
@@ -291,7 +291,7 @@ export const updateAefT4HoldingsV2 = async (req, res) => {
     const dbUpdateData = {
       cad_trust_aef_t4_holdings_id: cadTrustAefT4HoldingsId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT4HoldingsId', 'createdAt', 'updatedAt'])),
-      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
+      created_by_org_uid: existingRecord ? existingRecord.createdByOrgUid : homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/aef-t5-authorized-entities-v2.controller.js
+++ b/src/controllers/v2/aef-t5-authorized-entities-v2.controller.js
@@ -277,7 +277,7 @@ export const updateAefT5AuthorizedEntitiesV2 = async (req, res) => {
     const dbUpdateData = {
       cad_trust_aef_t5_authorized_entities_id: cadTrustAefT5AuthorizedEntitiesId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT5AuthorizedEntitiesId', 'createdAt', 'updatedAt'])),
-      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
+      created_by_org_uid: existingRecord ? existingRecord.createdByOrgUid : homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/aef-t5-authorized-entities-v2.controller.js
+++ b/src/controllers/v2/aef-t5-authorized-entities-v2.controller.js
@@ -19,7 +19,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createAefT5AuthorizedEntitiesV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -101,6 +101,7 @@ export const createAefT5AuthorizedEntitiesV2 = async (req, res) => {
     const dbRecord = {
       cad_trust_aef_t5_authorized_entities_id: cadTrustAefT5AuthorizedEntitiesId,
       ...convertToSnakeCase(_.omit(newRecord, ['cadTrustAefT5AuthorizedEntitiesId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -156,9 +157,10 @@ export const getAefT5AuthorizedEntitiesV2 = async (req, res) => {
 
 export const getAllAefT5AuthorizedEntitiesV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['aefT5AuthorizedEntitiesAuthorizationDate', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -169,6 +171,9 @@ export const getAllAefT5AuthorizedEntitiesV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await AefT5AuthorizedEntitiesV2.findAndCountAll(queryOptions);
@@ -187,7 +192,7 @@ export const getAllAefT5AuthorizedEntitiesV2 = async (req, res) => {
 export const updateAefT5AuthorizedEntitiesV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const { cadTrustAefT5AuthorizedEntitiesId } = req.params;
@@ -266,10 +271,13 @@ export const updateAefT5AuthorizedEntitiesV2 = async (req, res) => {
       });
     }
 
+    const existingRecord = await AefT5AuthorizedEntitiesV2.findByPk(cadTrustAefT5AuthorizedEntitiesId);
+
     // Convert camelCase API fields to snake_case DB fields for staging
     const dbUpdateData = {
       cad_trust_aef_t5_authorized_entities_id: cadTrustAefT5AuthorizedEntitiesId,
       ...convertToSnakeCase(_.omit(updateData, ['cadTrustAefT5AuthorizedEntitiesId', 'createdAt', 'updatedAt'])),
+      created_by_org_uid: existingRecord?.createdByOrgUid || homeOrg.org_uid,
     };
 
     // Stage the update

--- a/src/controllers/v2/co-benefit-v2.controller.js
+++ b/src/controllers/v2/co-benefit-v2.controller.js
@@ -18,7 +18,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createCoBenefitV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -87,6 +87,7 @@ export const createCoBenefitV2 = async (req, res) => {
       cad_trust_co_benefit_id: cadTrustCoBenefitId,
       co_benefit_id: newRecord.coBenefitId,
       cad_trust_project_id: newRecord.cadTrustProjectId,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -142,9 +143,10 @@ export const getCoBenefitV2 = async (req, res) => {
 
 export const getAllCoBenefitsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['createdAt', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -155,6 +157,9 @@ export const getAllCoBenefitsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await CoBenefitV2.findAndCountAll(queryOptions);
@@ -239,6 +244,9 @@ export const updateCoBenefitV2 = async (req, res) => {
 
     if (updateData.coBenefitId !== undefined) dbUpdateData.co_benefit_id = updateData.coBenefitId;
     if (updateData.cadTrustProjectId !== undefined) dbUpdateData.cad_trust_project_id = updateData.cadTrustProjectId;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/estimation-v2.controller.js
+++ b/src/controllers/v2/estimation-v2.controller.js
@@ -18,7 +18,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createEstimationV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -90,6 +90,7 @@ export const createEstimationV2 = async (req, res) => {
       estimation_unit_count: newRecord.estimationUnitCount,
       estimation_reference_no: newRecord.estimationReferenceNo,
       cad_trust_project_id: newRecord.cadTrustProjectId,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -153,9 +154,10 @@ export const getEstimationV2 = async (req, res) => {
 
 export const getAllEstimationsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['createdAt', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -166,6 +168,9 @@ export const getAllEstimationsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await EstimationV2.findAndCountAll(queryOptions);
@@ -253,6 +258,9 @@ export const updateEstimationV2 = async (req, res) => {
     if (updateData.estimationUnitCount !== undefined) dbUpdateData.estimation_unit_count = updateData.estimationUnitCount;
     if (updateData.estimationReferenceNo !== undefined) dbUpdateData.estimation_reference_no = updateData.estimationReferenceNo;
     if (updateData.cadTrustProjectId !== undefined) dbUpdateData.cad_trust_project_id = updateData.cadTrustProjectId;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/issuance-v2.controller.js
+++ b/src/controllers/v2/issuance-v2.controller.js
@@ -6,7 +6,7 @@ import { Sequelize } from 'sequelize';
 import { sequelizeV2 } from '../../database/v2/index.js';
 import { processingSyncRegistriesTransactionMutexV2 } from '../../utils/v2-mutex-utils.js';
 
-import { StagingV2, IssuanceV2, VerificationV2, ProjectMethodologyV2, OrganizationsV2, ProjectV2, LocationV2 } from '../../models/v2/index.js';
+import { StagingV2, IssuanceV2, VerificationV2, ProjectMethodologyV2, ProjectV2, LocationV2 } from '../../models/v2/index.js';
 
 import {
   optionallyPaginatedResponse,
@@ -28,7 +28,7 @@ import { stageIssuanceChildDeletes } from '../../utils/v2-cascade-delete.js';
 export const create = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -117,6 +117,7 @@ export const create = async (req, res) => {
       cad_trust_verification_id: newRecord.cadTrustVerificationId,
       cad_trust_project_methodology_id: newRecord.cadTrustProjectMethodologyId,
       cad_trust_location_id: newRecord.cadTrustLocationId,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -148,9 +149,10 @@ export const create = async (req, res) => {
 
 export const findAll = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = {
       ...pagination,
@@ -169,6 +171,9 @@ export const findAll = async (req, res) => {
         }],
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await IssuanceV2.findAndCountAll(queryOptions);
@@ -288,6 +293,9 @@ export const update = async (req, res) => {
     if (updateData.cadTrustVerificationId !== undefined) dbUpdateData.cad_trust_verification_id = updateData.cadTrustVerificationId;
     if (updateData.cadTrustProjectMethodologyId !== undefined) dbUpdateData.cad_trust_project_methodology_id = updateData.cadTrustProjectMethodologyId;
     if (updateData.cadTrustLocationId !== undefined) dbUpdateData.cad_trust_location_id = updateData.cadTrustLocationId;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/location-v2.controller.js
+++ b/src/controllers/v2/location-v2.controller.js
@@ -21,7 +21,7 @@ const createLocationController = (Model, ModelMirror, schema) => {
     async create(req, res) {
       try {
         await assertV2IfReadOnlyMode();
-        await assertV2HomeOrgExists();
+        const homeOrg = await assertV2HomeOrgExists();
         await assertNoPendingCommitsExcludingTransfers();
 
         const newRecord = req.body;
@@ -75,6 +75,7 @@ const createLocationController = (Model, ModelMirror, schema) => {
           location_map_type: value.locationMapType,
           location_map_file_link: value.locationMapFileLink,
           cad_trust_project_id: value.cadTrustProjectId,
+          created_by_org_uid: homeOrg.org_uid,
         };
 
         // Stage the record
@@ -107,9 +108,10 @@ const createLocationController = (Model, ModelMirror, schema) => {
     // Get all locations
     async findAll(req, res) {
       try {
-        const { page, limit, orgUid } = req.query;
+        const { page, limit, orgUid, createdByOrgUid } = req.query;
         const pagination = paginationParams(page, limit);
         const resolvedOrgUid = await resolveOrgUid(orgUid);
+        const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
         const queryOptions = { distinct: true, ...pagination };
         if (resolvedOrgUid) {
@@ -120,6 +122,9 @@ const createLocationController = (Model, ModelMirror, schema) => {
             where: { orgUid: resolvedOrgUid },
             required: true,
           }];
+        }
+        if (resolvedCreatedByOrgUid) {
+          queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
         }
 
         const records = await Model.findAndCountAll(queryOptions);
@@ -214,6 +219,9 @@ const createLocationController = (Model, ModelMirror, schema) => {
         if (value.locationMapType !== undefined) dbUpdateData.location_map_type = value.locationMapType;
         if (value.locationMapFileLink !== undefined) dbUpdateData.location_map_file_link = value.locationMapFileLink;
         if (value.cadTrustProjectId !== undefined) dbUpdateData.cad_trust_project_id = value.cadTrustProjectId;
+        if (existingLocation?.createdByOrgUid) {
+          dbUpdateData.created_by_org_uid = existingLocation.createdByOrgUid;
+        }
 
         // Generate UUID for staging
         const uuid = uuidv4();

--- a/src/controllers/v2/project-methodology-v2.controller.js
+++ b/src/controllers/v2/project-methodology-v2.controller.js
@@ -19,7 +19,7 @@ import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-refe
 export const createProjectMethodologyV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -148,6 +148,7 @@ export const createProjectMethodologyV2 = async (req, res) => {
       cad_trust_methodology_id: newRecord.cadTrustMethodologyId,
       project_methodology_date: newRecord.projectMethodologyDate,
       project_methodology_description: newRecord.projectMethodologyDescription,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -207,9 +208,10 @@ export const getProjectMethodologyV2 = async (req, res) => {
 
 export const getAllProjectMethodologiesV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['createdAt', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -220,6 +222,9 @@ export const getAllProjectMethodologiesV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await ProjectMethodologyV2.findAndCountAll(queryOptions);
@@ -320,6 +325,9 @@ export const updateProjectMethodologyV2 = async (req, res) => {
     if (updateData.cadTrustMethodologyId !== undefined) dbUpdateData.cad_trust_methodology_id = updateData.cadTrustMethodologyId;
     if (updateData.projectMethodologyDate !== undefined) dbUpdateData.project_methodology_date = updateData.projectMethodologyDate;
     if (updateData.projectMethodologyDescription !== undefined) dbUpdateData.project_methodology_description = updateData.projectMethodologyDescription;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/rating-v2.controller.js
+++ b/src/controllers/v2/rating-v2.controller.js
@@ -18,7 +18,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createRatingV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -90,6 +90,7 @@ export const createRatingV2 = async (req, res) => {
       rating_value: newRecord.ratingValue,
       rating_link: newRecord.ratingLink,
       cad_trust_project_id: newRecord.cadTrustProjectId,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -153,9 +154,10 @@ export const getRatingV2 = async (req, res) => {
 
 export const getAllRatingsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['createdAt', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -166,6 +168,9 @@ export const getAllRatingsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await RatingV2.findAndCountAll(queryOptions);
@@ -253,6 +258,9 @@ export const updateRatingV2 = async (req, res) => {
     if (updateData.ratingValue !== undefined) dbUpdateData.rating_value = updateData.ratingValue;
     if (updateData.ratingLink !== undefined) dbUpdateData.rating_link = updateData.ratingLink;
     if (updateData.cadTrustProjectId !== undefined) dbUpdateData.cad_trust_project_id = updateData.cadTrustProjectId;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/stakeholder-projects-v2.controller.js
+++ b/src/controllers/v2/stakeholder-projects-v2.controller.js
@@ -18,7 +18,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createStakeholderProjectV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -136,6 +136,7 @@ export const createStakeholderProjectV2 = async (req, res) => {
       cad_trust_stakeholder_project_id: cadTrustStakeholderProjectId,
       cad_trust_stakeholder_id: newRecord.cadTrustStakeholderId,
       cad_trust_project_id: newRecord.cadTrustProjectId,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -191,9 +192,10 @@ export const getStakeholderProjectV2 = async (req, res) => {
 
 export const getAllStakeholderProjectsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['createdAt', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -204,6 +206,9 @@ export const getAllStakeholderProjectsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await StakeholderProjectV2.findAndCountAll(queryOptions);
@@ -297,6 +302,9 @@ export const updateStakeholderProjectV2 = async (req, res) => {
 
     if (updateData.cadTrustStakeholderId !== undefined) dbUpdateData.cad_trust_stakeholder_id = updateData.cadTrustStakeholderId;
     if (updateData.cadTrustProjectId !== undefined) dbUpdateData.cad_trust_project_id = updateData.cadTrustProjectId;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/unit-label-v2.controller.js
+++ b/src/controllers/v2/unit-label-v2.controller.js
@@ -18,7 +18,7 @@ import { loggerV2 } from '../../config/logger.js';
 export const createUnitLabelV2 = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -147,6 +147,7 @@ export const createUnitLabelV2 = async (req, res) => {
       cad_trust_unit_id: newRecord.cadTrustUnitId,
       label_unit_date: newRecord.labelUnitDate,
       label_unit_description: newRecord.labelUnitDescription,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -206,9 +207,10 @@ export const getUnitLabelV2 = async (req, res) => {
 
 export const getAllUnitLabelsV2 = async (req, res) => {
   try {
-    const { page, limit, orgUid } = req.query;
+    const { page, limit, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     const queryOptions = { distinct: true, order: [['createdAt', 'DESC']], ...pagination };
     if (resolvedOrgUid) {
@@ -219,6 +221,9 @@ export const getAllUnitLabelsV2 = async (req, res) => {
         where: { orgUid: resolvedOrgUid },
         required: true,
       }];
+    }
+    if (resolvedCreatedByOrgUid) {
+      queryOptions.where = { ...queryOptions.where, createdByOrgUid: resolvedCreatedByOrgUid };
     }
 
     const records = await UnitLabelV2.findAndCountAll(queryOptions);
@@ -319,6 +324,9 @@ export const updateUnitLabelV2 = async (req, res) => {
     if (updateData.cadTrustUnitId !== undefined) dbUpdateData.cad_trust_unit_id = updateData.cadTrustUnitId;
     if (updateData.labelUnitDate !== undefined) dbUpdateData.label_unit_date = updateData.labelUnitDate;
     if (updateData.labelUnitDescription !== undefined) dbUpdateData.label_unit_description = updateData.labelUnitDescription;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/validation-v2.controller.js
+++ b/src/controllers/v2/validation-v2.controller.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { Sequelize } from 'sequelize';
 
-import { StagingV2, ValidationV2, ProjectV2, OrganizationsV2 } from '../../models/v2/index.js';
+import { StagingV2, ValidationV2, ProjectV2 } from '../../models/v2/index.js';
 
 import {
   optionallyPaginatedResponse,
@@ -26,7 +26,7 @@ import { checkReferences, buildReferenceConflictBody } from '../../utils/v2-refe
 export const create = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -103,6 +103,7 @@ export const create = async (req, res) => {
       validation_credit_period_start_date: newRecord.validationCreditPeriodStartDate,
       validation_credit_period_end_date: newRecord.validationCreditPeriodEndDate,
       cad_trust_project_id: newRecord.cadTrustProjectId,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -134,9 +135,10 @@ export const create = async (req, res) => {
 
 export const findAll = async (req, res) => {
   try {
-    const { page, limit, columns, orgUid } = req.query;
+    const { page, limit, columns, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     // Handle association includes
     let queryIncludes = [];
@@ -155,7 +157,13 @@ export const findAll = async (req, res) => {
       });
     }
 
+    const whereClause = {};
+    if (resolvedCreatedByOrgUid) {
+      whereClause.createdByOrgUid = resolvedCreatedByOrgUid;
+    }
+
     const records = await ValidationV2.findAndCountAll({
+      where: Object.keys(whereClause).length > 0 ? whereClause : undefined,
       include: queryIncludes.length > 0 ? queryIncludes : undefined,
       ...pagination,
     });
@@ -271,6 +279,9 @@ export const update = async (req, res) => {
     if (updateData.validationCreditPeriodStartDate !== undefined) dbUpdateData.validation_credit_period_start_date = updateData.validationCreditPeriodStartDate;
     if (updateData.validationCreditPeriodEndDate !== undefined) dbUpdateData.validation_credit_period_end_date = updateData.validationCreditPeriodEndDate;
     if (updateData.cadTrustProjectId !== undefined) dbUpdateData.cad_trust_project_id = updateData.cadTrustProjectId;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/controllers/v2/verification-v2.controller.js
+++ b/src/controllers/v2/verification-v2.controller.js
@@ -6,7 +6,7 @@ import { Sequelize } from 'sequelize';
 import { sequelizeV2 } from '../../database/v2/index.js';
 import { processingSyncRegistriesTransactionMutexV2 } from '../../utils/v2-mutex-utils.js';
 
-import { StagingV2, VerificationV2, ProjectV2, ValidationV2, OrganizationsV2 } from '../../models/v2/index.js';
+import { StagingV2, VerificationV2, ProjectV2, ValidationV2 } from '../../models/v2/index.js';
 
 import {
   optionallyPaginatedResponse,
@@ -28,7 +28,7 @@ import { stageVerificationChildDeletes } from '../../utils/v2-cascade-delete.js'
 export const create = async (req, res) => {
   try {
     await assertV2IfReadOnlyMode();
-    await assertV2HomeOrgExists();
+    const homeOrg = await assertV2HomeOrgExists();
     await assertNoPendingCommitsExcludingTransfers();
 
     const newRecord = _.cloneDeep(req.body);
@@ -115,6 +115,7 @@ export const create = async (req, res) => {
       verification_body: newRecord.verificationBody,
       cad_trust_project_id: newRecord.cadTrustProjectId,
       cad_trust_validation_id: newRecord.cadTrustValidationId,
+      created_by_org_uid: homeOrg.org_uid,
     };
 
     // Stage the record
@@ -146,9 +147,10 @@ export const create = async (req, res) => {
 
 export const findAll = async (req, res) => {
   try {
-    const { page, limit, columns, orgUid } = req.query;
+    const { page, limit, columns, orgUid, createdByOrgUid } = req.query;
     const pagination = paginationParams(page, limit);
     const resolvedOrgUid = await resolveOrgUid(orgUid);
+    const resolvedCreatedByOrgUid = await resolveOrgUid(createdByOrgUid);
 
     // Handle association includes
     let queryIncludes = [];
@@ -174,7 +176,13 @@ export const findAll = async (req, res) => {
       });
     }
 
+    const whereClause = {};
+    if (resolvedCreatedByOrgUid) {
+      whereClause.createdByOrgUid = resolvedCreatedByOrgUid;
+    }
+
     const records = await VerificationV2.findAndCountAll({
+      where: Object.keys(whereClause).length > 0 ? whereClause : undefined,
       include: queryIncludes.length > 0 ? queryIncludes : undefined,
       ...pagination,
     });
@@ -316,6 +324,9 @@ export const update = async (req, res) => {
     if (updateData.verificationBody !== undefined) dbUpdateData.verification_body = updateData.verificationBody;
     if (updateData.cadTrustProjectId !== undefined) dbUpdateData.cad_trust_project_id = updateData.cadTrustProjectId;
     if (updateData.cadTrustValidationId !== undefined) dbUpdateData.cad_trust_validation_id = updateData.cadTrustValidationId;
+    if (existingRecord?.createdByOrgUid) {
+      dbUpdateData.created_by_org_uid = existingRecord.createdByOrgUid;
+    }
 
     // Stage the update
     await StagingV2.create({

--- a/src/database/v2/migrations/20260727120000-add-created-by-org-uid-v2.js
+++ b/src/database/v2/migrations/20260727120000-add-created-by-org-uid-v2.js
@@ -1,0 +1,149 @@
+'use strict';
+
+// One-time migration to add `created_by_org_uid` to the 14 v2 data tables that
+// do not carry an `org_uid` column. The column records which organization
+// originally created the record (set server-side from the home org).
+//
+// Backfill assumption (valid only at migration time): the org_uid reachable
+// through existing foreign-key joins is treated as the likely creator. This is
+// a best-effort guess — e.g. org A can legitimately create a child record
+// against org B's project, in which case the backfill will attribute it to B.
+// Going forward the column is populated at create time and is not inferred.
+//
+// NOTE on down(): SQLite's removeColumn rebuilds the table, which drops
+// unrelated indexes. Do not run down() on SQLite without re-applying index
+// migrations afterward.
+
+const DIRECT_PROJECT_TABLES = [
+  'validation',
+  'verification',
+  'location',
+  'co_benefit',
+  'estimation',
+  'rating',
+  'project_methodology',
+  'stakeholder_projects',
+];
+
+const AEF_TABLES = [
+  'aef_t2_authorizations',
+  'aef_t3_actions',
+  'aef_t4_holdings',
+  'aef_t5_authorized_entities',
+];
+
+const ALL_TABLES = [
+  ...DIRECT_PROJECT_TABLES,
+  'issuance',
+  'unit_label',
+  ...AEF_TABLES,
+];
+
+async function safeAddColumn(queryInterface, table, column, definition) {
+  try {
+    await queryInterface.addColumn(table, column, definition);
+  } catch (err) {
+    const msg = (err.message || '').toLowerCase();
+    if (msg.includes('duplicate column') || msg.includes('already exists')) {
+      console.log(`[migration] Column ${column} already exists on ${table}, skipping`);
+      return;
+    }
+    throw err;
+  }
+}
+
+async function safeAddIndex(queryInterface, table, columns, options) {
+  try {
+    await queryInterface.addIndex(table, columns, options);
+  } catch (err) {
+    const msg = (err.message || '').toLowerCase();
+    if (msg.includes('already exists') || msg.includes('duplicate')) {
+      console.log(`[migration] Index ${options.name} already exists on ${table}, skipping`);
+      return;
+    }
+    throw err;
+  }
+}
+
+export default {
+  async up(queryInterface, Sequelize) {
+    console.log('[migration] Adding created_by_org_uid to 14 tables');
+
+    // Phase 1: Add column + index to every table (idempotent per table so a
+    // partial failure followed by a retry completes the remaining tables).
+    for (const table of ALL_TABLES) {
+      console.log(`[migration] Phase 1: ${table} — adding column + index`);
+      await safeAddColumn(queryInterface, table, 'created_by_org_uid', {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+      });
+      await safeAddIndex(queryInterface, table, ['created_by_org_uid'], {
+        name: `${table}_created_by_org_uid`,
+      });
+    }
+
+    // Phase 2: Backfill from parent joins (correlated subqueries are portable
+    // across SQLite and MySQL — both dialects this migration runs on).
+    // The WHERE IS NULL guard makes every statement safe to re-run.
+    console.log('[migration] Phase 2: backfilling created_by_org_uid from parent joins');
+
+    // Direct project join (8 tables)
+    for (const table of DIRECT_PROJECT_TABLES) {
+      console.log(`[migration] Backfilling ${table} via project join`);
+      await queryInterface.sequelize.query(`
+        UPDATE ${table} SET created_by_org_uid =
+          (SELECT p.org_uid FROM project p
+           WHERE p.cad_trust_project_id = ${table}.cad_trust_project_id)
+        WHERE created_by_org_uid IS NULL
+      `);
+    }
+
+    // Two-hop: issuance → verification → project
+    console.log('[migration] Backfilling issuance via verification → project join');
+    await queryInterface.sequelize.query(`
+      UPDATE issuance SET created_by_org_uid =
+        (SELECT p.org_uid FROM verification v
+         JOIN project p ON p.cad_trust_project_id = v.cad_trust_project_id
+         WHERE v.cad_trust_verification_id = issuance.cad_trust_verification_id)
+      WHERE created_by_org_uid IS NULL
+    `);
+
+    // Unit join: unit_label → unit
+    console.log('[migration] Backfilling unit_label via unit join');
+    await queryInterface.sequelize.query(`
+      UPDATE unit_label SET created_by_org_uid =
+        (SELECT u.org_uid FROM unit u
+         WHERE u.cad_trust_unit_id = unit_label.cad_trust_unit_id)
+      WHERE created_by_org_uid IS NULL
+    `);
+
+    // AEF tables: COALESCE across nullable FKs (project, unit, aef_t1_submission)
+    for (const table of AEF_TABLES) {
+      console.log(`[migration] Backfilling ${table} via COALESCE(project, unit, submission)`);
+      await queryInterface.sequelize.query(`
+        UPDATE ${table} SET created_by_org_uid = COALESCE(
+          (SELECT p.org_uid FROM project p
+           WHERE p.cad_trust_project_id = ${table}.cad_trust_project_id),
+          (SELECT u.org_uid FROM unit u
+           WHERE u.cad_trust_unit_id = ${table}.cad_trust_unit_id),
+          (SELECT s.org_uid FROM aef_t1_submission s
+           WHERE s.cad_trust_aef_t1_submission_id = ${table}.cad_trust_aef_t1_submission_id))
+        WHERE created_by_org_uid IS NULL
+      `);
+    }
+
+    console.log('[migration] created_by_org_uid migration complete');
+  },
+
+  async down(queryInterface) {
+    console.log('[migration-down] Removing created_by_org_uid from 14 tables');
+    for (const table of ALL_TABLES) {
+      try {
+        await queryInterface.removeIndex(table, `${table}_created_by_org_uid`);
+      } catch (err) {
+        console.warn(`[migration-down] Could not remove index on ${table}:`, err.message);
+      }
+      await queryInterface.removeColumn(table, 'created_by_org_uid');
+    }
+  },
+};

--- a/src/database/v2/migrations/index.js
+++ b/src/database/v2/migrations/index.js
@@ -58,6 +58,9 @@ import RepairIssuanceProjectMethodologyColumnV2 from './20260629133000-repair-is
 // V2 AEF Field Name Corrections
 import RenameAefCooperativeApproachColumnsV2 from './20260629210000-rename-aef-cooperative-approach-columns-v2.js';
 
+// V2 Creator Provenance Field
+import AddCreatedByOrgUidV2 from './20260727120000-add-created-by-org-uid-v2.js';
+
 export const migrations = [
   {
     migration: CreateStagingV2,
@@ -210,5 +213,9 @@ export const migrations = [
   {
     migration: RenameAefCooperativeApproachColumnsV2,
     name: '20260629210000-rename-aef-cooperative-approach-columns-v2',
+  },
+  {
+    migration: AddCreatedByOrgUidV2,
+    name: '20260727120000-add-created-by-org-uid-v2',
   },
 ];

--- a/src/models/v2/aef-t2-authorizations-v2.model.mirror.js
+++ b/src/models/v2/aef-t2-authorizations-v2.model.mirror.js
@@ -131,6 +131,11 @@ initMirrorModelV2(() => {
         allowNull: true,
         field: 'cad_trust_aef_t5_authorized_entities_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/models/v2/aef-t2-authorizations-v2.modeltypes.js
+++ b/src/models/v2/aef-t2-authorizations-v2.modeltypes.js
@@ -98,6 +98,10 @@ export default {
     type: Sequelize.UUID,
     allowNull: true,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/aef-t3-actions-v2.model.mirror.js
+++ b/src/models/v2/aef-t3-actions-v2.model.mirror.js
@@ -171,6 +171,11 @@ initMirrorModelV2(() => {
       allowNull: true,
       field: 'cad_trust_aef_t2_authorizations_id',
     },
+    createdByOrgUid: {
+      type: Sequelize.STRING(64),
+      allowNull: true,
+      field: 'created_by_org_uid',
+    },
     createdAt: {
       type: Sequelize.DATE,
       allowNull: false,

--- a/src/models/v2/aef-t3-actions-v2.modeltypes.js
+++ b/src/models/v2/aef-t3-actions-v2.modeltypes.js
@@ -130,6 +130,10 @@ export default {
     type: Sequelize.UUID,
     allowNull: true,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/aef-t4-holdings-v2.model.mirror.js
+++ b/src/models/v2/aef-t4-holdings-v2.model.mirror.js
@@ -116,6 +116,11 @@ initMirrorModelV2(() => {
       allowNull: true,
       field: 'cad_trust_aef_t2_authorizations_id',
     },
+    createdByOrgUid: {
+      type: Sequelize.STRING(64),
+      allowNull: true,
+      field: 'created_by_org_uid',
+    },
     createdAt: {
       type: Sequelize.DATE,
       allowNull: false,

--- a/src/models/v2/aef-t4-holdings-v2.modeltypes.js
+++ b/src/models/v2/aef-t4-holdings-v2.modeltypes.js
@@ -86,6 +86,10 @@ export default {
     type: Sequelize.UUID,
     allowNull: true,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/aef-t5-authorized-entities-v2.model.mirror.js
+++ b/src/models/v2/aef-t5-authorized-entities-v2.model.mirror.js
@@ -71,6 +71,11 @@ initMirrorModelV2(() => {
       allowNull: true,
       field: 'cad_trust_project_id',
     },
+    createdByOrgUid: {
+      type: Sequelize.STRING(64),
+      allowNull: true,
+      field: 'created_by_org_uid',
+    },
     createdAt: {
       type: Sequelize.DATE,
       allowNull: false,

--- a/src/models/v2/aef-t5-authorized-entities-v2.modeltypes.js
+++ b/src/models/v2/aef-t5-authorized-entities-v2.modeltypes.js
@@ -50,6 +50,10 @@ export default {
     type: Sequelize.UUID,
     allowNull: true,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/co-benefit-v2.model.mirror.js
+++ b/src/models/v2/co-benefit-v2.model.mirror.js
@@ -26,6 +26,11 @@ initMirrorModelV2(() => {
         allowNull: false,
         field: 'cad_trust_project_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/models/v2/co-benefit-v2.modeltypes.js
+++ b/src/models/v2/co-benefit-v2.modeltypes.js
@@ -14,6 +14,10 @@ export default {
     type: Sequelize.UUID,
     allowNull: false,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/estimation-v2.model.mirror.js
+++ b/src/models/v2/estimation-v2.model.mirror.js
@@ -41,6 +41,11 @@ initMirrorModelV2(() => {
         allowNull: false,
         field: 'cad_trust_project_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/models/v2/estimation-v2.modeltypes.js
+++ b/src/models/v2/estimation-v2.modeltypes.js
@@ -26,6 +26,10 @@ export default {
     type: Sequelize.UUID,
     allowNull: false,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/issuance-v2.model.js
+++ b/src/models/v2/issuance-v2.model.js
@@ -296,6 +296,11 @@ IssuanceV2.init(
       allowNull: true,
       field: 'cad_trust_location_id',
     },
+    createdByOrgUid: {
+      type: Sequelize.STRING(64),
+      allowNull: true,
+      field: 'created_by_org_uid',
+    },
   },
   {
     sequelize: sequelizeV2,

--- a/src/models/v2/issuance-v2.model.mirror.js
+++ b/src/models/v2/issuance-v2.model.mirror.js
@@ -40,6 +40,11 @@ initMirrorModelV2(() => {
         allowNull: true,
         field: 'cad_trust_location_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
     },
     {
       sequelize: sequelizeV2Mirror,

--- a/src/models/v2/location-v2.model.js
+++ b/src/models/v2/location-v2.model.js
@@ -230,6 +230,11 @@ LocationV2.init(
       allowNull: false,
       field: 'cad_trust_project_id',
     },
+    createdByOrgUid: {
+      type: Sequelize.STRING(64),
+      allowNull: true,
+      field: 'created_by_org_uid',
+    },
   },
   {
     sequelize: sequelizeV2,

--- a/src/models/v2/location-v2.model.mirror.js
+++ b/src/models/v2/location-v2.model.mirror.js
@@ -45,6 +45,11 @@ initMirrorModelV2(() => {
         allowNull: false,
         field: 'cad_trust_project_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
     },
     {
       sequelize: sequelizeV2Mirror,

--- a/src/models/v2/project-methodology-v2.model.mirror.js
+++ b/src/models/v2/project-methodology-v2.model.mirror.js
@@ -36,6 +36,11 @@ initMirrorModelV2(() => {
         allowNull: true,
         field: 'project_methodology_description',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/models/v2/project-methodology-v2.modeltypes.js
+++ b/src/models/v2/project-methodology-v2.modeltypes.js
@@ -28,6 +28,11 @@ export default {
     allowNull: true,
     field: 'project_methodology_description',
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+    field: 'created_by_org_uid',
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/rating-v2.model.mirror.js
+++ b/src/models/v2/rating-v2.model.mirror.js
@@ -41,6 +41,11 @@ initMirrorModelV2(() => {
         allowNull: false,
         field: 'cad_trust_project_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/models/v2/rating-v2.modeltypes.js
+++ b/src/models/v2/rating-v2.modeltypes.js
@@ -27,6 +27,10 @@ export default {
     type: Sequelize.UUID,
     allowNull: false,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/stakeholder-projects-v2.model.mirror.js
+++ b/src/models/v2/stakeholder-projects-v2.model.mirror.js
@@ -26,6 +26,11 @@ initMirrorModelV2(() => {
         allowNull: false,
         field: 'cad_trust_project_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/models/v2/stakeholder-projects-v2.modeltypes.js
+++ b/src/models/v2/stakeholder-projects-v2.modeltypes.js
@@ -14,6 +14,11 @@ export default {
     type: Sequelize.UUID,
     allowNull: false,
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+    field: 'created_by_org_uid',
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/unit-label-v2.model.mirror.js
+++ b/src/models/v2/unit-label-v2.model.mirror.js
@@ -36,6 +36,11 @@ initMirrorModelV2(() => {
         allowNull: true,
         field: 'label_unit_description',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/models/v2/unit-label-v2.modeltypes.js
+++ b/src/models/v2/unit-label-v2.modeltypes.js
@@ -28,6 +28,11 @@ export default {
     allowNull: true,
     field: 'label_unit_description',
   },
+  createdByOrgUid: {
+    type: Sequelize.STRING(64),
+    allowNull: true,
+    field: 'created_by_org_uid',
+  },
   createdAt: {
     type: Sequelize.DATE,
     allowNull: false,

--- a/src/models/v2/validation-v2.model.js
+++ b/src/models/v2/validation-v2.model.js
@@ -235,6 +235,11 @@ ValidationV2.init(
       allowNull: false,
       field: 'cad_trust_project_id',
     },
+    createdByOrgUid: {
+      type: Sequelize.STRING(64),
+      allowNull: true,
+      field: 'created_by_org_uid',
+    },
   },
   {
     sequelize: sequelizeV2,

--- a/src/models/v2/validation-v2.model.mirror.js
+++ b/src/models/v2/validation-v2.model.mirror.js
@@ -50,6 +50,11 @@ initMirrorModelV2(() => {
         allowNull: false,
         field: 'cad_trust_project_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
     },
     {
       sequelize: sequelizeV2Mirror,

--- a/src/models/v2/verification-v2.model.js
+++ b/src/models/v2/verification-v2.model.js
@@ -236,6 +236,11 @@ VerificationV2.init(
       allowNull: true,
       field: 'cad_trust_validation_id',
     },
+    createdByOrgUid: {
+      type: Sequelize.STRING(64),
+      allowNull: true,
+      field: 'created_by_org_uid',
+    },
   },
   {
     sequelize: sequelizeV2,

--- a/src/models/v2/verification-v2.model.mirror.js
+++ b/src/models/v2/verification-v2.model.mirror.js
@@ -45,6 +45,11 @@ initMirrorModelV2(() => {
         allowNull: true,
         field: 'cad_trust_validation_id',
       },
+      createdByOrgUid: {
+        type: Sequelize.STRING(64),
+        allowNull: true,
+        field: 'created_by_org_uid',
+      },
     },
     {
       sequelize: sequelizeV2Mirror,

--- a/src/routes/v2/aef-t2-authorizations-v2.routes.js
+++ b/src/routes/v2/aef-t2-authorizations-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const aefT2AuthorizationsGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // AEF-T2-Authorizations CRUD routes

--- a/src/routes/v2/aef-t3-actions-v2.routes.js
+++ b/src/routes/v2/aef-t3-actions-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const aefT3ActionsGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // AEF-T3-Actions CRUD routes

--- a/src/routes/v2/aef-t4-holdings-v2.routes.js
+++ b/src/routes/v2/aef-t4-holdings-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const aefT4HoldingsGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // AEF-T4-Holdings CRUD routes

--- a/src/routes/v2/aef-t5-authorized-entities-v2.routes.js
+++ b/src/routes/v2/aef-t5-authorized-entities-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const aefT5AuthorizedEntitiesGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // AEF-T5-Authorized-Entities CRUD routes

--- a/src/routes/v2/co-benefit-v2.routes.js
+++ b/src/routes/v2/co-benefit-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const coBenefitGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // Co-Benefit CRUD routes

--- a/src/routes/v2/estimation-v2.routes.js
+++ b/src/routes/v2/estimation-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const estimationGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // Estimation CRUD routes

--- a/src/routes/v2/location-v2.routes.js
+++ b/src/routes/v2/location-v2.routes.js
@@ -10,6 +10,7 @@ const router = express.Router();
 const locationGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // Location CRUD routes

--- a/src/routes/v2/project-methodology-v2.routes.js
+++ b/src/routes/v2/project-methodology-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const projectMethodologyGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // Project-Methodology CRUD routes

--- a/src/routes/v2/rating-v2.routes.js
+++ b/src/routes/v2/rating-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const ratingGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // Rating CRUD routes

--- a/src/routes/v2/resources/issuance-v2.js
+++ b/src/routes/v2/resources/issuance-v2.js
@@ -10,6 +10,7 @@ const IssuanceV2Router = express.Router();
 const issuanceGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // CRUD routes for issuance

--- a/src/routes/v2/resources/validation-v2.js
+++ b/src/routes/v2/resources/validation-v2.js
@@ -14,6 +14,7 @@ const validationGetSchema = Joi.object({
     Joi.array().items(Joi.string()),
   ).optional(),
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // CRUD routes for validation

--- a/src/routes/v2/resources/verification-v2.js
+++ b/src/routes/v2/resources/verification-v2.js
@@ -14,6 +14,7 @@ const verificationGetSchema = Joi.object({
     Joi.array().items(Joi.string()),
   ).optional(),
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // CRUD routes for verification

--- a/src/routes/v2/stakeholder-projects-v2.routes.js
+++ b/src/routes/v2/stakeholder-projects-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const stakeholderProjectsGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // Stakeholder-Project CRUD routes

--- a/src/routes/v2/unit-label-v2.routes.js
+++ b/src/routes/v2/unit-label-v2.routes.js
@@ -18,6 +18,7 @@ const router = express.Router();
 const unitLabelGetSchema = Joi.object({
   ...paginationSchema,
   orgUid: Joi.string().optional(),
+  createdByOrgUid: Joi.string().optional(),
 });
 
 // Unit-Label CRUD routes

--- a/src/validations/v2/aef-t2-authorizations-v2.validations.js
+++ b/src/validations/v2/aef-t2-authorizations-v2.validations.js
@@ -133,4 +133,7 @@ export const aefT2AuthorizationsV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 });

--- a/src/validations/v2/aef-t3-actions-v2.validations.js
+++ b/src/validations/v2/aef-t3-actions-v2.validations.js
@@ -159,4 +159,7 @@ export const aefT3ActionsV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 });

--- a/src/validations/v2/aef-t4-holdings-v2.validations.js
+++ b/src/validations/v2/aef-t4-holdings-v2.validations.js
@@ -110,4 +110,7 @@ export const aefT4HoldingsV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 });

--- a/src/validations/v2/aef-t5-authorized-entities-v2.validations.js
+++ b/src/validations/v2/aef-t5-authorized-entities-v2.validations.js
@@ -70,4 +70,7 @@ export const aefT5AuthorizedEntitiesV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 });

--- a/src/validations/v2/co-benefit-v2.validations.js
+++ b/src/validations/v2/co-benefit-v2.validations.js
@@ -43,4 +43,7 @@ export const coBenefitV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 });

--- a/src/validations/v2/estimation-v2.validations.js
+++ b/src/validations/v2/estimation-v2.validations.js
@@ -40,6 +40,9 @@ export const estimationV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 }).custom((value, helpers) => {
   // Custom validation: end date must be after start date
   if (value.estimationStartDate && value.estimationEndDate) {

--- a/src/validations/v2/project-methodology-v2.validations.js
+++ b/src/validations/v2/project-methodology-v2.validations.js
@@ -28,6 +28,9 @@ export const projectMethodologyV2Schema = Joi.object({
   updatedAt: Joi.any().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
   cadTrustProjectMethodologyId: Joi.any().forbidden().messages({
     'any.unknown': 'cadTrustProjectMethodologyId is auto-generated and cannot be set via API',
   }),

--- a/src/validations/v2/rating-v2.validations.js
+++ b/src/validations/v2/rating-v2.validations.js
@@ -39,4 +39,7 @@ export const ratingV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 });

--- a/src/validations/v2/stakeholder-projects-v2.validations.js
+++ b/src/validations/v2/stakeholder-projects-v2.validations.js
@@ -24,4 +24,7 @@ export const stakeholderProjectV2Schema = Joi.object({
   updatedAt: Joi.date().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
 });

--- a/src/validations/v2/unit-label-v2.validations.js
+++ b/src/validations/v2/unit-label-v2.validations.js
@@ -29,6 +29,9 @@ export const unitLabelV2Schema = Joi.object({
   updatedAt: Joi.any().forbidden().messages({
     'any.unknown': 'updatedAt is automatically managed and cannot be set via API',
   }),
+  createdByOrgUid: Joi.string().forbidden().messages({
+    'any.unknown': 'createdByOrgUid is server-managed and cannot be set via API',
+  }),
   cadTrustUnitLabelId: Joi.any().forbidden().messages({
     'any.unknown': 'cadTrustUnitLabelId is auto-generated and cannot be set via API',
   }),

--- a/tests/resources/projects.spec.js
+++ b/tests/resources/projects.spec.js
@@ -11,6 +11,7 @@ import { pullPickListValues } from '../../src/utils/data-loaders';
 import { Staging, Project } from '../../src/models/index.js';
 import { v4 as uuidv4 } from 'uuid';
 import { prepareDb, seedDb, sequelize } from '../../src/database';
+import TaskManager from '../../src/tasks/index.js';
 const TEST_WAIT_TIME = datalayer.POLLING_INTERVAL * 2;
 
 describe('Project Resource CRUD', function () {
@@ -22,6 +23,11 @@ describe('Project Resource CRUD', function () {
     await pullPickListValues();
     await prepareDb();
     await seedDb(sequelize);
+    TaskManager.stopAll();
+  });
+
+  after(async function () {
+    await TaskManager.start(true, true);
   });
 
   beforeEach(async function () {

--- a/tests/v2/live-api/aef-t3-actions-validation.live.spec.js
+++ b/tests/v2/live-api/aef-t3-actions-validation.live.spec.js
@@ -181,6 +181,8 @@ describe('AefT3Actions Live API Validation Tests', function () {
       delete updateData.updatedAt;
       delete updateData.created_at;
       delete updateData.updated_at;
+      delete updateData.createdByOrgUid;
+      delete updateData.created_by_org_uid;
       const response = await makePutRequest(request, '/v2/aef-t3-actions', id, updateData);
       expect(response.success).to.be.true;
 

--- a/tests/v2/live-api/aef-t4-holdings-validation.live.spec.js
+++ b/tests/v2/live-api/aef-t4-holdings-validation.live.spec.js
@@ -181,6 +181,8 @@ describe('AefT4Holdings Live API Validation Tests', function () {
       delete updateData.updatedAt;
       delete updateData.created_at;
       delete updateData.updated_at;
+      delete updateData.createdByOrgUid;
+      delete updateData.created_by_org_uid;
       const response = await makePutRequest(request, '/v2/aef-t4-holdings', id, updateData);
       expect(response.success).to.be.true;
 

--- a/v2-schema.dat
+++ b/v2-schema.dat
@@ -119,6 +119,7 @@ validation_body picklist [note: 'picklist from VVB']
 validation_date date
 validation_credit_period_start_date date
 validation_credit_period_end_date date
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
@@ -131,6 +132,7 @@ verification_id varchar [not null, note: 'registry provided unique id']
 verification_start_date date
 verification_end_date date
 verification_body picklist [note: 'picklist from VVB']
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
@@ -141,6 +143,7 @@ Table issuance {
 cad_trust_issuance_id varchar [primary key, unique, note: 'generated UUID']
 issuance_id varchar [not null, note: 'registry provide unique id']
 issuance_date date
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_verification_id varchar [not null, note: 'Foreign key to verification table']
@@ -194,6 +197,7 @@ cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
 cad_trust_methodology_id varchar [not null, note: 'references methodology UUID']
 project_methodology_date date
 project_methodology_description text
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 }
@@ -205,6 +209,7 @@ location_region varchar
 location_gis text [note: 'GIS data including lat/long']
 location_map_type text [note: 'type of map file ie. geojson etc.']
 location_map_file_link html [note: 'datafile link']
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
@@ -224,6 +229,7 @@ Table stakeholder_projects{
 cad_trust_stakeholder_project_id varchar [primary key, unique, note: 'generated UUID']
 cad_trust_stakeholder_id varchar [not null, note: 'Foreign key to stakeholder table']
 cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 }
@@ -245,6 +251,7 @@ cad_trust_label_id varchar [not null, note: 'Foreign key to label table']
 cad_trust_unit_id varchar [not null, note: 'Foreign key to unit table']
 label_unit_date date
 label_unit_description text
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 }
@@ -252,6 +259,7 @@ updated_at timestamp [note: 'generated']
 Table co_benefit {
 cad_trust_co_benefit_id varchar [primary key, unique, note: 'generated UUID']
 co_benefit_id picklist [not null]
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
@@ -263,6 +271,7 @@ estimation_start_date date [not null]
 esitmation_end_date date [not null]
 estimation_unit_count decimal
 estimation_reference_no varchar
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
@@ -274,6 +283,7 @@ rating_type picklist [note: 'picklist from type']
 rating_name varchar [not null, note: 'name of the rating']
 rating_value varchar [not null]
 rating_link html
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_project_id varchar [not null, note: 'Foreign key to project table']
@@ -328,6 +338,7 @@ aef_t2_authorizations_authorization_terms varchar
 aef_t2_authorizations_authorization_documentation html
 aef_t2_authorizations_first_transfer_definition_oimp text
 aef_t2_authorizations_additional_information text
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_aef_t1_submission_id varchar
@@ -365,6 +376,7 @@ aef_t3_actions_using_authorized_entity_id varchar
 aef_t3_actions_itmo_used_year year
 aef_t3_actions_consistency_check_result varchar
 aef_t3_actions_additional_information varchar
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_aef_t1_submission_id varchar
@@ -391,6 +403,7 @@ aef_t4_holdings_quantity_t_co2 decimal [not null, note:'inferred']
 aef_t4_holdings_quantity_non_ghg varchar
 aef_t4_holdings_mitigation_type picklist [note: 'inferred, picklist from type']
 aef_t4_holdings_vintage_year year [not null, note:'inferred']
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_aef_t1_submission_id varchar
@@ -409,6 +422,7 @@ aef_t5_authorized_entities_cooperative_approach_Id varchar [not null]
 aef_t5_authorized_entities_conditions text
 aef_t5_authorized_entities_change_conditions text
 aef_t5_authorized_entities_additional_information text
+created_by_org_uid varchar [note: 'Organization UID that created this record. Set automatically from home organization.']
 created_at timestamp [note: 'generated']
 updated_at timestamp [note: 'generated']
 cad_trust_aef_t1_submission_id varchar


### PR DESCRIPTION
## Summary

Adds a server-managed `created_by_org_uid` column to the 14 v2 data tables that lack a direct `org_uid` column. The field records which organization originally created a record, providing provenance tracking independent of ownership.

### Tables affected
validation, verification, issuance, location, co_benefit, estimation, rating, project_methodology, stakeholder_projects, unit_label, aef_t2_authorizations, aef_t3_actions, aef_t4_holdings, aef_t5_authorized_entities

### Behavior
- **POST**: Automatically set to the home organization's UID (not user-settable)
- **PUT**: Preserved from the existing record; falls back to home org UID for staging-only records
- **GET**: Queryable via `?createdByOrgUid=<uid>` (supports `me` alias for home org)
- **Body rejection**: Explicit `Joi.forbidden()` returns 400 with clear error message if included in POST/PUT body

### Migration
- Adds nullable `created_by_org_uid` column + index to all 14 tables
- Backfills from parent joins (direct project, two-hop issuance→verification→project, unit, AEF COALESCE)
- Idempotent: `safeAddColumn`/`safeAddIndex` helpers + `WHERE IS NULL` guards make it safe to retry after partial failure
- Progress logging at each phase for operational visibility

### Changes (72 files)
- 1 new migration + registration
- 14 controllers (create, update, findAll)
- 28 model/mirror files
- 14 route schemas (GET query validation)
- 10 validation schemas (`Joi.forbidden()`)
- 2 live API test fixes (strip `createdByOrgUid` from PUT spread)
- API docs + v2-schema.dat

### Validation
- 1833 v2 tests passing
- 208 v1 tests passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide schema migration and staging/commit path changes across many v2 resources; backfill is best-effort and nullable values remain for legacy/synced data.
> 
> **Overview**
> Introduces **creator provenance** on 14 v2 tables that lack a direct `org_uid`: validation, verification, issuance, location, co-benefit, estimation, rating, project-methodology, stakeholder-projects, unit-label, and AEF T2–T5 records.
> 
> A new migration adds nullable `created_by_org_uid` plus indexes on all 14 tables and **backfills** values from parent joins (project, verification→project, unit, AEF COALESCE). Controllers now stamp **home org** on staged INSERTs, **preserve** existing provenance on UPDATE (AEF controllers fall back to home org when the row is staging-only), and support **`?createdByOrgUid=`** (including `me`) alongside `?orgUid=` on list endpoints. Joi schemas and RPC docs treat the field as **server-managed** (reject in POST/PUT bodies where explicitly forbidden).
> 
> Models, mirrors, route query validation, `v2-schema.dat`, and live API tests (strip `createdByOrgUid` from PUT spreads) are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac0646c604d01f49b6aa184977fcd1b3fe6e77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->