### PR TITLE
docs: describe NaaS as affordable rather than free

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If you only need to read and consume carbon credit data, set up CADT as usual: i
 If you are a registry writing carbon credit data to the blockchain, consider Node as a Service before self-hosting.
 
 **Node as a Service (recommended)**
-Chia provides a free hosted Node as a Service (NaaS) for registry partners. Chia manages all Chia blockchain infrastructure on your behalf, so your team can focus entirely on data mapping and API integration rather than node operations. To get started with NaaS, contact CAD Trust to be onboarded as a registry partner. If you self-host instead, complete the [Installation](#installation) and [Configuration](#configuration) steps with `READ_ONLY` set to `false`.
+Chia provides an affordable hosted Node as a Service (NaaS) for registry partners. Chia manages all Chia blockchain infrastructure on your behalf, so your team can focus entirely on data mapping and API integration rather than node operations. To get started with NaaS, contact CAD Trust to be onboarded as a registry partner. If you self-host instead, complete the [Installation](#installation) and [Configuration](#configuration) steps with `READ_ONLY` set to `false`.
 
 **1. Understand the v2 data model**
 Review the machine-readable schema to understand the data tables, their fields, required values, picklists, and insert order. This is the reference your team (and any automated tools) should use when mapping your registry's data to CADT.


### PR DESCRIPTION
## Summary
- Update README NaaS wording from "free" to "affordable" to match current partner offering language.

## Test plan
- [ ] Confirm README NaaS section reads "an affordable hosted Node as a Service"
- [ ] Confirm PR targets `v2-rc2`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or API impact.
> 
> **Overview**
> Updates registry onboarding copy in **README** so Node as a Service (NaaS) is described as **an affordable** hosted offering instead of **free**, aligning partner-facing language with the current NaaS model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f66250365e2fde8ab629df1711db79ba600d9a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->