### PR TITLE
fix: coerce numeric config values and size coins above chia's dust threshold

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -46,6 +46,8 @@ jobs:
           docker run -d --name cadt-test \
             -e USE_SIMULATOR=true \
             -e BIND_ADDRESS=0.0.0.0 \
+            -e DEFAULT_FEE=13 \
+            -e DEFAULT_COIN_AMOUNT=7 \
             -p 31310:31310 \
             cadt-smoke-test
 
@@ -74,3 +76,17 @@ jobs:
           curl -sf http://localhost:31310/v2/health | jq .
 
           echo "All health checks passed"
+
+          # Numeric env vars must reach config.yaml as YAML numbers. Quoted
+          # values make the app concatenate them instead of adding them.
+          echo "Checking numeric config values are unquoted..."
+          docker exec cadt-test cat /root/.chia/mainnet/cadt/config.yaml
+
+          docker exec cadt-test \
+            grep -qE '^[[:space:]]*DEFAULT_FEE: 13$' \
+            /root/.chia/mainnet/cadt/config.yaml
+          docker exec cadt-test \
+            grep -qE '^[[:space:]]*DEFAULT_COIN_AMOUNT: 7$' \
+            /root/.chia/mainnet/cadt/config.yaml
+
+          echo "Numeric config values are unquoted"

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -48,6 +48,7 @@ jobs:
             -e BIND_ADDRESS=0.0.0.0 \
             -e DEFAULT_FEE=13 \
             -e DEFAULT_COIN_AMOUNT=7 \
+            -e V1_GOVERNANCE_BODY_ID=12345678 \
             -p 31310:31310 \
             cadt-smoke-test
 
@@ -77,16 +78,30 @@ jobs:
 
           echo "All health checks passed"
 
-          # Numeric env vars must reach config.yaml as YAML numbers. Quoted
-          # values make the app concatenate them instead of adding them.
-          echo "Checking numeric config values are unquoted..."
-          docker exec cadt-test cat /root/.chia/mainnet/cadt/config.yaml
+          # Numeric env vars must reach config.yaml as YAML numbers (quoted
+          # values make the app concatenate them instead of adding them), while
+          # digit-only values on non-numeric keys must keep their quotes.
+          # Only the asserted keys are printed: config.yaml is where every
+          # secret converges, so it must not be dumped into a public build log.
+          echo "Checking config.yaml value types..."
 
-          docker exec cadt-test \
-            grep -qE '^[[:space:]]*DEFAULT_FEE: 13$' \
-            /root/.chia/mainnet/cadt/config.yaml
-          docker exec cadt-test \
-            grep -qE '^[[:space:]]*DEFAULT_COIN_AMOUNT: 7$' \
-            /root/.chia/mainnet/cadt/config.yaml
+          assert_config_line() {
+            local pattern=$1 description=$2
+            if ! docker exec cadt-test \
+              grep -qE "$pattern" /root/.chia/mainnet/cadt/config.yaml; then
+              echo "FAIL: $description"
+              docker exec cadt-test \
+                grep -nE 'DEFAULT_FEE|DEFAULT_COIN_AMOUNT|GOVERNANCE_BODY_ID' \
+                /root/.chia/mainnet/cadt/config.yaml
+              exit 1
+            fi
+          }
 
-          echo "Numeric config values are unquoted"
+          assert_config_line '^[[:space:]]*DEFAULT_FEE: 13$' \
+            "DEFAULT_FEE was not written as an unquoted YAML number"
+          assert_config_line '^[[:space:]]*DEFAULT_COIN_AMOUNT: 7$' \
+            "DEFAULT_COIN_AMOUNT was not written as an unquoted YAML number"
+          assert_config_line '^[[:space:]]*GOVERNANCE_BODY_ID: "12345678"$' \
+            "a digit-only GOVERNANCE_BODY_ID lost its quotes"
+
+          echo "config.yaml value types are correct"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,6 +63,19 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v7
 
+      # mikefarah yq, matching the Dockerfile. Debian's `yq` package is the
+      # unrelated jq-based python-yq, which has no `eval` subcommand, so the
+      # docker-entrypoint.sh tests would skip themselves against it. Pinned to
+      # the same major the image builds from, so CI cannot start validating the
+      # entrypoint against a yq that production never runs.
+      - name: Install yq
+        run: |
+          curl -fsSL \
+            https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64 \
+            -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
       - name: Ignore Husky
         run: npm pkg delete scripts.prepare
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -65,21 +65,17 @@ update_app_config() {
     update_yaml_if_env_exists "$env_var" ".APP$yaml_path" "$UNIFIED_CONFIG_PATH"
 }
 
-# Same as update_app_config, but writes plain integers as YAML numbers instead
-# of quoted strings so the JS layer can do arithmetic on them (a quoted "300"
-# plus a quoted "300" concatenates to "300300" rather than adding to 600).
-# Scoped to keys that are numeric by contract: digit-only strings elsewhere
-# (API keys, DB names, governance body IDs) must keep their quotes. Anything
-# that is not a plain integer falls through to the generic handler, so boolean,
-# empty and string values behave exactly as before.
+# Writes unsigned integers as YAML numbers so the JS layer gets numbers, not
+# strings. Only for keys numeric by contract: digit-only values elsewhere (API
+# keys, DB names, governance body IDs) must keep their quotes. Anything else
+# falls through to update_app_config unchanged.
 update_numeric_app_config() {
     local env_var=$1
     local yaml_path=$2
 
-    # yq rejects integers wider than int64, so fall back to the generic writer
-    # on failure too; a quoted value the JS layer coerces beats dropping the
-    # operator's setting on the floor.
-    if [ -n "${!env_var+x}" ] && [[ "${!env_var}" =~ ^-?[0-9]+$ ]] &&
+    # yq rejects integers wider than int64. A quoted value the JS layer coerces
+    # beats dropping the setting, so a failed write falls through too.
+    if [ -n "${!env_var+x}" ] && [[ "${!env_var}" =~ ^[0-9]+$ ]] &&
         yq eval ".APP$yaml_path |= ${!env_var}" -i "$UNIFIED_CONFIG_PATH"; then
         return 0
     fi
@@ -103,11 +99,11 @@ update_v2_config() {
     update_yaml_if_env_exists "$env_var" ".V2$yaml_path" "$UNIFIED_CONFIG_PATH"
 }
 
-# Sourcing this script yields only the helper functions above, which is how
-# tests drive them against a temporary config file. Executing it runs the
-# container startup below. Keyed on sourcing rather than an environment
-# variable so a stray variable can never stop a real container from starting.
-if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+# Sourcing yields only the helper functions above, which is how tests drive them
+# against a temporary config file; executing runs container startup below. The
+# bash shebang guarantees BASH_SOURCE is populated whenever this is executed, so
+# an empty one means a non-bash shell sourced us and startup must not run.
+if [ "${BASH_SOURCE[0]:-}" != "$0" ]; then
     return 0
 fi
 
@@ -136,7 +132,7 @@ update_app_config "DATALAYER_FILE_SERVER_URL" '.DATALAYER_FILE_SERVER_URL'
 update_app_config "AUTO_SUBSCRIBE_FILESTORE" '.AUTO_SUBSCRIBE_FILESTORE'
 update_app_config "AUTO_MIRROR_EXTERNAL_STORES" '.AUTO_MIRROR_EXTERNAL_STORES'
 update_app_config "LOG_LEVEL" '.LOG_LEVEL'
-update_numeric_app_config "TRUST_PROXY" '.TRUST_PROXY'
+update_app_config "TRUST_PROXY" '.TRUST_PROXY'
 
 # APP.TASKS section (shared)
 update_numeric_app_config "GOVERNANCE_SYNC_TASK_INTERVAL" '.TASKS.GOVERNANCE_SYNC_TASK_INTERVAL'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -57,22 +57,30 @@ EOF
     fi
 }
 
-# Create config directories if they don't exist
-# V1 and V2 directories still needed for databases
-mkdir -p /root/.chia/mainnet/cadt/v1
-mkdir -p /root/.chia/mainnet/cadt/v2
-# Unified config directory
-mkdir -p /root/.chia/mainnet/cadt
-
-# Create unified config file if it doesn't exist
-create_config_if_not_exists "$UNIFIED_CONFIG_PATH"
-
 # Function to update unified config with environment variables for APP section
 update_app_config() {
     local env_var=$1
     local yaml_path=$2
 
     update_yaml_if_env_exists "$env_var" ".APP$yaml_path" "$UNIFIED_CONFIG_PATH"
+}
+
+# Same as update_app_config, but writes plain integers as YAML numbers instead
+# of quoted strings so the JS layer can do arithmetic on them (a quoted "300"
+# plus a quoted "300" concatenates to "300300" rather than adding to 600).
+# Scoped to keys that are numeric by contract: digit-only strings elsewhere
+# (API keys, DB names, governance body IDs) must keep their quotes. Anything
+# that is not a plain integer falls through to the generic handler, so boolean,
+# empty and string values behave exactly as before.
+update_numeric_app_config() {
+    local env_var=$1
+    local yaml_path=$2
+
+    if [ -n "${!env_var+x}" ] && [[ "${!env_var}" =~ ^-?[0-9]+$ ]]; then
+        yq eval ".APP$yaml_path |= ${!env_var}" -i "$UNIFIED_CONFIG_PATH"
+    else
+        update_app_config "$env_var" "$yaml_path"
+    fi
 }
 
 # Function to update unified config with environment variables for V1 section
@@ -91,37 +99,53 @@ update_v2_config() {
     update_yaml_if_env_exists "$env_var" ".V2$yaml_path" "$UNIFIED_CONFIG_PATH"
 }
 
