### PR TITLE
ci: publish multi-arch docker images for linux/arm64

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,4 +19,4 @@ jobs:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
       push: ${{ github.event_name != 'pull_request' }}
-      docker-platforms: linux/amd64
+      docker-platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -17,8 +17,16 @@ concurrency:
 
 jobs:
   docker-smoke-test:
-    name: Docker smoke test
-    runs-on: ubuntu-latest
+    name: Docker smoke test (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## What

Enable `linux/arm64` alongside `linux/amd64` for the published container images, and extend the Docker smoke test to cover both architectures.

## Why

`build-docker.yml` pinned `docker-platforms: linux/amd64`, which has been the case since March 2025. The shared `Chia-Network/actions/.github/workflows/docker-build.yaml` defaults to `linux/amd64,linux/arm64` and already runs `docker/setup-qemu-action`, so the vast majority of repos in the org publish multi-arch images by simply not overriding this input. This brings CADT in line with that default.

## Why arm64 is safe for this image

- **Base images are multi-arch.** `node:24-trixie` publishes amd64/arm64/ppc64le/s390x, and `mikefarah/yq:4` publishes amd64/arm/arm64/ppc64le/s390x, so the `COPY --from=yq` cross-stage copy resolves the correct arm64 binary under buildx.
- **`sqlite3` is the only native dependency, and it is compiled from source.** The `postinstall` script runs `node-gyp rebuild --napi_build_version=6`, so there is no prebuilt-binary substitution to get wrong on arm64.
- **No other platform-locked required packages.** Every `cpu`/`os`-constrained entry in `package-lock.json` is `optional`, and the ones that matter (`@esbuild/linux-arm64`, `@typescript/typescript-linux-arm64`) have arm64 variants. The only platform-locked non-arm package is `fsevents`, which is darwin-only and optional.
- **Nothing in the `Dockerfile` or `docker-entrypoint.sh` is architecture-specific** — no arch-pinned downloads and no fetched binaries.

## Smoke test coverage

`docker-smoke-test.yml` previously built and tested only the default amd64 image. Since its `require('sqlite3')` check is exactly the thing most likely to break on a new architecture, it now runs as a per-arch matrix:

| arch | runner |
|---|---|
| `amd64` | `ubuntu-latest` |
| `arm64` | `ubuntu-24.04-arm` |

Both legs build natively rather than under emulation, so this adds PR coverage without adding QEMU time. `fail-fast: false` keeps one arch's failure from masking the other's result. `build.yaml` already builds the arm64 binary on `ubuntu-22.04-arm`, so hosted arm runners are known to work for this repo; the GLIBC pin documented there does not apply here because the container supplies its own libc.

## Tradeoff

The arm64 leg of the release build runs under QEMU on a single runner, so the tag-triggered `Build Docker Images` job will get noticeably slower — expect roughly 20-40 minutes rather than a few, driven by the emulated `npm install` and `sqlite3` compile. The reusable workflow's 360-minute timeout leaves ample headroom. If that becomes painful, the follow-up options are `enable-cache: 'true'` on the reusable workflow, or splitting per-arch builds onto native runners with a manifest merge (which would mean not using the shared reusable workflow).

## Notes for reviewers

- The smoke test job name changes from `Docker smoke test` to `Docker smoke test (amd64)` / `(arm64)`. I confirmed `develop` has no required status checks configured and the only ruleset on the repo targets tags, so no merge gate breaks.
- Nothing verifies the arm64 image end to end until this merges and the smoke test runs on this PR — that is the intended verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflows; no application, Dockerfile, or runtime code is modified.
> 
> **Overview**
> **Release builds** now pass `linux/amd64,linux/arm64` into the shared `docker-build` workflow so tagged releases publish multi-arch images instead of amd64-only.
> 
> **PR/push smoke tests** run as a **matrix** over `amd64` (`ubuntu-latest`) and `arm64` (`ubuntu-24.04-arm`), each building the image natively and running the existing `sqlite3` load and health-check steps. Job names become `Docker smoke test (amd64)` / `(arm64)` with `fail-fast: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac507114473565c1c2af4f5f7271ccac42d2524e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->