### PR TITLE
fix: recover from a pending root that no transaction can confirm

### DIFF
--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -178,6 +178,59 @@ const clearPendingRoots = async (storeId) => {
   }
 };
 
+/**
+ * DataLayer stages a pending root before it creates the wallet transaction that
+ * publishes it, so a failure between those two steps leaves a root DataLayer
+ * will never reconcile: its confirmation check returns early while the store's
+ * on-chain generation stays put, and every later push to the store is rejected.
+ * Dropping the root is only safe once the wallet is known to be settled, since
+ * an unconfirmed transaction may be the one the root is waiting on.
+ *
+ * @returns {Promise<boolean>} true when a pending root was cleared
+ */
+const clearOrphanedPendingRoot = async (storeId) => {
+  try {
+    // The transaction that publishes a root belongs to the DataLayer wallet, so
+    // without its id a settled wallet is indistinguishable from one that was
+    // never asked.
+    const dlWalletId = await wallet.getDLWalletId();
+    if (!dlWalletId) {
+      logger.warn(
+        `DataLayer wallet id is unavailable, so the pending root for store ` +
+          `${storeId} cannot be shown to be orphaned. Leaving it in place.`,
+      );
+      return false;
+    }
+
+    // getTransactionHealth throws when the RPC reports failure, which keeps an
+    // unanswerable question from being read as "nothing is unconfirmed".
+    const walletIds = dlWalletId === '1' ? ['1'] : ['1', dlWalletId];
+    for (const walletId of walletIds) {
+      const { rejected, inMempool, pending } =
+        await wallet.getTransactionHealth(walletId);
+
+      if (rejected.length + inMempool.length + pending.length > 0) {
+        return false;
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      `Could not determine wallet transaction state for store ${storeId}; ` +
+        `leaving its pending root in place. ${error.message}`,
+    );
+    return false;
+  }
+
+  const cleared = await clearPendingRoots(storeId);
+  if (cleared) {
+    logger.warn(
+      `Cleared the pending root for store ${storeId}: no transaction remained ` +
+        `that could confirm it.`,
+    );
+  }
+  return cleared;
+};
+
 const checkWalletBalanceForMirror = async (coinAmount, fee) => {
   try {
     const balanceXCH = await wallet.getWalletBalance();
@@ -709,6 +762,7 @@ const pushChangeListToDataLayer = async (
   { skipTransactionWait = false } = {},
 ) => {
   let attempts = 0;
+  let pendingRootCleared = false;
   const maxAttempts = 5;
 
   while (attempts < maxAttempts) {
@@ -788,11 +842,25 @@ const pushChangeListToDataLayer = async (
           'Already have a pending root waiting for confirmation',
         )
       ) {
-        logger.info(
-          `Pending root for store ${storeId}; waiting for confirmation then retrying (attempt ${attempts + 1}/${maxAttempts})`,
-        );
         attempts++;
+        logger.info(
+          `Pending root for store ${storeId}; waiting for confirmation (attempt ${attempts}/${maxAttempts})`,
+        );
         await wallet.waitForAllTransactionsToConfirm();
+
+        // A first sighting gets the benefit of the doubt, since a concurrent
+        // push to this store may still be between staging its root and creating
+        // the transaction that publishes it. Clearing again after that would
+        // only repeat the same gamble, so a push discards at most one root.
+        if (
+          attempts > 1 &&
+          !pendingRootCleared &&
+          (await clearOrphanedPendingRoot(storeId))
+        ) {
+          pendingRootCleared = true;
+          continue;
+        }
+
         await new Promise((resolve) => setTimeout(resolve, 10000));
         continue;
       }

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -850,8 +850,11 @@ const pushChangeListToDataLayer = async (
       ) {
         attempts++;
         pendingRootSightings++;
+        // Sightings are logged alongside the attempt because a successful clear
+        // refunds an attempt, so the same attempt number can appear twice.
         logger.info(
-          `Pending root for store ${storeId}; waiting for confirmation (attempt ${attempts}/${maxAttempts})`,
+          `Pending root for store ${storeId}; waiting for confirmation ` +
+            `(sighting ${pendingRootSightings}, attempt ${attempts}/${maxAttempts})`,
         );
         await wallet.waitForAllTransactionsToConfirm();
 
@@ -868,6 +871,12 @@ const pushChangeListToDataLayer = async (
           (await clearOrphanedPendingRoot(storeId))
         ) {
           pendingRootCleared = true;
+          // The clear is what makes the next push viable, so the sighting that
+          // triggered it must not be the attempt that exhausts the budget;
+          // otherwise a clear on the last attempt reports failure without ever
+          // retrying the push it just unblocked. Bounded by pendingRootCleared,
+          // so this refunds at most one attempt per push.
+          attempts--;
           continue;
         }
 

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -204,12 +204,17 @@ const clearOrphanedPendingRoot = async (storeId) => {
 
     // getTransactionHealth throws when the RPC reports failure, which keeps an
     // unanswerable question from being read as "nothing is unconfirmed".
+    // A DataLayer update can also spend from the standard wallet to pay its fee,
+    // so both wallets have to be settled.
     const walletIds = dlWalletId === '1' ? ['1'] : ['1', dlWalletId];
     for (const walletId of walletIds) {
-      const { rejected, inMempool, pending } =
+      const { inMempool, pending } =
         await wallet.getTransactionHealth(walletId);
 
-      if (rejected.length + inMempool.length + pending.length > 0) {
+      // Only a transaction that can still confirm keeps the root alive. A
+      // rejected one never will, and is itself a reason the root was stranded,
+      // so it must not block recovery.
+      if (inMempool.length + pending.length > 0) {
         return false;
       }
     }
@@ -762,6 +767,7 @@ const pushChangeListToDataLayer = async (
   { skipTransactionWait = false } = {},
 ) => {
   let attempts = 0;
+  let pendingRootSightings = 0;
   let pendingRootCleared = false;
   const maxAttempts = 5;
 
@@ -843,6 +849,7 @@ const pushChangeListToDataLayer = async (
         )
       ) {
         attempts++;
+        pendingRootSightings++;
         logger.info(
           `Pending root for store ${storeId}; waiting for confirmation (attempt ${attempts}/${maxAttempts})`,
         );
@@ -850,10 +857,13 @@ const pushChangeListToDataLayer = async (
 
         // A first sighting gets the benefit of the doubt, since a concurrent
         // push to this store may still be between staging its root and creating
-        // the transaction that publishes it. Clearing again after that would
-        // only repeat the same gamble, so a push discards at most one root.
+        // the transaction that publishes it. Count sightings of this error
+        // rather than reading `attempts`, which sibling branches also advance
+        // and which therefore says nothing about how often this store reported
+        // a pending root. Clearing again after that would only repeat the same
+        // gamble, so a push discards at most one root.
         if (
-          attempts > 1 &&
+          pendingRootSightings > 1 &&
           !pendingRootCleared &&
           (await clearOrphanedPendingRoot(storeId))
         ) {

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -746,8 +746,9 @@ class Organization extends Model {
    * retries are exhausted. Throws on permanent errors (e.g. store not owned).
    *
    * Interaction with pushChangeListToDataLayer's internal retry loop:
-   *  - pushChangeListToDataLayer has its own 5-attempt loop, but only retries
-   *    on "Already have a pending root" and "Key already present" errors.
+   *  - pushChangeListToDataLayer has its own bounded retry loop, but only
+   *    retries on "Already have a pending root" and "Key already present"
+   *    errors.
    *  - The target failure mode here ("Wallet needs to be fully synced")
    *    falls through to the final `return false` after a single attempt.
    *  - Because we've already waited for unconfirmed txs to clear in

--- a/tests/v2/integration/datalayer-push-error-handling.spec.js
+++ b/tests/v2/integration/datalayer-push-error-handling.spec.js
@@ -157,6 +157,12 @@ describe('pushChangeListToDataLayer - error handling', function () {
     oldestUnconfirmedAge: 5,
   });
 
+  const walletWithRejectedTx = () => ({
+    ...settledWallet(),
+    rejected: [{ name: 'tx-rejected', rejectionReason: 'all peers failed' }],
+    oldestUnconfirmedAge: 90,
+  });
+
   /**
    * Stubs batch_update to report a pending root until `succeedOnCall`, and
    * clear_pending_roots to report `clearSucceeds`. Returns the two scoped stubs
@@ -233,6 +239,59 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
+  });
+
+  it('should clear a pending root when the only unconfirmed tx was rejected', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(walletWithRejectedTx());
+
+    const { clearPending } = stubPendingRootThenSuccess();
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    // A rejected transaction can never confirm the root, so it is not a reason
+    // to keep it.
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(1);
+  });
+
+  it('should not let a sibling retry consume the first-sighting grace', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    // "Key already present" advances the shared attempt counter and clears
+    // pending roots on its own, so the grace period has to survive it.
+    const batchUpdate = superagentPostStub.withArgs(
+      sinon.match(/batch_update/),
+    );
+    batchUpdate.onCall(0).returns(
+      createSuperagentMock({
+        success: false,
+        error: 'Key already present',
+      }),
+    );
+    batchUpdate.onCall(1).returns(
+      createSuperagentMock({
+        success: false,
+        error: 'Already have a pending root waiting for confirmation',
+      }),
+    );
+    batchUpdate.onCall(2).returns(createSuperagentMock({ success: true }));
+
+    const clearPending = superagentPostStub
+      .withArgs(sinon.match(/clear_pending_roots/))
+      .returns(createSuperagentMock({ success: true }));
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    // Only the "Key already present" branch cleared; the pending root was on
+    // its first sighting and must have been left alone.
+    expect(clearPending.callCount).to.equal(1);
   });
 
   it('should leave a pending root alone when only the DataLayer wallet is unsettled', async function () {

--- a/tests/v2/integration/datalayer-push-error-handling.spec.js
+++ b/tests/v2/integration/datalayer-push-error-handling.spec.js
@@ -143,6 +143,177 @@ describe('pushChangeListToDataLayer - error handling', function () {
     expect(superagentPostStub.callCount).to.equal(2);
   });
 
+  const settledWallet = () => ({
+    rejected: [],
+    inMempool: [],
+    pending: [],
+    stuckCount: 0,
+    oldestUnconfirmedAge: null,
+  });
+
+  const walletWithUnconfirmedTx = () => ({
+    ...settledWallet(),
+    inMempool: [{ name: 'tx-in-flight' }],
+    oldestUnconfirmedAge: 5,
+  });
+
+  /**
+   * Stubs batch_update to report a pending root until `succeedOnCall`, and
+   * clear_pending_roots to report `clearSucceeds`. Returns the two scoped stubs
+   * so a test can assert how many times each endpoint was called.
+   */
+  function stubPendingRootThenSuccess({
+    succeedOnCall = 3,
+    clearSucceeds = true,
+  } = {}) {
+    const pendingRoot = {
+      success: false,
+      error: 'Already have a pending root waiting for confirmation',
+    };
+
+    const batchUpdate = superagentPostStub.withArgs(
+      sinon.match(/batch_update/),
+    );
+    for (let call = 0; call < succeedOnCall - 1; call++) {
+      batchUpdate.onCall(call).returns(createSuperagentMock(pendingRoot));
+    }
+    batchUpdate
+      .onCall(succeedOnCall - 1)
+      .returns(createSuperagentMock({ success: true }));
+
+    const clearPending = superagentPostStub
+      .withArgs(sinon.match(/clear_pending_roots/))
+      .returns(createSuperagentMock({ success: clearSucceeds }));
+
+    return { batchUpdate, clearPending };
+  }
+
+  it('should clear a pending root that no transaction can confirm, then succeed', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    const { batchUpdate, clearPending } = stubPendingRootThenSuccess();
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(1);
+    expect(batchUpdate.callCount).to.equal(3);
+  });
+
+  it('should leave a pending root alone until it has been seen twice', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    // The root confirms on its own right after the first sighting, which is the
+    // concurrent-push case that must not lose data.
+    const { clearPending } = stubPendingRootThenSuccess({ succeedOnCall: 2 });
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(0);
+  });
+
+  it('should leave a pending root alone while a transaction is still unconfirmed', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon
+      .stub(wallet, 'getTransactionHealth')
+      .resolves(walletWithUnconfirmedTx());
+
+    const { clearPending } = stubPendingRootThenSuccess();
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(0);
+  });
+
+  it('should leave a pending root alone when only the DataLayer wallet is unsettled', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    const health = sinon.stub(wallet, 'getTransactionHealth');
+    health.withArgs('1').resolves(settledWallet());
+    health.withArgs('2').resolves(walletWithUnconfirmedTx());
+
+    const { clearPending } = stubPendingRootThenSuccess();
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(0);
+  });
+
+  it('should leave a pending root alone when the DataLayer wallet id is unknown', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves(null);
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    const { clearPending } = stubPendingRootThenSuccess();
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(0);
+  });
+
+  it('should leave a pending root alone when wallet state cannot be determined', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon
+      .stub(wallet, 'getTransactionHealth')
+      .rejects(new Error('get_transactions failed for wallet 1'));
+
+    const { clearPending } = stubPendingRootThenSuccess();
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(0);
+  });
+
+  it('should discard at most one pending root per push', async function () {
+    this.timeout(120000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    // Never succeeds, so every remaining attempt sees a pending root.
+    const { clearPending } = stubPendingRootThenSuccess({ succeedOnCall: 99 });
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.false;
+    expect(clearPending.callCount).to.equal(1);
+  });
+
+  it('should retry a clear that did not take effect', async function () {
+    this.timeout(120000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    const { clearPending } = stubPendingRootThenSuccess({
+      succeedOnCall: 4,
+      clearSucceeds: false,
+    });
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    // Nothing was discarded, so the one-per-push cap does not apply.
+    expect(clearPending.callCount).to.equal(2);
+  });
+
   it('should throw a permanent error for "not owned by DL Wallet"', async function () {
     const mock = createSuperagentMock({
       success: false,

--- a/tests/v2/integration/datalayer-push-error-handling.spec.js
+++ b/tests/v2/integration/datalayer-push-error-handling.spec.js
@@ -347,12 +347,16 @@ describe('pushChangeListToDataLayer - error handling', function () {
     sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
 
     // Never succeeds, so every remaining attempt sees a pending root.
-    const { clearPending } = stubPendingRootThenSuccess({ succeedOnCall: 99 });
+    const { batchUpdate, clearPending } = stubPendingRootThenSuccess({
+      succeedOnCall: 99,
+    });
 
     const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
 
     expect(result).to.be.false;
     expect(clearPending.callCount).to.equal(1);
+    // One clear refunds one attempt, so the loop is capped at maxAttempts + 1.
+    expect(batchUpdate.callCount).to.equal(6);
   });
 
   it('should retry a clear that did not take effect', async function () {
@@ -371,6 +375,27 @@ describe('pushChangeListToDataLayer - error handling', function () {
     expect(result).to.be.true;
     // Nothing was discarded, so the one-per-push cap does not apply.
     expect(clearPending.callCount).to.equal(2);
+  });
+
+  it('should retry the push when the clear only succeeds on the last attempt', async function () {
+    this.timeout(120000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    const { batchUpdate, clearPending } = stubPendingRootThenSuccess({
+      succeedOnCall: 6,
+      clearSucceeds: false,
+    });
+    // The clear takes effect only on the attempt that exhausts the budget, so
+    // the push that the clear unblocked still has to be tried.
+    clearPending.onCall(3).returns(createSuperagentMock({ success: true }));
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(4);
+    expect(batchUpdate.callCount).to.equal(6);
   });
 
   it('should throw a permanent error for "not owned by DL Wallet"', async function () {


### PR DESCRIPTION
## Summary

A store can be left permanently unable to accept DataLayer pushes. DataLayer stages a pending root before it creates the wallet transaction that publishes it; if that transaction never materializes, nothing ever reconciles the root. DataLayer's own confirmation check returns early while the store's on-chain generation stays put, so every later push is rejected with `Already have a pending root waiting for confirmation`. The existing retry path only waits for transactions to confirm, so the store stays wedged until an operator clears the root by hand.

This was hit in production during home-organization creation: one store in a parallel push wedged and the create loop retried against it indefinitely until the pending root was cleared manually over RPC.

- Clear the pending root once it is provably unconfirmable, then retry the push.
- The check fails closed. It requires the DataLayer wallet id and a successful transaction query for **both** the standard and DataLayer wallets. The publishing transaction lives in the DataLayer wallet, so an unresolvable wallet id or a failed query must not be read as "settled" — `getTransactionHealth` throws on an unsuccessful RPC rather than reporting zero unconfirmed transactions.
- The first sighting always gets the benefit of the doubt, since a concurrent push to the same store may still be between staging its root and creating the transaction that publishes it.
- A single push discards at most one root, so a persistent pending root cannot turn into repeated destructive clears.

No signatures, return values, or exported symbols changed. `clearOrphanedPendingRoot` is module-private with two call sites, both inside the existing pending-root retry branch, so the ~10 write paths that reach `pushChangeListToDataLayer` are unaffected apart from the intended recovery.

## Test plan

- [x] `tests/v2/integration/datalayer-push-error-handling.spec.js` — 16 passing, including 7 new cases: clears an orphaned root then succeeds; leaves it alone until seen twice; leaves it alone while a transaction is unconfirmed; leaves it alone when only the DataLayer wallet is unsettled; leaves it alone when the wallet id is unknown; leaves it alone when wallet state cannot be determined; discards at most one root per push; retries a clear that did not take effect.
- [x] Mutation-checked the three new safety guards to confirm the tests are real regression guards, each failing only the intended test: `attempts > 1` → `attempts > 0`; removing the one-discard-per-push cap; removing the DataLayer wallet id check.
- [x] Adjacent specs (`organization-creation-status-v2`, `import-organization-singleton-precheck`, `sync-organization-meta-unsynced`) show no regressions; verified against a `v2-rc2` baseline, since these specs are order-dependent when run together and fail identically without this change.
- [x] `prettier` — `src/datalayer/persistance.js` is clean; the spec file's only deviations are pre-existing lines untouched by this change.
- [x] `eslint` — problem count unchanged from baseline (8 errors, 1 warning, all pre-existing).

## Notes for reviewers

`Key already present` is handled in a sibling branch of the same retry loop and clears pending roots unconditionally, with no wallet check and no cap. That predates this change and is left alone here to keep the diff contained, but the two branches now apply different policies to the same destructive operation and it may be worth reconciling in a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Clears pending roots is destructive if mis-timed; guards and fail-closed wallet checks limit exposure, but wrong settlement logic could drop a root that a late tx would have confirmed.
> 
> **Overview**
> Fixes stores that stay wedged after DataLayer stages a **pending root** but never creates the wallet transaction that would confirm it. The existing `pushChangeListToDataLayer` retry loop only waited for confirmations, so every later push kept failing with `Already have a pending root waiting for confirmation`.
> 
> Adds **`clearOrphanedPendingRoot`**, which calls `clear_pending_roots` only when wallet checks show no transaction can still confirm the root: DataLayer wallet id is known, `getTransactionHealth` succeeds for the standard and DataLayer wallets, and neither has in-mempool or pending txs (rejected txs do not block clearing). On RPC or id lookup failure it **fails closed** and leaves the root in place.
> 
> The pending-root branch in **`pushChangeListToDataLayer`** now tracks **sightings** (not only shared `attempts`), waits on the first sighting, and on the second may clear once per push via `clearOrphanedPendingRoot`, with an **attempt refund** so a successful clear still gets a retry. Integration tests cover grace period, unsettled wallets, unknown wallet id, and one-clear-per-push limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016b5f37a44550e52ad06bbf45a435705c0ebad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->