+# Tests source this script to exercise the helpers above against a temporary
+# config file; stop before anything touches /root/.chia or execs the server.
+if [ -n "${CADT_ENTRYPOINT_FUNCTIONS_ONLY:-}" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+# Create config directories if they don't exist
+# V1 and V2 directories still needed for databases
+mkdir -p /root/.chia/mainnet/cadt/v1
+mkdir -p /root/.chia/mainnet/cadt/v2
+# Unified config directory
+mkdir -p /root/.chia/mainnet/cadt
+
+# Create unified config file if it doesn't exist
+create_config_if_not_exists "$UNIFIED_CONFIG_PATH"
+
 # APP section (shared across V1 and V2)
-update_app_config "CW_PORT" '.CW_PORT'
+update_numeric_app_config "CW_PORT" '.CW_PORT'
 update_app_config "BIND_ADDRESS" '.BIND_ADDRESS'
 update_app_config "DATALAYER_URL" '.DATALAYER_URL'
 update_app_config "WALLET_URL" '.WALLET_URL'
 update_app_config "USE_SIMULATOR" '.USE_SIMULATOR'
 update_app_config "CHIA_NETWORK" '.CHIA_NETWORK'
 update_app_config "USE_DEVELOPMENT_MODE" '.USE_DEVELOPMENT_MODE'
-update_app_config "DEFAULT_FEE" '.DEFAULT_FEE'
-update_app_config "DEFAULT_COIN_AMOUNT" '.DEFAULT_COIN_AMOUNT'
+update_numeric_app_config "DEFAULT_FEE" '.DEFAULT_FEE'
+update_numeric_app_config "DEFAULT_COIN_AMOUNT" '.DEFAULT_COIN_AMOUNT'
 update_app_config "CERTIFICATE_FOLDER_PATH" '.CERTIFICATE_FOLDER_PATH'
 update_app_config "DATALAYER_FILE_SERVER_URL" '.DATALAYER_FILE_SERVER_URL'
 update_app_config "AUTO_SUBSCRIBE_FILESTORE" '.AUTO_SUBSCRIBE_FILESTORE'
 update_app_config "AUTO_MIRROR_EXTERNAL_STORES" '.AUTO_MIRROR_EXTERNAL_STORES'
 update_app_config "LOG_LEVEL" '.LOG_LEVEL'
-update_app_config "TRUST_PROXY" '.TRUST_PROXY'
+update_numeric_app_config "TRUST_PROXY" '.TRUST_PROXY'
 
 # APP.TASKS section (shared)
-update_app_config "GOVERNANCE_SYNC_TASK_INTERVAL" '.TASKS.GOVERNANCE_SYNC_TASK_INTERVAL'
-update_app_config "ORGANIZATION_META_SYNC_TASK_INTERVAL" '.TASKS.ORGANIZATION_META_SYNC_TASK_INTERVAL'
-update_app_config "PICKLIST_SYNC_TASK_INTERVAL" '.TASKS.PICKLIST_SYNC_TASK_INTERVAL'
-update_app_config "MIRROR_CHECK_TASK_INTERVAL" '.TASKS.MIRROR_CHECK_TASK_INTERVAL'
-update_app_config "VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL" '.TASKS.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL'
-update_app_config "COIN_MANAGEMENT_TASK_INTERVAL" '.TASKS.COIN_MANAGEMENT_TASK_INTERVAL'
+update_numeric_app_config "GOVERNANCE_SYNC_TASK_INTERVAL" '.TASKS.GOVERNANCE_SYNC_TASK_INTERVAL'
+update_numeric_app_config "ORGANIZATION_META_SYNC_TASK_INTERVAL" '.TASKS.ORGANIZATION_META_SYNC_TASK_INTERVAL'
+update_numeric_app_config "PICKLIST_SYNC_TASK_INTERVAL" '.TASKS.PICKLIST_SYNC_TASK_INTERVAL'
+update_numeric_app_config "MIRROR_CHECK_TASK_INTERVAL" '.TASKS.MIRROR_CHECK_TASK_INTERVAL'
+update_numeric_app_config "VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL" '.TASKS.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL'
+update_numeric_app_config "COIN_MANAGEMENT_TASK_INTERVAL" '.TASKS.COIN_MANAGEMENT_TASK_INTERVAL'
 
 # APP.REQUEST_CONTENT_LIMITS section (shared)
-update_app_config "STAGING_EDIT_DATA_LEN" '.REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN'
-update_app_config "UNITS_INCLUDE_COLUMNS_LEN" '.REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN'
-update_app_config "UNITS_MARKETPLACE_IDENTIFIERS_LEN" '.REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN'
-update_app_config "PROJECTS_INCLUDE_COLUMNS_LEN" '.REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN'
-update_app_config "PROJECTS_PROJECT_IDS_LEN" '.REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN'
+update_numeric_app_config "STAGING_EDIT_DATA_LEN" '.REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN'
+update_numeric_app_config "UNITS_INCLUDE_COLUMNS_LEN" '.REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN'
+update_numeric_app_config "UNITS_MARKETPLACE_IDENTIFIERS_LEN" '.REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN'
+update_numeric_app_config "PROJECTS_INCLUDE_COLUMNS_LEN" '.REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN'
+update_numeric_app_config "PROJECTS_PROJECT_IDS_LEN" '.REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN'
 
 # V1 section - independent configuration with V1_ prefix
 update_v1_config "V1_ENABLE" '.ENABLE'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,11 +76,15 @@ update_numeric_app_config() {
     local env_var=$1
     local yaml_path=$2
 
-    if [ -n "${!env_var+x}" ] && [[ "${!env_var}" =~ ^-?[0-9]+$ ]]; then
-        yq eval ".APP$yaml_path |= ${!env_var}" -i "$UNIFIED_CONFIG_PATH"
-    else
-        update_app_config "$env_var" "$yaml_path"
+    # yq rejects integers wider than int64, so fall back to the generic writer
+    # on failure too; a quoted value the JS layer coerces beats dropping the
+    # operator's setting on the floor.
+    if [ -n "${!env_var+x}" ] && [[ "${!env_var}" =~ ^-?[0-9]+$ ]] &&
+        yq eval ".APP$yaml_path |= ${!env_var}" -i "$UNIFIED_CONFIG_PATH"; then
+        return 0
     fi
+
+    update_app_config "$env_var" "$yaml_path"
 }
 
 # Function to update unified config with environment variables for V1 section

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -99,10 +99,12 @@ update_v2_config() {
     update_yaml_if_env_exists "$env_var" ".V2$yaml_path" "$UNIFIED_CONFIG_PATH"
 }
 
-# Tests source this script to exercise the helpers above against a temporary
-# config file; stop before anything touches /root/.chia or execs the server.
-if [ -n "${CADT_ENTRYPOINT_FUNCTIONS_ONLY:-}" ]; then
-    return 0 2>/dev/null || exit 0
+# Sourcing this script yields only the helper functions above, which is how
+# tests drive them against a temporary config file. Executing it runs the
+# container startup below. Keyed on sourcing rather than an environment
+# variable so a stray variable can never stop a real container from starting.
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    return 0
 fi
 
 # Create config directories if they don't exist

--- a/src/routes/diagnostics.js
+++ b/src/routes/diagnostics.js
@@ -364,9 +364,9 @@ const collectNonDefaultTaskIntervals = (actualTasks, defaultTasks = defaultConfi
     const defaultValue = defaultTasks?.[key];
     const actualValue = actualTasks?.[key];
     if (actualValue === undefined) continue;
-    // docker-entrypoint.sh writes env-provided intervals back as quoted YAML
-    // strings, so a config value can equal the numeric default semantically
-    // ("120" vs 120). Compare numerically when both parse as finite numbers,
+    // Config intervals are coerced to numbers by the config loader, but this
+    // helper is also called directly with raw values, where "120" and 120 mean
+    // the same thing. Compare numerically when both parse as finite numbers,
     // falling back to strict equality otherwise.
     const defaultNum = Number(defaultValue);
     const actualNum = Number(actualValue);

--- a/src/tasks/coin-management.js
+++ b/src/tasks/coin-management.js
@@ -3,8 +3,11 @@ import {
   assertDataLayerAvailable,
   assertWalletIsSynced,
 } from '../utils/data-assertions';
+import _ from 'lodash';
 import { logger } from '../config/logger.js';
 import { getConfig } from '../utils/config-loader';
+import { coerceConfigNumber } from '../utils/numeric-config.js';
+import { getChiaConfig } from '../datalayer/fullNode.js';
 import wallet from '../datalayer/wallet.js';
 
 const CONFIG = getConfig();
@@ -15,12 +18,76 @@ const TARGET_COIN_COUNT = 15;      // Number of coins to maintain
 const SPLIT_FEE = APP_CONFIG.DEFAULT_FEE || 3000; // Fee from config, fallback to 3000 mojos
 const DEFAULT_COIN_AMOUNT = APP_CONFIG.DEFAULT_COIN_AMOUNT || 300; // Coin amount for DataLayer operations from config
 const MIN_USABLE_COIN_SIZE = DEFAULT_COIN_AMOUNT + SPLIT_FEE; // A coin must cover both the operation amount and the fee to be usable
-// Chia's default xch_spam_amount is 1,000,000 mojos. Coins below this threshold
-// may be filtered out by the wallet's spam filter once enough small UTXOs exist.
-// Not available via RPC, so we use a floor above the default to be safe.
-const DUST_FILTER_FLOOR = 1_000_000;
-const COIN_SIZE = Math.max(MIN_USABLE_COIN_SIZE, DUST_FILTER_FLOOR);
-const MIN_COIN_SIZE = COIN_SIZE;
+// Chia's own default when wallet.xch_spam_amount is absent from its config.
+const CHIA_DEFAULT_XCH_SPAM_AMOUNT = 1_000_000;
+
+/**
+ * Size of the coins we create, in mojos.
+ *
+ * Chia's wallet hides coins below `wallet.xch_spam_amount` once enough small
+ * UTXOs accumulate, so every coin we create must clear that threshold outright
+ * rather than merely equal it. When the operational minimum is smaller than the
+ * threshold we create the smallest coin that still clears it, so a wallet is
+ * not carved into more value per coin than an operation needs.
+ *
+ * @param {unknown} rawSpamAmount   wallet.xch_spam_amount from Chia's config.
+ * @param {number} [minUsableCoinSize]
+ * @param {{warn: (msg: string) => void}} [log]
+ * @returns {number}
+ */
+export const resolveCoinSize = (
+  rawSpamAmount,
+  minUsableCoinSize = MIN_USABLE_COIN_SIZE,
+  log = logger,
+) => {
+  const dustFilterFloor = coerceConfigNumber(
+    rawSpamAmount,
+    CHIA_DEFAULT_XCH_SPAM_AMOUNT,
+    'chia config wallet.xch_spam_amount',
+    log,
+  );
+
+  return Math.max(minUsableCoinSize, dustFilterFloor + 1);
+};
+
+// Reads lazily, and only when a split is actually being considered: reading at
+// import time would make every consumer of this module depend on a readable
+// Chia config. Memoize caches returns but not throws, so an unreadable config
+// is retried on the next run instead of pinning the coin size for the life of
+// the process.
+const readCoinSize = _.memoize(() => {
+  const rawSpamAmount = _.get(getChiaConfig(), 'wallet.xch_spam_amount');
+  const coinSize = resolveCoinSize(rawSpamAmount);
+
+  logger.info(
+    `[COIN_MANAGEMENT] Creating coins of ${coinSize} mojos (configured wallet.xch_spam_amount: ${rawSpamAmount ?? 'unset'})`,
+  );
+
+  return coinSize;
+});
+
+export const getCoinSize = () => {
+  try {
+    return readCoinSize();
+  } catch (error) {
+    const message =
+      `[COIN_MANAGEMENT] Could not read chia config for wallet.xch_spam_amount ` +
+      `(${error.message}); assuming the chia default of ${CHIA_DEFAULT_XCH_SPAM_AMOUNT} mojos.`;
+    // A CADT host with no local chia node is supported, so an absent config is
+    // routine; one that exists but cannot be read is worth an operator's time.
+    if (error.code === 'ENOENT') {
+      logger.debug(message);
+    } else {
+      logger.warn(message);
+    }
+
+    return resolveCoinSize(undefined);
+  }
+};
+
+// The same handle every other memoized reader in the codebase exposes, so tests
+// can drop a cached read after repointing CHIA_ROOT.
+getCoinSize.cache = readCoinSize.cache;
 
 // Exported flag so other tasks (mirror check, etc.) can avoid operating
 // while a coin split has temporarily reduced the wallet's spendable balance.
@@ -118,14 +185,15 @@ const waitForSplitConfirmation = async (expectedNewCoins, originalCoinId) => {
  * flag so other tasks know the wallet balance is temporarily reduced.
  */
 const executeSplit = async (coinId, numberOfCoins) => {
-  logger.info(`[COIN_MANAGEMENT] Splitting coin ${coinId} into ${numberOfCoins} new coins of ${COIN_SIZE} mojos each (fee: ${SPLIT_FEE} mojos)`);
+  const coinSize = getCoinSize();
+  logger.info(`[COIN_MANAGEMENT] Splitting coin ${coinId} into ${numberOfCoins} new coins of ${coinSize} mojos each (fee: ${SPLIT_FEE} mojos)`);
 
   splitInProgress = true;
   try {
-    const splitResult = await wallet.splitCoins(coinId, numberOfCoins, COIN_SIZE, SPLIT_FEE);
+    const splitResult = await wallet.splitCoins(coinId, numberOfCoins, coinSize, SPLIT_FEE);
 
     if (splitResult.success) {
-      logger.info(`[COIN_MANAGEMENT] Successfully initiated coin split. Waiting for ${numberOfCoins} new coins of ${COIN_SIZE} mojos to confirm...`);
+      logger.info(`[COIN_MANAGEMENT] Successfully initiated coin split. Waiting for ${numberOfCoins} new coins of ${coinSize} mojos to confirm...`);
       const confirmed = await waitForSplitConfirmation(numberOfCoins, coinId);
       if (!confirmed) {
         logger.warn('[COIN_MANAGEMENT] Split transaction may still be pending. Coins will be available once confirmed.');
@@ -220,38 +288,40 @@ const runCoinManagement = async () => {
     logger.info(`[COIN_MANAGEMENT] Wallet synced=${syncStatus.synced} (syncing=${syncStatus.syncing}). Proceeding with coin split.`);
 
     // Calculate how many coins we need and can create
+    const coinSize = getCoinSize();
     const coinsNeeded = TARGET_COIN_COUNT - coinCount;
-    const requiredAmount = (coinsNeeded * COIN_SIZE) + SPLIT_FEE;
+    const requiredAmount = (coinsNeeded * coinSize) + SPLIT_FEE;
 
     // Check if we have enough mojos in the largest coin
     if (largestCoinAmount < requiredAmount) {
       const currencySymbol = await getCurrencySymbol();
-      const maxPossibleCoins = Math.floor((largestCoinAmount - SPLIT_FEE) / COIN_SIZE);
+      const maxPossibleCoins = Math.floor((largestCoinAmount - SPLIT_FEE) / coinSize);
 
       if (maxPossibleCoins < 1) {
         logger.warn(
           `[COIN_MANAGEMENT] WARNING: Largest coin (${formatMojos(largestCoinAmount, currencySymbol)}) is too small to split. ` +
-          `Need at least ${formatMojos(COIN_SIZE + SPLIT_FEE, currencySymbol)} to create one ${COIN_SIZE} mojo coin.`
+          `Need at least ${formatMojos(coinSize + SPLIT_FEE, currencySymbol)} to create one ${coinSize} mojo coin.`
         );
         return;
       }
 
-      // Verify the remainder (change) coin won't be below MIN_COIN_SIZE
-      const totalSplitAmount = (maxPossibleCoins * COIN_SIZE) + SPLIT_FEE;
+      // Verify the remainder (change) coin won't be below the coin size, which
+      // would leave dust the wallet may hide.
+      const totalSplitAmount = (maxPossibleCoins * coinSize) + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
       let adjustedCoins = maxPossibleCoins;
-      if (remainderAmount > 0 && remainderAmount < MIN_COIN_SIZE) {
+      if (remainderAmount > 0 && remainderAmount < coinSize) {
         adjustedCoins = maxPossibleCoins - 1;
         if (adjustedCoins < 1) {
           logger.warn(
-            `[COIN_MANAGEMENT] WARNING: Cannot split without creating a remainder coin below ${MIN_COIN_SIZE} mojos ` +
+            `[COIN_MANAGEMENT] WARNING: Cannot split without creating a remainder coin below ${coinSize} mojos ` +
             `(remainder would be ${remainderAmount} mojos). Aborting split.`
           );
           return;
         }
         logger.warn(
           `[COIN_MANAGEMENT] Reducing split from ${maxPossibleCoins} to ${adjustedCoins} coins to avoid ` +
-          `creating a remainder below ${MIN_COIN_SIZE} mojos.`
+          `creating a remainder below ${coinSize} mojos.`
         );
       }
 
@@ -265,22 +335,22 @@ const runCoinManagement = async () => {
       return;
     }
 
-    // We have enough - check that the remainder won't be below MIN_COIN_SIZE
-    const totalSplitAmount = (coinsNeeded * COIN_SIZE) + SPLIT_FEE;
+    // We have enough - check that the remainder won't be below the coin size
+    const totalSplitAmount = (coinsNeeded * coinSize) + SPLIT_FEE;
     const remainderAmount = largestCoinAmount - totalSplitAmount;
     let actualCoinsToCreate = coinsNeeded;
 
-    if (remainderAmount > 0 && remainderAmount < MIN_COIN_SIZE) {
+    if (remainderAmount > 0 && remainderAmount < coinSize) {
       actualCoinsToCreate = coinsNeeded - 1;
       if (actualCoinsToCreate < 1) {
         logger.warn(
-          `[COIN_MANAGEMENT] WARNING: Cannot split without creating a remainder coin below ${MIN_COIN_SIZE} mojos. Aborting split.`
+          `[COIN_MANAGEMENT] WARNING: Cannot split without creating a remainder coin below ${coinSize} mojos. Aborting split.`
         );
         return;
       }
       logger.warn(
         `[COIN_MANAGEMENT] Reducing split from ${coinsNeeded} to ${actualCoinsToCreate} coins to avoid ` +
-        `creating a remainder below ${MIN_COIN_SIZE} mojos.`
+        `creating a remainder below ${coinSize} mojos.`
       );
     }
 

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -7,7 +7,10 @@ import { mergeObjects } from './helpers';
 import { defaultConfig } from './defaultConfig.js';
 import { getChiaRoot } from './chia-root.js';
 import { migrateConfigFiles } from './config-migration.js';
-import { coerceNumericAppConfig } from './numeric-config.js';
+import {
+  coerceConfigNumber,
+  coerceNumericAppConfig,
+} from './numeric-config.js';
 
 // Helper function to load config for a specific version
 const loadConfigForVersion = (dataModelVersion) => {
@@ -137,7 +140,11 @@ const loadConfigForVersion = (dataModelVersion) => {
 
   // Handle CW_PORT environment variable override
   if (process.env.CW_PORT) {
-    mergedConfig.APP.CW_PORT = parseInt(process.env.CW_PORT, 10);
+    mergedConfig.APP.CW_PORT = coerceConfigNumber(
+      process.env.CW_PORT,
+      defaultConfig.APP.CW_PORT,
+      'CW_PORT',
+    );
   }
 
   // Handle USE_SIMULATOR environment variable override

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -133,17 +133,17 @@ const loadConfigForVersion = (dataModelVersion) => {
     };
   }
 
-  // YAML preserves quoting, so a config value written as "3000" stays a string
-  // and turns `DEFAULT_COIN_AMOUNT + DEFAULT_FEE` into concatenation. Coerce
-  // the numeric keys once here so no consumer has to.
+  // Numeric APP keys can arrive from YAML as strings; coerce once for all consumers.
   mergedConfig.APP = coerceNumericAppConfig(mergedConfig.APP);
 
-  // Handle CW_PORT environment variable override
+  // Handle CW_PORT environment variable override. An unusable env value falls
+  // back to the port already resolved from config.yaml rather than discarding
+  // the operator's file setting.
   if (process.env.CW_PORT) {
     mergedConfig.APP.CW_PORT = coerceConfigNumber(
       process.env.CW_PORT,
-      defaultConfig.APP.CW_PORT,
-      'CW_PORT',
+      mergedConfig.APP.CW_PORT,
+      'CW_PORT (env)',
     );
   }
 

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -7,6 +7,7 @@ import { mergeObjects } from './helpers';
 import { defaultConfig } from './defaultConfig.js';
 import { getChiaRoot } from './chia-root.js';
 import { migrateConfigFiles } from './config-migration.js';
+import { coerceNumericAppConfig } from './numeric-config.js';
 
 // Helper function to load config for a specific version
 const loadConfigForVersion = (dataModelVersion) => {
@@ -128,6 +129,11 @@ const loadConfigForVersion = (dataModelVersion) => {
       APP: { ...unifiedConfig.APP },
     };
   }
+
+  // YAML preserves quoting, so a config value written as "3000" stays a string
+  // and turns `DEFAULT_COIN_AMOUNT + DEFAULT_FEE` into concatenation. Coerce
+  // the numeric keys once here so no consumer has to.
+  mergedConfig.APP = coerceNumericAppConfig(mergedConfig.APP);
 
   // Handle CW_PORT environment variable override
   if (process.env.CW_PORT) {

--- a/src/utils/numeric-config.js
+++ b/src/utils/numeric-config.js
@@ -94,8 +94,11 @@ export const coerceNumericAppConfig = (appConfig, log = console) => {
     return appConfig;
   }
 
-  // Clone so coercion cannot write through the shared nested objects that
-  // config-loader's shallow spreads leave pointing at defaultConfig.
+  // Clone so coercion cannot write through into defaultConfig. When
+  // config-loader falls back to `{ ...defaultConfig }`, that shallow spread
+  // leaves APP.TASKS and APP.REQUEST_CONTENT_LIMITS pointing at the shared
+  // module-level defaults, and mergeObjects keeps the aliases because the keys
+  // already exist in the target.
   const coerced = _.cloneDeep(appConfig);
 
   for (const configPath of NUMERIC_APP_CONFIG_PATHS) {

--- a/src/utils/numeric-config.js
+++ b/src/utils/numeric-config.js
@@ -4,48 +4,51 @@ import _ from 'lodash';
 
 import { defaultConfig } from './defaultConfig.js';
 
-// APP config values arrive from YAML, which happily yields a string when the
-// value was quoted. `docker-entrypoint.sh` quoted every env-provided value, and
-// hand-edited config files can do the same. A string then breaks arithmetic:
-// `DEFAULT_COIN_AMOUNT + DEFAULT_FEE` concatenates "300" and "300" into
-// "300300" instead of adding to 600. Joi's `.max()` likewise requires a number.
-//
-// Coercing once here keeps every consumer of getConfig()/getConfigV2() free of
-// per-call-site Number() calls.
+// YAML preserves quoting, so numeric APP keys can arrive as strings. Coercing
+// once here keeps consumers (arithmetic in wallet.js, Joi `.max()` in
+// src/validations) free of per-call-site Number() calls.
+
+const numericLeafPaths = (node, prefix = '') =>
+  Object.entries(node).flatMap(([key, value]) => {
+    const configPath = prefix ? `${prefix}.${key}` : key;
+    if (_.isPlainObject(value)) {
+      return numericLeafPaths(value, configPath);
+    }
+    return typeof value === 'number' ? [configPath] : [];
+  });
 
 /**
- * APP-relative paths whose values must be numbers.
+ * APP-relative paths whose values must be numbers, derived from the numeric
+ * leaves of defaultConfig.APP so a new numeric key is covered automatically.
  *
- * TRUST_PROXY is deliberately absent: `resolveTrustProxyHops`
+ * TRUST_PROXY is deliberately excluded: `resolveTrustProxyHops`
  * (src/utils/trust-proxy.js) owns its coercion and logs warnings for inputs
  * (booleans, "loopback") that this helper would silently replace with 0.
  */
-export const NUMERIC_APP_CONFIG_PATHS = Object.freeze([
-  'CW_PORT',
-  'DEFAULT_FEE',
-  'DEFAULT_COIN_AMOUNT',
-  'TASKS.GOVERNANCE_SYNC_TASK_INTERVAL',
-  'TASKS.ORGANIZATION_META_SYNC_TASK_INTERVAL',
-  'TASKS.PICKLIST_SYNC_TASK_INTERVAL',
-  'TASKS.MIRROR_CHECK_TASK_INTERVAL',
-  'TASKS.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL',
-  'TASKS.COIN_MANAGEMENT_TASK_INTERVAL',
-  'REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN',
-  'REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN',
-  'REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN',
-  'REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN',
-  'REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN',
-]);
+export const NUMERIC_APP_CONFIG_PATHS = Object.freeze(
+  numericLeafPaths(defaultConfig.APP).filter((path) => path !== 'TRUST_PROXY'),
+);
 
-// A complete decimal literal and nothing else, so "1e3", "300 mojos", "0x12"
-// and "" are rejected rather than partially parsed. Number() would accept
-// booleans, arrays and whitespace, hence the explicit type checks below.
-const DECIMAL_LITERAL = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
+// Every key above is a non-negative integer by contract: a TCP port, a mojo
+// amount, a count of seconds, or a length bound. Matching `resolveTrustProxyHops`,
+// signs, fractions and values past MAX_SAFE_INTEGER are rejected rather than
+// silently accepted or truncated.
+const UNSIGNED_INTEGER_LITERAL = /^\d+$/;
+
+const isNonNegativeSafeInteger = (value) =>
+  Number.isSafeInteger(value) && value >= 0;
+
+// String() rather than JSON.stringify(): the latter renders NaN and Infinity as
+// `null`, which reads as "not configured", and throws on circular values that
+// js-yaml can produce from recursive anchors.
+const describeValue = (value) =>
+  typeof value === 'string' ? JSON.stringify(value) : String(value);
 
 /**
- * Coerce a raw config value to a finite number, falling back to the documented
- * default when the value is missing or not numeric. Never returns NaN: NaN
- * would make every `>=` threshold comparison false without raising an error.
+ * Coerce a raw config value to a non-negative safe integer, falling back to the
+ * documented default when the value is missing or out of contract. Never
+ * returns NaN: NaN would make every `>=` threshold comparison false without
+ * raising an error.
  *
  * @param {unknown} rawValue
  * @param {number} fallback     Value from defaultConfig for this key.
@@ -59,13 +62,16 @@ export const coerceConfigNumber = (
   label,
   log = console,
 ) => {
-  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+  if (typeof rawValue === 'number' && isNonNegativeSafeInteger(rawValue)) {
     return rawValue;
   }
 
-  if (typeof rawValue === 'string' && DECIMAL_LITERAL.test(rawValue.trim())) {
+  if (
+    typeof rawValue === 'string' &&
+    UNSIGNED_INTEGER_LITERAL.test(rawValue.trim())
+  ) {
     const parsed = Number(rawValue.trim());
-    if (Number.isFinite(parsed)) {
+    if (isNonNegativeSafeInteger(parsed)) {
       return parsed;
     }
   }
@@ -73,8 +79,8 @@ export const coerceConfigNumber = (
   // undefined/null mean "not configured", which the default already covers.
   if (rawValue !== undefined && rawValue !== null) {
     log.warn(
-      `[config]: ${label}=${JSON.stringify(rawValue)} is not a number; ` +
-        `falling back to the default of ${fallback}.`,
+      `[config]: ${label}=${describeValue(rawValue)} is not a non-negative ` +
+        `integer; falling back to ${fallback}.`,
     );
   }
 
@@ -83,17 +89,14 @@ export const coerceConfigNumber = (
 
 /**
  * Return a copy of an APP config section with every numeric key coerced to a
- * number. Non-numeric keys are passed through untouched.
+ * number. Non-numeric keys are passed through untouched; numeric keys absent
+ * from the input are materialized from defaultConfig.
  *
  * @param {object} appConfig
  * @param {{warn: (msg: string) => void}} [log]
  * @returns {object}
  */
 export const coerceNumericAppConfig = (appConfig, log = console) => {
-  if (!appConfig || typeof appConfig !== 'object') {
-    return appConfig;
-  }
-
   // Clone so coercion cannot write through into defaultConfig. When
   // config-loader falls back to `{ ...defaultConfig }`, that shallow spread
   // leaves APP.TASKS and APP.REQUEST_CONTENT_LIMITS pointing at the shared

--- a/src/utils/numeric-config.js
+++ b/src/utils/numeric-config.js
@@ -1,0 +1,115 @@
+'use strict';
+
+import _ from 'lodash';
+
+import { defaultConfig } from './defaultConfig.js';
+
+// APP config values arrive from YAML, which happily yields a string when the
+// value was quoted. `docker-entrypoint.sh` quoted every env-provided value, and
+// hand-edited config files can do the same. A string then breaks arithmetic:
+// `DEFAULT_COIN_AMOUNT + DEFAULT_FEE` concatenates "300" and "300" into
+// "300300" instead of adding to 600. Joi's `.max()` likewise requires a number.
+//
+// Coercing once here keeps every consumer of getConfig()/getConfigV2() free of
+// per-call-site Number() calls.
+
+/**
+ * APP-relative paths whose values must be numbers.
+ *
+ * TRUST_PROXY is deliberately absent: `resolveTrustProxyHops`
+ * (src/utils/trust-proxy.js) owns its coercion and logs warnings for inputs
+ * (booleans, "loopback") that this helper would silently replace with 0.
+ */
+export const NUMERIC_APP_CONFIG_PATHS = Object.freeze([
+  'CW_PORT',
+  'DEFAULT_FEE',
+  'DEFAULT_COIN_AMOUNT',
+  'TASKS.GOVERNANCE_SYNC_TASK_INTERVAL',
+  'TASKS.ORGANIZATION_META_SYNC_TASK_INTERVAL',
+  'TASKS.PICKLIST_SYNC_TASK_INTERVAL',
+  'TASKS.MIRROR_CHECK_TASK_INTERVAL',
+  'TASKS.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL',
+  'TASKS.COIN_MANAGEMENT_TASK_INTERVAL',
+  'REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN',
+  'REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN',
+  'REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN',
+  'REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN',
+  'REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN',
+]);
+
+// A complete decimal literal and nothing else, so "1e3", "300 mojos", "0x12"
+// and "" are rejected rather than partially parsed. Number() would accept
+// booleans, arrays and whitespace, hence the explicit type checks below.
+const DECIMAL_LITERAL = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
+
+/**
+ * Coerce a raw config value to a finite number, falling back to the documented
+ * default when the value is missing or not numeric. Never returns NaN: NaN
+ * would make every `>=` threshold comparison false without raising an error.
+ *
+ * @param {unknown} rawValue
+ * @param {number} fallback     Value from defaultConfig for this key.
+ * @param {string} label        Config path, used in the warning message.
+ * @param {{warn: (msg: string) => void}} [log]
+ * @returns {number}
+ */
+export const coerceConfigNumber = (
+  rawValue,
+  fallback,
+  label,
+  log = console,
+) => {
+  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+    return rawValue;
+  }
+
+  if (typeof rawValue === 'string' && DECIMAL_LITERAL.test(rawValue.trim())) {
+    const parsed = Number(rawValue.trim());
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  // undefined/null mean "not configured", which the default already covers.
+  if (rawValue !== undefined && rawValue !== null) {
+    log.warn(
+      `[config]: ${label}=${JSON.stringify(rawValue)} is not a number; ` +
+        `falling back to the default of ${fallback}.`,
+    );
+  }
+
+  return fallback;
+};
+
+/**
+ * Return a copy of an APP config section with every numeric key coerced to a
+ * number. Non-numeric keys are passed through untouched.
+ *
+ * @param {object} appConfig
+ * @param {{warn: (msg: string) => void}} [log]
+ * @returns {object}
+ */
+export const coerceNumericAppConfig = (appConfig, log = console) => {
+  if (!appConfig || typeof appConfig !== 'object') {
+    return appConfig;
+  }
+
+  // Clone so coercion cannot write through the shared nested objects that
+  // config-loader's shallow spreads leave pointing at defaultConfig.
+  const coerced = _.cloneDeep(appConfig);
+
+  for (const configPath of NUMERIC_APP_CONFIG_PATHS) {
+    _.set(
+      coerced,
+      configPath,
+      coerceConfigNumber(
+        _.get(coerced, configPath),
+        _.get(defaultConfig.APP, configPath),
+        `APP.${configPath}`,
+        log,
+      ),
+    );
+  }
+
+  return coerced;
+};

--- a/tests/shell/docker-entrypoint-numeric-config.sh
+++ b/tests/shell/docker-entrypoint-numeric-config.sh
@@ -28,8 +28,7 @@ V1:
     GOVERNANCE_BODY_ID: placeholder
 EOF
 
-# Load the helper functions without running the container startup steps.
-export CADT_ENTRYPOINT_FUNCTIONS_ONLY=1
+# Sourcing loads the helper functions without running the container startup.
 # shellcheck source=/dev/null
 source "$REPO_ROOT/docker-entrypoint.sh"
 

--- a/tests/shell/docker-entrypoint-numeric-config.sh
+++ b/tests/shell/docker-entrypoint-numeric-config.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Exercises docker-entrypoint.sh's config writers against a throwaway config
+# file and prints the result to stdout for the caller to assert on.
+#
+# Standalone use:
+#   bash tests/shell/docker-entrypoint-numeric-config.sh
+#
+# Requires mikefarah yq v4 (the version the Docker image installs).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat > "$TMP_DIR/config.yaml" << 'EOF'
+APP:
+  DEFAULT_FEE: 3000
+  DEFAULT_COIN_AMOUNT: 300
+  CHIA_NETWORK: mainnet
+  USE_SIMULATOR: false
+  CERTIFICATE_FOLDER_PATH: /some/path
+V1:
+  CADT_API_KEY: placeholder
+  GOVERNANCE:
+    GOVERNANCE_BODY_ID: placeholder
+EOF
+
+# Load the helper functions without running the container startup steps.
+export CADT_ENTRYPOINT_FUNCTIONS_ONLY=1
+# shellcheck source=/dev/null
+source "$REPO_ROOT/docker-entrypoint.sh"
+
+# The helpers read UNIFIED_CONFIG_PATH at call time, so point them at the
+# temporary file rather than /root/.chia.
+# shellcheck disable=SC2034  # read by the functions sourced above
+UNIFIED_CONFIG_PATH="$TMP_DIR/config.yaml"
+
+export DEFAULT_FEE=300
+export DEFAULT_COIN_AMOUNT=300
+export CHIA_NETWORK=testnet
+export USE_SIMULATOR=true
+export CERTIFICATE_FOLDER_PATH=
+# Digit-only values on non-numeric keys must keep their quotes.
+export V1_CADT_API_KEY=12345678
+export V1_GOVERNANCE_BODY_ID=99999999
+
+update_numeric_app_config "DEFAULT_FEE" '.DEFAULT_FEE'
+update_numeric_app_config "DEFAULT_COIN_AMOUNT" '.DEFAULT_COIN_AMOUNT'
+update_app_config "CHIA_NETWORK" '.CHIA_NETWORK'
+update_app_config "USE_SIMULATOR" '.USE_SIMULATOR'
+update_app_config "CERTIFICATE_FOLDER_PATH" '.CERTIFICATE_FOLDER_PATH'
+update_v1_config "V1_CADT_API_KEY" '.CADT_API_KEY'
+update_v1_config "V1_GOVERNANCE_BODY_ID" '.GOVERNANCE.GOVERNANCE_BODY_ID'
+
+cat "$TMP_DIR/config.yaml"

--- a/tests/shell/docker-entrypoint-numeric-config.sh
+++ b/tests/shell/docker-entrypoint-numeric-config.sh
@@ -17,11 +17,17 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 cat > "$TMP_DIR/config.yaml" << 'EOF'
 APP:
+  CW_PORT: 31310
   DEFAULT_FEE: 3000
   DEFAULT_COIN_AMOUNT: 300
   CHIA_NETWORK: mainnet
   USE_SIMULATOR: false
   CERTIFICATE_FOLDER_PATH: /some/path
+  TASKS:
+    MIRROR_CHECK_TASK_INTERVAL: 900
+    # Deliberately not the shipped default, so "left at its existing value" is
+    # distinguishable from "reset to the default".
+    PICKLIST_SYNC_TASK_INTERVAL: 121
 V1:
   CADT_API_KEY: placeholder
   GOVERNANCE:
@@ -45,9 +51,18 @@ export CERTIFICATE_FOLDER_PATH=
 # Digit-only values on non-numeric keys must keep their quotes.
 export V1_CADT_API_KEY=12345678
 export V1_GOVERNANCE_BODY_ID=99999999
+# Values the numeric writer cannot emit as YAML numbers: yq rejects integers
+# wider than int64, and a negative fails the unsigned-integer guard. Both must
+# fall through to the quoted writer rather than being dropped.
+export MIRROR_CHECK_TASK_INTERVAL=99999999999999999999
+export CW_PORT=-5
 
 update_numeric_app_config "DEFAULT_FEE" '.DEFAULT_FEE'
 update_numeric_app_config "DEFAULT_COIN_AMOUNT" '.DEFAULT_COIN_AMOUNT'
+update_numeric_app_config "MIRROR_CHECK_TASK_INTERVAL" '.TASKS.MIRROR_CHECK_TASK_INTERVAL'
+update_numeric_app_config "CW_PORT" '.CW_PORT'
+# Unset numeric keys must be left at their existing value.
+update_numeric_app_config "PICKLIST_SYNC_TASK_INTERVAL" '.TASKS.PICKLIST_SYNC_TASK_INTERVAL'
 update_app_config "CHIA_NETWORK" '.CHIA_NETWORK'
 update_app_config "USE_SIMULATOR" '.USE_SIMULATOR'
 update_app_config "CERTIFICATE_FOLDER_PATH" '.CERTIFICATE_FOLDER_PATH'

--- a/tests/v2/integration/coin-management.spec.js
+++ b/tests/v2/integration/coin-management.spec.js
@@ -1,6 +1,15 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import coinManagementJob from '../../../src/tasks/coin-management.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as yaml from 'js-yaml';
+import coinManagementJob, {
+  getCoinSize,
+  resolveCoinSize,
+} from '../../../src/tasks/coin-management.js';
+import { getChiaConfig } from '../../../src/datalayer/fullNode.js';
+import { getChiaRoot } from '../../../src/utils/chia-root.js';
 import wallet from '../../../src/datalayer/wallet.js';
 
 /**
@@ -109,29 +118,154 @@ describe('Coin Management Task Tests', function () {
     });
   });
 
-  describe('Coin Splitting Calculations', function () {
-    // Constants matching coin-management.js (using simulator/default config values)
-    const DEFAULT_COIN_AMOUNT = 300;
-    const SPLIT_FEE = 3000;
-    const MIN_USABLE_COIN_SIZE = DEFAULT_COIN_AMOUNT + SPLIT_FEE; // 3300
-    const DUST_FILTER_FLOOR = 1_000_000;
-    const COIN_SIZE = Math.max(MIN_USABLE_COIN_SIZE, DUST_FILTER_FLOOR); // 1,000,000
-    const MIN_COIN_SIZE = COIN_SIZE;
-    const TARGET_COIN_COUNT = 15;
+  describe('Coin Size Resolution', function () {
+    const MIN_USABLE_COIN_SIZE = 3300; // DEFAULT_COIN_AMOUNT 300 + DEFAULT_FEE 3000
+    const CHIA_DEFAULT_SPAM_AMOUNT = 1_000_000;
+    const silentLog = { warn: () => {} };
 
-    it('should set COIN_SIZE to max of MIN_USABLE_COIN_SIZE and DUST_FILTER_FLOOR', function () {
-      expect(COIN_SIZE).to.equal(Math.max(MIN_USABLE_COIN_SIZE, DUST_FILTER_FLOOR));
-      expect(COIN_SIZE).to.equal(1_000_000);
+    const resolve = (rawSpamAmount) =>
+      resolveCoinSize(rawSpamAmount, MIN_USABLE_COIN_SIZE, silentLog);
+
+    it('creates coins strictly above the dust filter floor, never equal to it', function () {
+      // A coin exactly at xch_spam_amount is not reliably spendable, so the
+      // floor must be cleared outright.
+      expect(resolve(CHIA_DEFAULT_SPAM_AMOUNT)).to.equal(1_000_001);
+      expect(resolve(CHIA_DEFAULT_SPAM_AMOUNT)).to.be.greaterThan(
+        CHIA_DEFAULT_SPAM_AMOUNT,
+      );
     });
 
-    it('should ensure COIN_SIZE meets MIN_COIN_SIZE', function () {
-      expect(COIN_SIZE).to.be.greaterThanOrEqual(MIN_COIN_SIZE);
+    it('takes the floor from the chia config rather than a hardcoded value', function () {
+      expect(resolve(5_000_000)).to.equal(5_000_001);
+      expect(resolve(250)).to.be.greaterThan(250);
+    });
+
+    it('creates the smallest coin that clears the floor', function () {
+      // Not merely "some coin above the floor": a wallet should not be carved
+      // into more value per coin than an operation needs.
+      for (const spamAmount of [1_000_000, 5_000_000, 42_000_000]) {
+        expect(resolve(spamAmount), String(spamAmount)).to.equal(
+          spamAmount + 1,
+        );
+      }
+    });
+
+    it('uses the operational minimum when it already clears the floor', function () {
+      expect(resolve(100)).to.equal(MIN_USABLE_COIN_SIZE);
+      expect(resolve(100)).to.be.greaterThan(100);
+    });
+
+    it("falls back to chia's default when the config value is missing or unusable", function () {
+      for (const unusable of [undefined, null, 'abc', -1, 1.5, true, {}]) {
+        expect(resolve(unusable), String(unusable)).to.equal(1_000_001);
+      }
+    });
+
+    it('accepts a quoted spam amount, as YAML can yield a string', function () {
+      expect(resolve('5000000')).to.equal(5_000_001);
+    });
+  });
+
+  // resolveCoinSize is pure; these cover the production path that actually
+  // reaches chia's config file and decides how real coins are denominated.
+  describe('Coin Size From Chia Config', function () {
+    let testChiaRoot;
+    let savedChiaRoot;
+
+    // getCoinSize's own memo is left alone so a test can observe whether a
+    // previous read was cached.
+    const clearChiaConfigCaches = () => {
+      getChiaRoot.cache?.clear();
+      getChiaConfig.cache?.clear();
+    };
+
+    const writeChiaConfig = (config) => {
+      const configDir = path.join(testChiaRoot, 'config');
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(configDir, 'config.yaml'),
+        yaml.dump(config),
+        'utf8',
+      );
+      clearChiaConfigCaches();
+    };
+
+    beforeEach(function () {
+      testChiaRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cadt-coin-size-'));
+      savedChiaRoot = process.env.CHIA_ROOT;
+      process.env.CHIA_ROOT = testChiaRoot;
+      clearChiaConfigCaches();
+      getCoinSize.cache?.clear();
+    });
+
+    afterEach(function () {
+      fs.rmSync(testChiaRoot, { recursive: true, force: true });
+      // CHIA_ROOT is process-global and read by every module that resolves a
+      // chia path, so restore rather than delete.
+      if (savedChiaRoot === undefined) {
+        delete process.env.CHIA_ROOT;
+      } else {
+        process.env.CHIA_ROOT = savedChiaRoot;
+      }
+      clearChiaConfigCaches();
+      getCoinSize.cache?.clear();
+    });
+
+    it('sizes coins from wallet.xch_spam_amount in chia config', function () {
+      writeChiaConfig({ wallet: { xch_spam_amount: 5_000_000 } });
+
+      expect(getCoinSize()).to.equal(5_000_001);
+    });
+
+    it("assumes chia's default when there is no local chia config", function () {
+      // The supported container deployments mount only the ssl and cadt
+      // directories, so this is the common case rather than an error.
+      expect(getCoinSize()).to.equal(1_000_001);
+    });
+
+    it("assumes chia's default when the config omits the wallet section", function () {
+      writeChiaConfig({ full_node: { rpc_port: 8555 } });
+
+      expect(getCoinSize()).to.equal(1_000_001);
+    });
+
+    it('picks up a config that only becomes readable later', function () {
+      expect(getCoinSize()).to.equal(1_000_001);
+
+      writeChiaConfig({ wallet: { xch_spam_amount: 5_000_000 } });
+
+      expect(getCoinSize()).to.equal(5_000_001);
+    });
+
+    it('reads the config once', function () {
+      writeChiaConfig({ wallet: { xch_spam_amount: 5_000_000 } });
+      expect(getCoinSize()).to.equal(5_000_001);
+
+      writeChiaConfig({ wallet: { xch_spam_amount: 9_000_000 } });
+
+      expect(getCoinSize()).to.equal(5_000_001);
+    });
+  });
+
+  describe('Coin Splitting Calculations', function () {
+    const MIN_USABLE_COIN_SIZE = 3300;
+    const SPLIT_FEE = 3000;
+    // The production value for a node running chia's default spam threshold.
+    const COIN_SIZE = resolveCoinSize(1_000_000, MIN_USABLE_COIN_SIZE, {
+      warn: () => {},
+    });
+    const TARGET_COIN_COUNT = 15;
+
+    it("sizes coins just above chia's default spam threshold", function () {
+      expect(COIN_SIZE).to.equal(1_000_001);
     });
 
     it('should calculate max possible coins correctly', function () {
       const largestCoinAmount = 20_000_000;
-      const maxPossibleCoins = Math.floor((largestCoinAmount - SPLIT_FEE) / COIN_SIZE);
-      // (20_000_000 - 3000) / 1_000_000 = 19.997 → 19
+      const maxPossibleCoins = Math.floor(
+        (largestCoinAmount - SPLIT_FEE) / COIN_SIZE,
+      );
+      // (20_000_000 - 3000) / 1_000_001 = 19.996 → 19
       expect(maxPossibleCoins).to.equal(19);
     });
 
@@ -155,47 +289,49 @@ describe('Coin Management Task Tests', function () {
 
     it('should handle case where coin is too small to split', function () {
       const largestCoinAmount = 3000;
-      const maxPossibleCoins = Math.floor((largestCoinAmount - SPLIT_FEE) / COIN_SIZE);
-      // (3000 - 3000) / 1_000_000 = 0
+      const maxPossibleCoins = Math.floor(
+        (largestCoinAmount - SPLIT_FEE) / COIN_SIZE,
+      );
       expect(maxPossibleCoins).to.equal(0);
     });
 
     it('should calculate required amount for coins needed', function () {
       const currentCoinCount = 1;
       const coinsNeeded = TARGET_COIN_COUNT - currentCoinCount; // 14
-      const requiredAmount = (coinsNeeded * COIN_SIZE) + SPLIT_FEE;
-      // (14 * 1_000_000) + 3000 = 14_003_000
-      expect(requiredAmount).to.equal(14_003_000);
+      const requiredAmount = coinsNeeded * COIN_SIZE + SPLIT_FEE;
+      // (14 * 1_000_001) + 3000 = 14_003_014
+      expect(requiredAmount).to.equal(14_003_014);
     });
 
-    it('should detect when remainder would be below MIN_COIN_SIZE', function () {
+    it('should detect when remainder would be below the coin size', function () {
       const largestCoinAmount = 2_500_000;
       const coinsToCreate = 2;
-      const totalSplitAmount = (coinsToCreate * COIN_SIZE) + SPLIT_FEE;
+      const totalSplitAmount = coinsToCreate * COIN_SIZE + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
-      // 2_500_000 - (2_000_000 + 3000) = 497_000
-      expect(remainderAmount).to.equal(497_000);
-      expect(remainderAmount).to.be.lessThan(MIN_COIN_SIZE);
+      // 2_500_000 - (2_000_002 + 3000) = 496_998
+      expect(remainderAmount).to.equal(496_998);
+      expect(remainderAmount).to.be.lessThan(COIN_SIZE);
     });
 
     it('should allow split when remainder is zero', function () {
-      const largestCoinAmount = (2 * COIN_SIZE) + SPLIT_FEE; // 2_003_000
+      const largestCoinAmount = 2 * COIN_SIZE + SPLIT_FEE;
       const coinsToCreate = 2;
-      const totalSplitAmount = (coinsToCreate * COIN_SIZE) + SPLIT_FEE;
+      const totalSplitAmount = coinsToCreate * COIN_SIZE + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
       expect(remainderAmount).to.equal(0);
-      const shouldReduceCoins = remainderAmount > 0 && remainderAmount < MIN_COIN_SIZE;
+      const shouldReduceCoins =
+        remainderAmount > 0 && remainderAmount < COIN_SIZE;
       expect(shouldReduceCoins).to.be.false;
     });
 
-    it('should allow split when remainder exceeds MIN_COIN_SIZE', function () {
+    it('should allow split when remainder exceeds the coin size', function () {
       const largestCoinAmount = 500_000_000; // 0.5 XCH
       const coinsToCreate = 3;
-      const totalSplitAmount = (coinsToCreate * COIN_SIZE) + SPLIT_FEE;
+      const totalSplitAmount = coinsToCreate * COIN_SIZE + SPLIT_FEE;
       const remainderAmount = largestCoinAmount - totalSplitAmount;
-      // 500_000_000 - (3_000_000 + 3000) = 496_997_000
-      expect(remainderAmount).to.equal(496_997_000);
-      expect(remainderAmount).to.be.greaterThan(MIN_COIN_SIZE);
+      // 500_000_000 - (3_000_003 + 3000) = 496_996_997
+      expect(remainderAmount).to.equal(496_996_997);
+      expect(remainderAmount).to.be.greaterThan(COIN_SIZE);
     });
   });
 

--- a/tests/v2/integration/diagnostics-helpers.spec.js
+++ b/tests/v2/integration/diagnostics-helpers.spec.js
@@ -627,7 +627,7 @@ describe('diagnostics collectNonDefaultTaskIntervals', function () {
   });
 
   it('treats numeric-string intervals equal to the default as default', function () {
-    // docker-entrypoint.sh writes env-provided intervals as quoted YAML strings.
+    // The helper is also called directly with raw, uncoerced values.
     const actual = {
       ...defaultTasks,
       GOVERNANCE_SYNC_TASK_INTERVAL: '120',

--- a/tests/v2/integration/numeric-config-coercion.spec.js
+++ b/tests/v2/integration/numeric-config-coercion.spec.js
@@ -86,6 +86,28 @@ describe('Numeric config coercion', function () {
     });
   });
 
+  describe('NUMERIC_APP_CONFIG_PATHS', function () {
+    it('lists every number-valued key in defaultConfig.APP', function () {
+      const numericLeaves = (node, prefix = '') =>
+        Object.entries(node).flatMap(([key, value]) => {
+          const configPath = prefix ? `${prefix}.${key}` : key;
+          if (value !== null && typeof value === 'object') {
+            return numericLeaves(value, configPath);
+          }
+          return typeof value === 'number' ? [configPath] : [];
+        });
+
+      // TRUST_PROXY is numeric but owned by resolveTrustProxyHops.
+      const expected = numericLeaves(defaultConfig.APP).filter(
+        (configPath) => configPath !== 'TRUST_PROXY',
+      );
+
+      expect([...NUMERIC_APP_CONFIG_PATHS].sort()).to.deep.equal(
+        expected.sort(),
+      );
+    });
+  });
+
   describe('coerceNumericAppConfig', function () {
     it('coerces every documented numeric key', function () {
       const stringified = {};
@@ -278,17 +300,21 @@ describe('Numeric config coercion', function () {
       const numericPaths = [...NUMERIC_APP_CONFIG_PATHS, 'TRUST_PROXY'];
 
       for (const configPath of numericPaths) {
-        const callSite = entrypoint
+        // Every matching line, not just the first, so a stray update_app_config
+        // added later for the same key is still caught.
+        const callSites = entrypoint
           .split('\n')
-          .find((line) => line.includes(`'.${configPath}'`));
+          .filter((line) => line.includes(`'.${configPath}'`));
 
         expect(
-          callSite,
+          callSites,
           `no docker-entrypoint.sh call site for APP.${configPath}`,
-        ).to.exist;
-        expect(callSite, `APP.${configPath}`).to.match(
-          /^update_numeric_app_config /,
-        );
+        ).to.not.be.empty;
+        for (const callSite of callSites) {
+          expect(callSite, `APP.${configPath}`).to.match(
+            /^update_numeric_app_config /,
+          );
+        }
       }
     });
 

--- a/tests/v2/integration/numeric-config-coercion.spec.js
+++ b/tests/v2/integration/numeric-config-coercion.spec.js
@@ -6,6 +6,7 @@ import path from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 import * as yaml from 'js-yaml';
 
+import TaskManager from '../../../src/tasks/index.js';
 import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
 import { getChiaRoot } from '../../../src/utils/chia-root.js';
 import { defaultConfig } from '../../../src/utils/defaultConfig.js';
@@ -15,23 +16,16 @@ import {
   coerceNumericAppConfig,
 } from '../../../src/utils/numeric-config.js';
 
-/**
- * Numeric APP config values must reach the JS layer as numbers.
- *
- * YAML keeps quoted values as strings, so `DEFAULT_COIN_AMOUNT + DEFAULT_FEE`
- * concatenated "300" and "300" into "300300" instead of adding to 600, and the
- * wallet then waited for coins of 300300+ mojos before creating an org.
- */
 describe('Numeric config coercion', function () {
   const silentLog = { warn: () => {} };
 
   describe('coerceConfigNumber', function () {
-    it('passes finite numbers through unchanged', function () {
+    it('passes non-negative safe integers through unchanged', function () {
       expect(coerceConfigNumber(300, 3000, 'APP.DEFAULT_FEE')).to.equal(300);
       expect(coerceConfigNumber(0, 3000, 'APP.DEFAULT_FEE')).to.equal(0);
     });
 
-    it('parses numeric strings, including padded ones', function () {
+    it('parses unsigned integer strings, including padded ones', function () {
       expect(coerceConfigNumber('300', 3000, 'APP.DEFAULT_FEE')).to.equal(300);
       expect(coerceConfigNumber(' 300 ', 3000, 'APP.DEFAULT_FEE')).to.equal(
         300,
@@ -51,81 +45,112 @@ describe('Numeric config coercion', function () {
       expect(warnings).to.deep.equal([]);
     });
 
-    it('falls back to the default for non-numeric values and warns', function () {
+    it('falls back to the default for out-of-contract values and warns once each', function () {
       const warnings = [];
       const log = { warn: (msg) => warnings.push(msg) };
 
-      for (const garbage of [
+      const rejected = [
+        // '' is a value, not an absence, so it warns like the rest.
         '',
         'abc',
         '300 mojos',
         '0x12',
+        '1e3',
         true,
         false,
         [],
         {},
         NaN,
         Infinity,
-      ]) {
+        // Every key is a count of mojos, seconds, ports or items: a sign or a
+        // fraction is out of contract, not a value to round or truncate.
+        -5,
+        '-5',
+        '+3000',
+        31310.5,
+        '31310.5',
+        // Beyond MAX_SAFE_INTEGER, Number() silently returns a different value.
+        '99999999999999999999',
+      ];
+
+      rejected.forEach((value, index) => {
         expect(
-          coerceConfigNumber(garbage, 3000, 'APP.DEFAULT_FEE', log),
+          coerceConfigNumber(value, 3000, 'APP.DEFAULT_FEE', log),
+          `input ${String(value)}`,
         ).to.equal(3000);
-      }
-      // '' is a value, not an absence, so it warns like the rest.
-      expect(warnings).to.have.lengthOf(10);
+        expect(warnings, `input ${String(value)}`).to.have.lengthOf(index + 1);
+      });
     });
 
-    it('never returns NaN, which would make every >= comparison false', function () {
-      for (const garbage of ['abc', true, {}, NaN]) {
-        expect(
-          Number.isNaN(
-            coerceConfigNumber(garbage, 3000, 'APP.DEFAULT_FEE', silentLog),
-          ),
-        ).to.be.false;
-      }
+    it('names the key and the offending value in the warning', function () {
+      const warnings = [];
+      const log = { warn: (msg) => warnings.push(msg) };
+
+      coerceConfigNumber(NaN, 3000, 'APP.DEFAULT_FEE', log);
+      coerceConfigNumber('abc', 300, 'APP.DEFAULT_COIN_AMOUNT', log);
+
+      // NaN must not render as `null`, which reads as "not configured".
+      expect(warnings[0]).to.include('APP.DEFAULT_FEE=NaN');
+      expect(warnings[0]).to.include('falling back to 3000');
+      expect(warnings[1]).to.include('APP.DEFAULT_COIN_AMOUNT="abc"');
     });
   });
 
   describe('NUMERIC_APP_CONFIG_PATHS', function () {
-    it('lists every number-valued key in defaultConfig.APP', function () {
-      const numericLeaves = (node, prefix = '') =>
-        Object.entries(node).flatMap(([key, value]) => {
-          const configPath = prefix ? `${prefix}.${key}` : key;
-          if (value !== null && typeof value === 'object') {
-            return numericLeaves(value, configPath);
-          }
-          return typeof value === 'number' ? [configPath] : [];
-        });
-
-      // TRUST_PROXY is numeric but owned by resolveTrustProxyHops.
-      const expected = numericLeaves(defaultConfig.APP).filter(
-        (configPath) => configPath !== 'TRUST_PROXY',
-      );
-
+    // Spelled out rather than re-derived from defaultConfig: the production
+    // list is derived, so a copy of that derivation would agree with any drift.
+    // Adding a numeric APP key should fail here until it also gets a
+    // docker-entrypoint.sh call site, which the suite below checks.
+    it('covers exactly the numeric APP keys', function () {
       expect([...NUMERIC_APP_CONFIG_PATHS].sort()).to.deep.equal(
-        expected.sort(),
+        [
+          'CW_PORT',
+          'DEFAULT_FEE',
+          'DEFAULT_COIN_AMOUNT',
+          'TASKS.GOVERNANCE_SYNC_TASK_INTERVAL',
+          'TASKS.ORGANIZATION_META_SYNC_TASK_INTERVAL',
+          'TASKS.PICKLIST_SYNC_TASK_INTERVAL',
+          'TASKS.MIRROR_CHECK_TASK_INTERVAL',
+          'TASKS.VALIDATE_ORGANIZATION_TABLE_TASK_INTERVAL',
+          'TASKS.COIN_MANAGEMENT_TASK_INTERVAL',
+          'REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN',
+          'REQUEST_CONTENT_LIMITS.UNITS.INCLUDE_COLUMNS_LEN',
+          'REQUEST_CONTENT_LIMITS.UNITS.MARKETPLACE_IDENTIFIERS_LEN',
+          'REQUEST_CONTENT_LIMITS.PROJECTS.INCLUDE_COLUMNS_LEN',
+          'REQUEST_CONTENT_LIMITS.PROJECTS.PROJECT_IDS_LEN',
+        ].sort(),
       );
+    });
+
+    it('excludes TRUST_PROXY, which resolveTrustProxyHops owns', function () {
+      expect(defaultConfig.APP.TRUST_PROXY).to.be.a('number');
+      expect(NUMERIC_APP_CONFIG_PATHS).to.not.include('TRUST_PROXY');
     });
   });
 
   describe('coerceNumericAppConfig', function () {
-    it('coerces every documented numeric key', function () {
+    it('coerces every numeric key', function () {
+      const warnings = [];
+      const log = { warn: (msg) => warnings.push(msg) };
+
+      // Offset from the defaults so a silent fall back to defaultConfig is
+      // distinguishable from an actual parse.
+      const expected = {};
       const stringified = {};
       for (const configPath of NUMERIC_APP_CONFIG_PATHS) {
-        _.set(
-          stringified,
-          configPath,
-          String(_.get(defaultConfig.APP, configPath)),
-        );
+        const value = _.get(defaultConfig.APP, configPath) + 1;
+        _.set(expected, configPath, value);
+        _.set(stringified, configPath, String(value));
       }
 
-      const coerced = coerceNumericAppConfig(stringified, silentLog);
+      const coerced = coerceNumericAppConfig(stringified, log);
 
       for (const configPath of NUMERIC_APP_CONFIG_PATHS) {
         expect(_.get(coerced, configPath), configPath).to.equal(
-          _.get(defaultConfig.APP, configPath),
+          _.get(expected, configPath),
         );
       }
+      expect(warnings).to.deep.equal([]);
     });
 
     it('leaves non-numeric keys untouched', function () {
@@ -167,11 +192,20 @@ describe('Numeric config coercion', function () {
     let testChiaRoot;
     let configFile;
     let savedCwPort;
+    let savedChiaRoot;
 
     const clearConfigCaches = () => {
       getChiaRoot.cache?.clear();
       getConfig.cache?.clear();
       getConfigV2.cache?.clear();
+    };
+
+    const restoreEnv = (name, saved) => {
+      if (saved === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = saved;
+      }
     };
 
     const writeConfig = (app) => {
@@ -183,6 +217,13 @@ describe('Numeric config coercion', function () {
       clearConfigCaches();
     };
 
+    before(function () {
+      // This suite repoints CHIA_ROOT at a temp directory it later deletes and
+      // clears the config memo caches. A background task waking up mid-test
+      // would repopulate those caches from the synthetic config.
+      TaskManager.stopAll();
+    });
+
     beforeEach(function () {
       testChiaRoot = fs.mkdtempSync(
         path.join(os.tmpdir(), 'cadt-numeric-config-'),
@@ -191,6 +232,7 @@ describe('Numeric config coercion', function () {
       configFile = path.join(testChiaRoot, 'cadt', 'config.yaml');
 
       savedCwPort = process.env.CW_PORT;
+      savedChiaRoot = process.env.CHIA_ROOT;
       delete process.env.CW_PORT;
       process.env.CHIA_ROOT = testChiaRoot;
       clearConfigCaches();
@@ -198,10 +240,11 @@ describe('Numeric config coercion', function () {
 
     afterEach(function () {
       fs.rmSync(testChiaRoot, { recursive: true, force: true });
-      delete process.env.CHIA_ROOT;
-      if (savedCwPort !== undefined) {
-        process.env.CW_PORT = savedCwPort;
-      }
+      // Both are process-global and read by every module that calls
+      // getConfig(), so restore rather than delete: a test that leaves either
+      // one set changes how later spec files resolve their config.
+      restoreEnv('CHIA_ROOT', savedChiaRoot);
+      restoreEnv('CW_PORT', savedCwPort);
       clearConfigCaches();
     });
 
@@ -216,17 +259,17 @@ describe('Numeric config coercion', function () {
       expect(app.DEFAULT_COIN_AMOUNT + app.DEFAULT_FEE).to.equal(600);
     });
 
-    it('resolves stock defaults quoted as strings to 3300 and a 1,000,000 COIN_SIZE', function () {
+    it('resolves stock defaults quoted as strings to a 3300 minimum usable coin size', function () {
       writeConfig({ DEFAULT_FEE: '3000', DEFAULT_COIN_AMOUNT: '300' });
 
       const app = getConfig().APP;
-      const DUST_FILTER_FLOOR = 1_000_000;
-      const minUsableCoinSize = app.DEFAULT_COIN_AMOUNT + app.DEFAULT_FEE;
 
-      expect(minUsableCoinSize).to.equal(3300);
-      expect(Math.max(minUsableCoinSize, DUST_FILTER_FLOOR)).to.equal(
-        1_000_000,
-      );
+      // These happen to equal the shipped defaults, so assert the types too:
+      // that is what separates coercion from the strings passing straight
+      // through, which is the reported bug.
+      expect(app.DEFAULT_FEE).to.be.a('number');
+      expect(app.DEFAULT_COIN_AMOUNT).to.be.a('number');
+      expect(app.DEFAULT_COIN_AMOUNT + app.DEFAULT_FEE).to.equal(3300);
     });
 
     it('applies the same coercion to the V2 config', function () {
@@ -238,14 +281,14 @@ describe('Numeric config coercion', function () {
     });
 
     it('gives the Chia RPC numbers for fee and amount_per_coin', function () {
-      writeConfig({ DEFAULT_FEE: '300', DEFAULT_COIN_AMOUNT: '300' });
+      writeConfig({ DEFAULT_FEE: '13', DEFAULT_COIN_AMOUNT: '7' });
 
       const app = getConfig().APP;
 
-      // The accessors used in src/datalayer/persistance.js.
-      expect(_.get(app, 'DEFAULT_FEE', 3000)).to.be.a('number');
-      expect(_.get(app, 'DEFAULT_COIN_AMOUNT', 300)).to.be.a('number');
-      expect(app.DEFAULT_FEE).to.be.a('number');
+      // The accessors used in src/datalayer/persistance.js. Exact values, so a
+      // loader that ignored the file and returned defaults would still fail.
+      expect(_.get(app, 'DEFAULT_FEE', 3000)).to.equal(13);
+      expect(_.get(app, 'DEFAULT_COIN_AMOUNT', 300)).to.equal(7);
     });
 
     it('coerces quoted task intervals and request content limits', function () {
@@ -261,15 +304,26 @@ describe('Numeric config coercion', function () {
     });
 
     it('keeps the CW_PORT env override numeric', function () {
-      writeConfig({ CW_PORT: '31310' });
+      // Distinct from defaultConfig.APP.CW_PORT so each branch is identifiable.
+      writeConfig({ CW_PORT: '31315' });
+
+      expect(getConfig().APP.CW_PORT).to.equal(31315);
 
       process.env.CW_PORT = '31399';
       clearConfigCaches();
       expect(getConfig().APP.CW_PORT).to.equal(31399);
+    });
 
-      process.env.CW_PORT = 'not-a-port';
-      clearConfigCaches();
-      expect(getConfig().APP.CW_PORT).to.equal(defaultConfig.APP.CW_PORT);
+    it('keeps the configured port when the CW_PORT env value is unusable', function () {
+      writeConfig({ CW_PORT: '31315' });
+
+      // A fractional port reaches http.listen as ERR_SOCKET_BAD_PORT, and
+      // Kubernetes injects `tcp://10.0.0.5:31310` for a Service named cw.
+      for (const unusable of ['not-a-port', '31399.5', '-1']) {
+        process.env.CW_PORT = unusable;
+        clearConfigCaches();
+        expect(getConfig().APP.CW_PORT, unusable).to.equal(31315);
+      }
     });
 
     it('falls back to documented defaults for unparseable values', function () {
@@ -289,20 +343,14 @@ describe('Numeric config coercion', function () {
       repoRoot,
       'tests/shell/docker-entrypoint-numeric-config.sh',
     );
+    const entrypoint = () =>
+      fs.readFileSync(path.join(repoRoot, 'docker-entrypoint.sh'), 'utf8');
 
     it('routes every numeric APP key through the numeric writer', function () {
-      const entrypoint = fs.readFileSync(
-        path.join(repoRoot, 'docker-entrypoint.sh'),
-        'utf8',
-      );
-      // TRUST_PROXY is not in NUMERIC_APP_CONFIG_PATHS (resolveTrustProxyHops
-      // coerces it) but still belongs in config.yaml as a number.
-      const numericPaths = [...NUMERIC_APP_CONFIG_PATHS, 'TRUST_PROXY'];
-
-      for (const configPath of numericPaths) {
+      for (const configPath of NUMERIC_APP_CONFIG_PATHS) {
         // Every matching line, not just the first, so a stray update_app_config
         // added later for the same key is still caught.
-        const callSites = entrypoint
+        const callSites = entrypoint()
           .split('\n')
           .filter((line) => line.includes(`'.${configPath}'`));
 
@@ -311,10 +359,40 @@ describe('Numeric config coercion', function () {
           `no docker-entrypoint.sh call site for APP.${configPath}`,
         ).to.not.be.empty;
         for (const callSite of callSites) {
-          expect(callSite, `APP.${configPath}`).to.match(
+          expect(callSite.trim(), `APP.${configPath}`).to.match(
             /^update_numeric_app_config /,
           );
         }
+      }
+    });
+
+    it('keeps an entrypoint call site for TRUST_PROXY', function () {
+      // Excluded from the numeric writer because resolveTrustProxyHops owns its
+      // own coercion, which leaves it outside both guards above.
+      const callSites = entrypoint()
+        .split('\n')
+        .filter((line) => line.includes("'.TRUST_PROXY'"));
+
+      expect(callSites).to.have.lengthOf(1);
+      expect(callSites[0].trim()).to.match(/^update_app_config /);
+    });
+
+    it('routes nothing else through the numeric writer', function () {
+      // The inverse guard. Sending a digit-only API key or governance body ID
+      // through the numeric writer would strip its quotes and change its type
+      // in the JS layer. Indentation-insensitive so a call site tucked inside a
+      // conditional cannot slip past the count.
+      const numericCallSites = entrypoint()
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.startsWith('update_numeric_app_config '));
+
+      expect(numericCallSites).to.have.lengthOf(
+        NUMERIC_APP_CONFIG_PATHS.length,
+      );
+      for (const callSite of numericCallSites) {
+        const yamlPath = callSite.split(/\s+/)[2].replace(/'/g, '').slice(1);
+        expect([...NUMERIC_APP_CONFIG_PATHS], callSite).to.include(yamlPath);
       }
     });
 
@@ -322,19 +400,44 @@ describe('Numeric config coercion', function () {
       let written;
 
       before(function () {
-        // The image installs mikefarah yq v4; the unrelated jq-based python-yq
-        // of the same name has no `eval` subcommand, so skip on anything else
-        // rather than reporting a spurious failure.
+        // mikefarah yq v4, as installed by the Dockerfile and the test
+        // workflow. The unrelated jq-based python-yq of the same name has no
+        // `eval` subcommand. Skipping locally is a convenience; in CI the
+        // binary is installed on purpose, so a miss is a real failure.
         const yqVersion = spawnSync('yq', ['--version'], { encoding: 'utf8' });
-        if (yqVersion.error || !/mikefarah/i.test(yqVersion.stdout || '')) {
+        // Pinned to the major the image builds from, so CI cannot start
+        // validating the entrypoint against a yq production never runs.
+        const hasMikefarahYq =
+          !yqVersion.error && /mikefarah.*version v4\./i.test(yqVersion.stdout);
+
+        if (!hasMikefarahYq) {
+          if (process.env.CI) {
+            throw new Error(
+              'mikefarah yq v4 is required to test docker-entrypoint.sh ' +
+                `but was not found (got: ${
+                  yqVersion.error?.message ?? yqVersion.stdout?.trim()
+                })`,
+            );
+          }
           this.skip();
         }
-        written = yaml.load(
-          execFileSync('bash', [scriptPath], {
-            cwd: repoRoot,
-            encoding: 'utf8',
-          }),
-        );
+
+        try {
+          written = yaml.load(
+            execFileSync('bash', [scriptPath], {
+              cwd: repoRoot,
+              encoding: 'utf8',
+              stdio: ['ignore', 'pipe', 'pipe'],
+            }),
+          );
+        } catch (error) {
+          // The script runs under `set -euo pipefail`, so any unexpected abort
+          // fails all of the tests below with nothing to go on otherwise.
+          throw new Error(
+            `${scriptPath} failed: ${error.message}\n${error.stderr ?? ''}`,
+            { cause: error },
+          );
+        }
       });
 
       it('writes integer env vars as YAML numbers', function () {
@@ -345,6 +448,23 @@ describe('Numeric config coercion', function () {
       it('keeps digit-only values on non-numeric keys as strings', function () {
         expect(written.V1.CADT_API_KEY).to.equal('12345678');
         expect(written.V1.GOVERNANCE.GOVERNANCE_BODY_ID).to.equal('99999999');
+      });
+
+      it('preserves values it cannot write as YAML numbers', function () {
+        // yq rejects integers wider than int64 and the writer rejects signs, so
+        // both fall through to the quoted writer. The JS layer then replaces
+        // them with the documented default and warns, which still beats
+        // dropping the operator's setting here without a trace.
+        expect(written.APP.TASKS.MIRROR_CHECK_TASK_INTERVAL).to.equal(
+          '99999999999999999999',
+        );
+        expect(written.APP.CW_PORT).to.equal('-5');
+      });
+
+      it('leaves numeric keys without an env var at their existing value', function () {
+        // The fixture seeds 121 rather than the shipped 120, so this fails if
+        // the writer resets an unset key to the default.
+        expect(written.APP.TASKS.PICKLIST_SYNC_TASK_INTERVAL).to.equal(121);
       });
 
       it('leaves boolean, string and empty handling unchanged', function () {

--- a/tests/v2/integration/numeric-config-coercion.spec.js
+++ b/tests/v2/integration/numeric-config-coercion.spec.js
@@ -238,6 +238,18 @@ describe('Numeric config coercion', function () {
       expect(app.REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN).to.equal(50);
     });
 
+    it('keeps the CW_PORT env override numeric', function () {
+      writeConfig({ CW_PORT: '31310' });
+
+      process.env.CW_PORT = '31399';
+      clearConfigCaches();
+      expect(getConfig().APP.CW_PORT).to.equal(31399);
+
+      process.env.CW_PORT = 'not-a-port';
+      clearConfigCaches();
+      expect(getConfig().APP.CW_PORT).to.equal(defaultConfig.APP.CW_PORT);
+    });
+
     it('falls back to documented defaults for unparseable values', function () {
       writeConfig({ DEFAULT_FEE: 'not-a-number', DEFAULT_COIN_AMOUNT: '' });
 
@@ -284,8 +296,11 @@ describe('Numeric config coercion', function () {
       let written;
 
       before(function () {
-        // yq v4 ships in the Docker image but is not a dev dependency.
-        if (spawnSync('yq', ['--version']).error) {
+        // The image installs mikefarah yq v4; the unrelated jq-based python-yq
+        // of the same name has no `eval` subcommand, so skip on anything else
+        // rather than reporting a spurious failure.
+        const yqVersion = spawnSync('yq', ['--version'], { encoding: 'utf8' });
+        if (yqVersion.error || !/mikefarah/i.test(yqVersion.stdout || '')) {
           this.skip();
         }
         written = yaml.load(

--- a/tests/v2/integration/numeric-config-coercion.spec.js
+++ b/tests/v2/integration/numeric-config-coercion.spec.js
@@ -1,0 +1,316 @@
+import { expect } from 'chai';
+import _ from 'lodash';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import * as yaml from 'js-yaml';
+
+import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
+import { getChiaRoot } from '../../../src/utils/chia-root.js';
+import { defaultConfig } from '../../../src/utils/defaultConfig.js';
+import {
+  NUMERIC_APP_CONFIG_PATHS,
+  coerceConfigNumber,
+  coerceNumericAppConfig,
+} from '../../../src/utils/numeric-config.js';
+
+/**
+ * Numeric APP config values must reach the JS layer as numbers.
+ *
+ * YAML keeps quoted values as strings, so `DEFAULT_COIN_AMOUNT + DEFAULT_FEE`
+ * concatenated "300" and "300" into "300300" instead of adding to 600, and the
+ * wallet then waited for coins of 300300+ mojos before creating an org.
+ */
+describe('Numeric config coercion', function () {
+  const silentLog = { warn: () => {} };
+
+  describe('coerceConfigNumber', function () {
+    it('passes finite numbers through unchanged', function () {
+      expect(coerceConfigNumber(300, 3000, 'APP.DEFAULT_FEE')).to.equal(300);
+      expect(coerceConfigNumber(0, 3000, 'APP.DEFAULT_FEE')).to.equal(0);
+    });
+
+    it('parses numeric strings, including padded ones', function () {
+      expect(coerceConfigNumber('300', 3000, 'APP.DEFAULT_FEE')).to.equal(300);
+      expect(coerceConfigNumber(' 300 ', 3000, 'APP.DEFAULT_FEE')).to.equal(
+        300,
+      );
+    });
+
+    it('falls back to the default for missing values without warning', function () {
+      const warnings = [];
+      const log = { warn: (msg) => warnings.push(msg) };
+
+      expect(
+        coerceConfigNumber(undefined, 3000, 'APP.DEFAULT_FEE', log),
+      ).to.equal(3000);
+      expect(coerceConfigNumber(null, 3000, 'APP.DEFAULT_FEE', log)).to.equal(
+        3000,
+      );
+      expect(warnings).to.deep.equal([]);
+    });
+
+    it('falls back to the default for non-numeric values and warns', function () {
+      const warnings = [];
+      const log = { warn: (msg) => warnings.push(msg) };
+
+      for (const garbage of [
+        '',
+        'abc',
+        '300 mojos',
+        '0x12',
+        true,
+        false,
+        [],
+        {},
+        NaN,
+        Infinity,
+      ]) {
+        expect(
+          coerceConfigNumber(garbage, 3000, 'APP.DEFAULT_FEE', log),
+        ).to.equal(3000);
+      }
+      // '' is a value, not an absence, so it warns like the rest.
+      expect(warnings).to.have.lengthOf(10);
+    });
+
+    it('never returns NaN, which would make every >= comparison false', function () {
+      for (const garbage of ['abc', true, {}, NaN]) {
+        expect(
+          Number.isNaN(
+            coerceConfigNumber(garbage, 3000, 'APP.DEFAULT_FEE', silentLog),
+          ),
+        ).to.be.false;
+      }
+    });
+  });
+
+  describe('coerceNumericAppConfig', function () {
+    it('coerces every documented numeric key', function () {
+      const stringified = {};
+      for (const configPath of NUMERIC_APP_CONFIG_PATHS) {
+        _.set(
+          stringified,
+          configPath,
+          String(_.get(defaultConfig.APP, configPath)),
+        );
+      }
+
+      const coerced = coerceNumericAppConfig(stringified, silentLog);
+
+      for (const configPath of NUMERIC_APP_CONFIG_PATHS) {
+        expect(_.get(coerced, configPath), configPath).to.equal(
+          _.get(defaultConfig.APP, configPath),
+        );
+      }
+    });
+
+    it('leaves non-numeric keys untouched', function () {
+      const coerced = coerceNumericAppConfig(
+        {
+          LOG_LEVEL: 'debug',
+          CHIA_NETWORK: 'testnet',
+          CERTIFICATE_FOLDER_PATH: null,
+        },
+        silentLog,
+      );
+
+      expect(coerced.LOG_LEVEL).to.equal('debug');
+      expect(coerced.CHIA_NETWORK).to.equal('testnet');
+      expect(coerced.CERTIFICATE_FOLDER_PATH).to.be.null;
+    });
+
+    it('does not mutate the input or defaultConfig', function () {
+      const input = {
+        DEFAULT_FEE: '300',
+        TASKS: { PICKLIST_SYNC_TASK_INTERVAL: '60' },
+      };
+
+      coerceNumericAppConfig(input, silentLog);
+
+      expect(input.DEFAULT_FEE).to.equal('300');
+      expect(input.TASKS.PICKLIST_SYNC_TASK_INTERVAL).to.equal('60');
+      expect(defaultConfig.APP.DEFAULT_FEE).to.equal(3000);
+      expect(defaultConfig.APP.TASKS.PICKLIST_SYNC_TASK_INTERVAL).to.equal(120);
+    });
+
+    it('leaves TRUST_PROXY to resolveTrustProxyHops', function () {
+      const coerced = coerceNumericAppConfig({ TRUST_PROXY: true }, silentLog);
+      expect(coerced.TRUST_PROXY).to.equal(true);
+    });
+  });
+
+  describe('config-loader with quoted YAML values', function () {
+    let testChiaRoot;
+    let configFile;
+    let savedCwPort;
+
+    const clearConfigCaches = () => {
+      getChiaRoot.cache?.clear();
+      getConfig.cache?.clear();
+      getConfigV2.cache?.clear();
+    };
+
+    const writeConfig = (app) => {
+      fs.writeFileSync(
+        configFile,
+        yaml.dump({ APP: app, V1: { ENABLE: true }, V2: { ENABLE: true } }),
+        'utf8',
+      );
+      clearConfigCaches();
+    };
+
+    beforeEach(function () {
+      testChiaRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'cadt-numeric-config-'),
+      );
+      fs.mkdirSync(path.join(testChiaRoot, 'cadt'), { recursive: true });
+      configFile = path.join(testChiaRoot, 'cadt', 'config.yaml');
+
+      savedCwPort = process.env.CW_PORT;
+      delete process.env.CW_PORT;
+      process.env.CHIA_ROOT = testChiaRoot;
+      clearConfigCaches();
+    });
+
+    afterEach(function () {
+      fs.rmSync(testChiaRoot, { recursive: true, force: true });
+      delete process.env.CHIA_ROOT;
+      if (savedCwPort !== undefined) {
+        process.env.CW_PORT = savedCwPort;
+      }
+      clearConfigCaches();
+    });
+
+    it('turns DEFAULT_FEE: "300" and DEFAULT_COIN_AMOUNT: "300" into 600, not 300300', function () {
+      writeConfig({ DEFAULT_FEE: '300', DEFAULT_COIN_AMOUNT: '300' });
+
+      const app = getConfig().APP;
+
+      expect(app.DEFAULT_FEE).to.equal(300);
+      expect(app.DEFAULT_COIN_AMOUNT).to.equal(300);
+      // The expression from wallet.js and coin-management.js.
+      expect(app.DEFAULT_COIN_AMOUNT + app.DEFAULT_FEE).to.equal(600);
+    });
+
+    it('resolves stock defaults quoted as strings to 3300 and a 1,000,000 COIN_SIZE', function () {
+      writeConfig({ DEFAULT_FEE: '3000', DEFAULT_COIN_AMOUNT: '300' });
+
+      const app = getConfig().APP;
+      const DUST_FILTER_FLOOR = 1_000_000;
+      const minUsableCoinSize = app.DEFAULT_COIN_AMOUNT + app.DEFAULT_FEE;
+
+      expect(minUsableCoinSize).to.equal(3300);
+      expect(Math.max(minUsableCoinSize, DUST_FILTER_FLOOR)).to.equal(
+        1_000_000,
+      );
+    });
+
+    it('applies the same coercion to the V2 config', function () {
+      writeConfig({ DEFAULT_FEE: '300', DEFAULT_COIN_AMOUNT: '300' });
+
+      const app = getConfigV2().APP;
+
+      expect(app.DEFAULT_COIN_AMOUNT + app.DEFAULT_FEE).to.equal(600);
+    });
+
+    it('gives the Chia RPC numbers for fee and amount_per_coin', function () {
+      writeConfig({ DEFAULT_FEE: '300', DEFAULT_COIN_AMOUNT: '300' });
+
+      const app = getConfig().APP;
+
+      // The accessors used in src/datalayer/persistance.js.
+      expect(_.get(app, 'DEFAULT_FEE', 3000)).to.be.a('number');
+      expect(_.get(app, 'DEFAULT_COIN_AMOUNT', 300)).to.be.a('number');
+      expect(app.DEFAULT_FEE).to.be.a('number');
+    });
+
+    it('coerces quoted task intervals and request content limits', function () {
+      writeConfig({
+        TASKS: { COIN_MANAGEMENT_TASK_INTERVAL: '3600' },
+        REQUEST_CONTENT_LIMITS: { STAGING: { EDIT_DATA_LEN: '50' } },
+      });
+
+      const app = getConfig().APP;
+
+      expect(app.TASKS.COIN_MANAGEMENT_TASK_INTERVAL).to.equal(3600);
+      expect(app.REQUEST_CONTENT_LIMITS.STAGING.EDIT_DATA_LEN).to.equal(50);
+    });
+
+    it('falls back to documented defaults for unparseable values', function () {
+      writeConfig({ DEFAULT_FEE: 'not-a-number', DEFAULT_COIN_AMOUNT: '' });
+
+      const app = getConfig().APP;
+
+      expect(app.DEFAULT_FEE).to.equal(3000);
+      expect(app.DEFAULT_COIN_AMOUNT).to.equal(300);
+      expect(app.DEFAULT_COIN_AMOUNT + app.DEFAULT_FEE).to.equal(3300);
+    });
+  });
+
+  describe('docker-entrypoint.sh', function () {
+    const repoRoot = path.resolve(process.cwd());
+    const scriptPath = path.join(
+      repoRoot,
+      'tests/shell/docker-entrypoint-numeric-config.sh',
+    );
+
+    it('routes every numeric APP key through the numeric writer', function () {
+      const entrypoint = fs.readFileSync(
+        path.join(repoRoot, 'docker-entrypoint.sh'),
+        'utf8',
+      );
+      // TRUST_PROXY is not in NUMERIC_APP_CONFIG_PATHS (resolveTrustProxyHops
+      // coerces it) but still belongs in config.yaml as a number.
+      const numericPaths = [...NUMERIC_APP_CONFIG_PATHS, 'TRUST_PROXY'];
+
+      for (const configPath of numericPaths) {
+        const callSite = entrypoint
+          .split('\n')
+          .find((line) => line.includes(`'.${configPath}'`));
+
+        expect(
+          callSite,
+          `no docker-entrypoint.sh call site for APP.${configPath}`,
+        ).to.exist;
+        expect(callSite, `APP.${configPath}`).to.match(
+          /^update_numeric_app_config /,
+        );
+      }
+    });
+
+    describe('config.yaml it writes', function () {
+      let written;
+
+      before(function () {
+        // yq v4 ships in the Docker image but is not a dev dependency.
+        if (spawnSync('yq', ['--version']).error) {
+          this.skip();
+        }
+        written = yaml.load(
+          execFileSync('bash', [scriptPath], {
+            cwd: repoRoot,
+            encoding: 'utf8',
+          }),
+        );
+      });
+
+      it('writes integer env vars as YAML numbers', function () {
+        expect(written.APP.DEFAULT_FEE).to.equal(300);
+        expect(written.APP.DEFAULT_COIN_AMOUNT).to.equal(300);
+      });
+
+      it('keeps digit-only values on non-numeric keys as strings', function () {
+        expect(written.V1.CADT_API_KEY).to.equal('12345678');
+        expect(written.V1.GOVERNANCE.GOVERNANCE_BODY_ID).to.equal('99999999');
+      });
+
+      it('leaves boolean, string and empty handling unchanged', function () {
+        expect(written.APP.USE_SIMULATOR).to.equal(true);
+        expect(written.APP.CHIA_NETWORK).to.equal('testnet');
+        expect(written.APP.CERTIFICATE_FOLDER_PATH).to.be.null;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## The bug

Numeric config values reached the JS layer as strings, and the code does
arithmetic on them with `+`, which concatenates instead of adding.

A 1.7.26-rc36 instance configured with `DEFAULT_FEE=300` and
`DEFAULT_COIN_AMOUNT=300` logged this while creating a v2 home organization:

```
[wallet]: Timeout waiting for 4 coins of 300300+ mojos after 301s
```

The usable-coin threshold should have been 600 mojos (300 + 300). It came out
as `300300`, the string concatenation of `"300"` and `"300"`, so no coin in the
wallet could ever qualify and org creation timed out.

## Root cause, in two layers

**1. `docker-entrypoint.sh` quoted everything.** `update_yaml_if_env_exists`
wrote every non-boolean, non-empty env var as a quoted YAML scalar, so
`DEFAULT_FEE=300` became `DEFAULT_FEE: "300"` in
`/root/.chia/mainnet/cadt/config.yaml`.

**2. Nothing coerced on the JS side.** YAML preserves quoting, so the strings
flowed straight into `DEFAULT_COIN_AMOUNT + DEFAULT_FEE` in
`src/datalayer/wallet.js` and `src/tasks/coin-management.js`, and into
`coinAmount + fee` in `checkWalletBalanceForMirror`.

Both layers need fixing independently. The entrypoint only rewrites keys whose
env var is still set, so an instance upgraded to a fixed image that no longer
passes those vars keeps the quoted values already persisted in its
`config.yaml`. Hand-edited configs and non-Docker installs are never touched by
the entrypoint at all.

## Why it matters more than the log line suggests

The severity depends on the configured values, which is what made it easy to
miss. Both permutations, computed with the real expressions:

| | fee 300 / amount 300 | fee 3000 / amount 300 (stock defaults) |
|---|---|---|
| `MIN_USABLE_COIN_SIZE` before | `"300300"` | `"3003000"` |
| `MIN_USABLE_COIN_SIZE` after | `600` | `3300` |
| coin size before | 1,000,000 | **3,003,000** |
| coin size after | 1,000,001 | 1,000,001 |
| `requiredAmount` for a 14-coin split, before | `"14000000300"` | `"420420003000"` |
| `requiredAmount` after | `14,000,314` | `14,003,014` |

With stock defaults the concatenated `"3003000"` exceeded the dust filter
floor, so coin management reserved roughly 3x the intended amount per coin, and
`requiredAmount` came out as 0.42 XCH instead of ~14,003,000 mojos.

The string also propagated into `fee:` fields sent to the Chia RPC from
`src/datalayer/persistance.js` and into `wallet.splitCoins(..., SPLIT_FEE)`.

## What changed

### 1. Numeric coercion at the JS boundary

New `src/utils/numeric-config.js` coerces the numeric `APP` keys once, in
`config-loader.js`, so no consumer needs `Number(...)` at the call site.

Every key it covers is a non-negative integer by contract — a TCP port, a mojo
amount, a count of seconds, or a length bound — so signed, fractional, and
past-`MAX_SAFE_INTEGER` values are rejected rather than accepted or silently
truncated. This matches the existing `resolveTrustProxyHops`, which already
enforces the same contract for `TRUST_PROXY`. Out-of-contract values fall back
to the documented default with a warning rather than producing `NaN`, which
would silently make every `>=` comparison false. Default values are unchanged:
`DEFAULT_FEE` 3000, `DEFAULT_COIN_AMOUNT` 300.

The covered paths are derived from the numeric leaves of `defaultConfig.APP`,
so a newly added numeric key is coerced automatically and fails a test until it
also gets a `docker-entrypoint.sh` call site.

`TRUST_PROXY` is deliberately excluded — `resolveTrustProxyHops` owns its
coercion and emits security-relevant warnings for booleans and strings like
`"loopback"` that a blanket coercion would silently replace with 0.

An unusable `CW_PORT` environment variable now falls back to the port resolved
from `config.yaml` rather than to the shipped default, so an operator's
configured port is not discarded. This matters under Kubernetes, which injects
`<SVC>_PORT=tcp://10.0.0.5:31310` style values for a Service named `cw`.

### 2. `docker-entrypoint.sh` writes integers unquoted

`update_numeric_app_config` writes unsigned integers as YAML numbers. This is
scoped to keys that are numeric by contract, because digit-only values
elsewhere must keep their quotes — an all-digits `CADT_API_KEY` or
`GOVERNANCE_BODY_ID` written as a bare number would be a much worse bug.
Boolean, empty and string handling is untouched, and anything that isn't a
plain unsigned integer, or that `yq` refuses to write (beyond int64), falls
through to the original quoted writer so the operator's setting is preserved
rather than dropped.

The helper definitions moved above the container startup block so the script
can be sourced for its functions alone; the startup block itself is unchanged,
and an unset `BASH_SOURCE` falls through to startup so a non-bash shell cannot
silently skip it.

### 3. Coin sizing now derives from Chia's dust filter threshold

`coin-management.js` previously computed
`Math.max(MIN_USABLE_COIN_SIZE, 1_000_000)` against a hardcoded floor. Two
problems: the floor is an operator-configurable Chia setting
(`wallet.xch_spam_amount`), not a constant, and `Math.max` produced a coin
sitting exactly *at* the threshold rather than clear of it, despite the comment
claiming the value was chosen to be above it.

`resolveCoinSize` now reads the threshold from Chia's own config via the
existing `getChiaConfig()` and returns
`Math.max(minUsableCoinSize, dustFilterFloor + 1)`:



| configured `wallet.xch_spam_amount` | coin size |
|---|---|
| unset | 1,000,001 |
| 1,000,000 (Chia's default) | 1,000,001 |
| 5,000,000 | 5,000,001 |
| 100 | 3,300 (operational minimum already clears it) |
| garbage / negative / fractional | 1,000,001 |

No coin is created at or below the floor, and when the floor is low enough that
the operational minimum already clears it, that minimum wins — a wallet is not
carved into more value per coin than an operation needs.

The read is lazy rather than done at import: `coin-management.js` is imported by
the task scheduler, so reading at import time would make every consumer of the
module depend on a readable Chia config, and would fire in simulator mode where
coin management never runs. Only a *successful* read is cached, so a node whose
chia config is not mounted yet is retried on the next run instead of being
pinned to the assumed default for the life of the process.

A missing chia config is not fatal or even unusual — it warns at `debug` and
assumes Chia's own default, matching how `fullNodeRpc.js` already treats that
exact condition. A config that exists but cannot be read warns at `warn`, since
that is the case an operator can act on.

**Where this does and does not take effect.** Reading the threshold only works
where CADT can see a local chia `config.yaml`. The container deployments cannot:
the image creates only `config/ssl`, `docker-compose-example.yml` mounts only
`ssl`, and the k8s chart mounts only `cadt/` while pointing `WALLET_URL` at a
remote wallet. Those deployments fall back to Chia's documented default of
1,000,000 and get a 1,000,001-mojo coin, which is correct for any node running
the default threshold. Operators who have customized `xch_spam_amount` *and* run
in a container will not see it reflected until they mount the chia config
directory. Exposing the threshold as a CADT config key would close that gap and
is deliberately left out of this PR.

## Observable effect for existing deployments

Worth calling out in release notes: any deployment supplying `DEFAULT_FEE` and
`DEFAULT_COIN_AMOUNT` as Docker env vars will see coin management begin
creating coins just above the dust filter threshold (1,000,001 mojos on a node
running Chia's default) instead of 3,003,000-mojo ones, and treat smaller coins
as usable. Existing larger coins remain spendable and still pass the usability
filter. This matches what non-Docker installs with a numeric `config.yaml`
already did, but it is a change in on-chain coin sizing that happens on upgrade
with no operator action.

Operators who have raised `wallet.xch_spam_amount` in their Chia config, and who
run CADT where it can read that config, will now get correspondingly larger
coins, which previously would have been created below their configured threshold
and hidden by the wallet. Raising that threshold a long way also raises the
balance a split needs, so a wallet that cannot fund it will log an insufficient
balance and skip splitting; the log names both the required amount and the coin
size so the cause is visible.

Two smaller behavior changes worth a release note:

- A numeric `APP` value that is negative, fractional, or past
  `Number.MAX_SAFE_INTEGER` is now replaced by its documented default with a
  warning, where previously it passed through. Nothing in the repo emits such
  values, but a hand-edited `config.yaml` could contain one — grep startup logs
  for `[config]:` after upgrading.
- `/diagnostics` reports `nonDefaultTaskIntervals[].actual` as a JSON number
  rather than a quoted string for container deployments. The set of reported
  entries is unchanged.

## Tests

`tests/v2/integration/numeric-config-coercion.spec.js` (27 assertions),
`tests/v2/integration/coin-management.spec.js` (44), and
`tests/shell/docker-entrypoint-numeric-config.sh`.

Verified to fail before the fix — reverting the loader call reproduces
`expected '3003000' to equal 3300` and `expected '300300' to equal 600`, and
reverting the entrypoint routing fails the wiring assertion.

Coverage includes:

- `DEFAULT_FEE: "300"` / `DEFAULT_COIN_AMOUNT: "300"` yields numeric 300s and a
  minimum usable coin size of 600, not 300300.
- Signed, fractional, and past-`MAX_SAFE_INTEGER` values fall back to the
  documented default and warn, each asserted individually.
- `fee` and `amount_per_coin` reaching the Chia RPC are numbers, asserted by
  exact value so a loader that ignored the file would still fail.
- An unusable `CW_PORT` env value keeps the port configured in `config.yaml`.
- Coin size is strictly above the dust filter threshold, follows the threshold
  from Chia's config, and falls back when that value is missing or unusable.
  These call `resolveCoinSize` directly rather than re-implementing the
  arithmetic.
- The production read path is covered against a real chia `config.yaml` in a
  temporary `CHIA_ROOT`, including an absent config, a config with no `wallet`
  section, a config that only becomes readable on a later run, and that a
  successful read is not repeated. Verified by mutation: typing the lookup path
  fails three of these, and caching a failed read fails the retry case.
- The entrypoint writes integers unquoted while keeping digit-only API keys and
  governance body IDs quoted, preserves values `yq` cannot write as numbers,
  leaves unset keys alone, and leaves boolean/string/empty handling intact.
- Only numeric keys are routed through the numeric writer, asserted in both
  directions and insensitive to indentation, plus a separate assertion that
  `TRUST_PROXY` keeps its own call site so excluding it from the numeric writer
  cannot quietly become "no longer honored".

The v2 test job now installs mikefarah `yq`, so the assertions covering
`docker-entrypoint.sh` actually execute in CI instead of skipping — Debian's
`yq` package is the unrelated jq-based python-yq, which has no `eval`
subcommand. It is pinned to the same major the image builds from so CI cannot
drift onto a `yq` production never runs, the test asserts that major rather than
just the vendor, and the guard fails rather than skips when `CI` is set.

The docker smoke test passes integer env vars to the real image and asserts
they land in `config.yaml` unquoted, plus a digit-only `GOVERNANCE_BODY_ID`
that must stay quoted, on both amd64 and arm64.

**Results:** `npm run test:v2` 1869 passing, `npm run test:v1` 208 passing,
0 failing. ESLint and Prettier report nothing new on changed files; the
remaining `no-console` warnings and three `no-unused-vars` / `no-unassigned-vars`
errors are pre-existing and present at the base commit, as are the Prettier
findings in `coin-management.js` and its spec, which have never been formatted.

## Out of scope

No changes to the coin-management schedule, `TARGET_COIN_COUNT`, the 6-hour
interval, org-creation retry logic, or the default fee and coin amount values.

The `X || default` fallbacks in `wallet.js` and `coin-management.js` still
discard a deliberate `0`. That predates this change — a quoted `"0"` was
truthy but concatenated, so the setting was ignored then too — and fixing it
means editing modules this PR otherwise only reads from.

`wallet.js` computes its own `MIN_USABLE_COIN_SIZE` and the usable-coin filter
in `coin-management.js` still counts anything at or above 3300, so neither
tracks the dust threshold the way coin *creation* now does. That gap is
pre-existing and only widens for operators who raise `xch_spam_amount`; closing
it means reworking the split-confirmation and affordability logic, which is
more than this fix should carry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet coin sizing and fee/amount handling used by org creation and RPC calls; behavior changes for Docker env-based configs but reduces incorrect string concatenation and oversized splits.
> 
> **Overview**
> Fixes a production failure where quoted YAML/env values made `DEFAULT_FEE` and `DEFAULT_COIN_AMOUNT` strings, so `+` concatenated (e.g. `300300`) and wallet coin waits never succeeded.
> 
> **JS config boundary:** Adds `numeric-config.js` and runs `coerceNumericAppConfig` in `config-loader.js` so numeric `APP` keys (ports, fees, task intervals, content limits) are safe integers with fallbacks; `CW_PORT` env overrides use the same coercion. `TRUST_PROXY` stays on its existing path.
> 
> **Docker entrypoint:** Introduces `update_numeric_app_config` for contract-numeric keys only; digit-only secrets like governance body IDs remain quoted. Startup logic is gated so the script can be sourced in shell tests.
> 
> **Coin management:** Split coin size is resolved lazily from Chia `wallet.xch_spam_amount` (strictly above the spam threshold) instead of a fixed 1M mojo floor, with memoization and tests.
> 
> **CI:** Installs mikefarah `yq` v4 in the test workflow; the Docker smoke test asserts numeric env vars land unquoted in `config.yaml` while quoted IDs stay strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de10bc88c0723e218fff3216ea424d611085c23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->