### PR TITLE
ci: publish multi-arch docker images for linux/arm64

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,4 +19,4 @@ jobs:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
       push: ${{ github.event_name != 'pull_request' }}
-      docker-platforms: linux/amd64
+      docker-platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -17,8 +17,16 @@ concurrency:
 
 jobs:
   docker-smoke-test:
-    name: Docker smoke test
-    runs-on: ubuntu-latest
+    name: Docker smoke test (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+          - arch: arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## What

Enable `linux/arm64` alongside `linux/amd64` for the published container images, and extend the Docker smoke test to cover both architectures.

Same change as #1722 (which targets `develop`), applied to the `v2-rc2` release line so the RC containers are multi-arch too.

## Why

`build-docker.yml` pinned `docker-platforms: linux/amd64`, which has been the case since March 2025. The shared `Chia-Network/actions/.github/workflows/docker-build.yaml` defaults to `linux/amd64,linux/arm64` and already runs `docker/setup-qemu-action`, so most repos in the org publish multi-arch images by simply not overriding this input. This brings CADT in line with that default.

## Why arm64 is safe for this image

- **Base images are multi-arch.** `node:24-trixie` publishes amd64/arm64/ppc64le/s390x, and `mikefarah/yq:4` publishes amd64/arm/arm64/ppc64le/s390x, so the `COPY --from=yq` cross-stage copy resolves the correct arm64 binary under buildx.
- **`sqlite3` is the only native dependency, and it is compiled from source.** The `postinstall` script runs `node-gyp rebuild --napi_build_version=6`, so there is no prebuilt-binary substitution to get wrong on arm64.
- **No other platform-locked required packages.** Every `cpu`/`os`-constrained entry in `package-lock.json` is `optional`, and the ones that matter (`@esbuild/linux-arm64`, `@typescript/typescript-linux-arm64`) have arm64 variants. The only platform-locked non-arm package is `fsevents`, which is darwin-only and optional.
- **Nothing in the `Dockerfile` or `docker-entrypoint.sh` is architecture-specific** — no arch-pinned downloads and no fetched binaries.

## Verified, not assumed

The equivalent change on #1722 ran the new arm64 smoke test leg green in 2m34s (versus 2m10s for amd64, both native). The arm64 job log confirms the parts that actually mattered:

```
sqlite3 native module loaded OK
Server started successfully
All health checks passed
```

So the `sqlite3` native addon compiles and loads on aarch64, and `/health`, `/v1/health`, `/v2/health` all respond inside the arm64 image.

## Smoke test coverage

`docker-smoke-test.yml` previously built and tested only the default amd64 image. Since its `require('sqlite3')` check is exactly the thing most likely to break on a new architecture, it now runs as a per-arch matrix:

| arch | runner |
|---|---|
| `amd64` | `ubuntu-latest` |
| `arm64` | `ubuntu-24.04-arm` |

Both legs build natively rather than under emulation, so this adds PR coverage without adding QEMU time. `fail-fast: false` keeps one arch's failure from masking the other's result. `build.yaml` already builds the arm64 binary on `ubuntu-22.04-arm`, so hosted arm runners are known to work for this repo; the GLIBC pin documented there does not apply here because the container supplies its own libc.

## Tradeoff

The arm64 leg of the release build runs under QEMU on a single runner, so the tag-triggered `Build Docker Images` job will get noticeably slower — expect roughly 20-40 minutes rather than a few, driven by the emulated `npm install` and `sqlite3` compile. The reusable workflow's 360-minute timeout leaves ample headroom. If that becomes painful, the follow-up options are `enable-cache: 'true'` on the reusable workflow, or splitting per-arch builds onto native runners with a manifest merge (which would mean not using the shared reusable workflow).

## Notes for reviewers

- The smoke test job name changes from `Docker smoke test` to `Docker smoke test (amd64)` / `(arm64)`. I confirmed the repo has no required status checks configured on its protected branches and its only ruleset targets tags, so no merge gate breaks.
- This is cherry-picked onto a branch cut from `v2-rc2` rather than retargeting #1722, so the diff here is exactly the two workflow files and nothing from `develop` leaks in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflows; no runtime application or security logic is modified, though release image builds may run longer.
> 
> **Overview**
> **Release builds** now publish **`linux/arm64`** images in addition to **`linux/amd64`** by setting `docker-platforms: linux/amd64,linux/arm64` in `build-docker.yml` (was amd64-only).
> 
> **PR smoke tests** run on a **per-arch matrix**: amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`, each building and exercising the image natively (`sqlite3` load, container start, health endpoints). Job names become `Docker smoke test (amd64)` / `(arm64)` with `fail-fast: false` so one arch failure does not cancel the other.
> 
> Tag-triggered release Docker builds may take longer because arm64 is built via QEMU on a single runner; PR smoke coverage does not add QEMU time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6ec47da0324e7747e1bbefd1d35244b053f3ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->