### PR TITLE
fix: dedupe concurrent file store creation attempts

### DIFF
--- a/src/datalayer/pending-file-store-creations.js
+++ b/src/datalayer/pending-file-store-creations.js
@@ -1,5 +1,5 @@
 /**
- * Orgs with a file store creation already running, keyed by org uid.
+ * Orgs currently minting a file store, keyed by org uid.
  *
  * Creation is detached from the request that triggers it, so without this every
  * retry of the "try again later" error would mint another store, each costing
@@ -7,6 +7,10 @@
  * because an upgraded org keeps the same file store on both sides
  * (see OrganizationsV2.upgradeFromV1), so a per-model guard would let one
  * request slip past the other.
+ *
+ * The entry covers only the mint and the write that records the new id, not the
+ * subsequent org-store push. A cleared entry therefore does not mean the store
+ * has been registered on the org store, only that no further mint is needed.
  */
 const pendingFileStoreCreations = new Set();
 

--- a/src/datalayer/pending-file-store-creations.js
+++ b/src/datalayer/pending-file-store-creations.js
@@ -1,0 +1,13 @@
+/**
+ * Orgs with a file store creation already running, keyed by org uid.
+ *
+ * Creation is detached from the request that triggers it, so without this every
+ * retry of the "try again later" error would mint another store, each costing
+ * coins and orphaning the last. Shared between the v1 and v2 file store models
+ * because an upgraded org keeps the same file store on both sides
+ * (see OrganizationsV2.upgradeFromV1), so a per-model guard would let one
+ * request slip past the other.
+ */
+const pendingFileStoreCreations = new Set();
+
+export default pendingFileStoreCreations;

--- a/src/datalayer/pending-file-store-creations.js
+++ b/src/datalayer/pending-file-store-creations.js
@@ -14,4 +14,71 @@
  */
 const pendingFileStoreCreations = new Set();
 
+/**
+ * File store ids that have been minted and recorded but not yet registered on
+ * the org store, keyed by org uid.
+ *
+ * Until that push lands the org store has no fileStoreId of its own, and v2 org
+ * reconciliation takes the org store as the source of truth and clears the
+ * recorded id (see OrganizationsV2.reconcileOrganization). The store exists and
+ * is paid for, so the creation flow consults this map before minting and
+ * re-adopts the id rather than paying for a replacement.
+ *
+ * An entry outlives a failed push so a later request can retry the org-store
+ * registration instead of minting a replacement. This protection is
+ * process-local: a restart while a push is failing leaves the recorded id as
+ * the only copy.
+ */
+const fileStoreIdsPendingOrgStorePush = new Map();
+
+const getFileStoreIdPendingOrgStorePush = (orgUid) =>
+  fileStoreIdsPendingOrgStorePush.get(orgUid)?.fileStoreId || null;
+
+const markFileStoreOrgStorePushStarted = (orgUid, fileStoreId) => {
+  fileStoreIdsPendingOrgStorePush.set(orgUid, {
+    fileStoreId,
+    pushInProgress: true,
+  });
+};
+
+const markFileStoreOrgStorePushFailed = (orgUid, fileStoreId) => {
+  const entry = fileStoreIdsPendingOrgStorePush.get(orgUid);
+  if (entry && entry.fileStoreId !== fileStoreId) {
+    return;
+  }
+
+  fileStoreIdsPendingOrgStorePush.set(orgUid, {
+    fileStoreId,
+    pushInProgress: false,
+  });
+};
+
+const claimFailedFileStoreOrgStorePush = (orgUid) => {
+  const entry = fileStoreIdsPendingOrgStorePush.get(orgUid);
+  if (!entry || entry.pushInProgress) {
+    return null;
+  }
+
+  entry.pushInProgress = true;
+  return entry.fileStoreId;
+};
+
+const clearFileStoreIdPendingOrgStorePush = (orgUid, fileStoreId = null) => {
+  const entry = fileStoreIdsPendingOrgStorePush.get(orgUid);
+  if (fileStoreId !== null && entry?.fileStoreId !== fileStoreId) {
+    return;
+  }
+
+  fileStoreIdsPendingOrgStorePush.delete(orgUid);
+};
+
+export {
+  claimFailedFileStoreOrgStorePush,
+  clearFileStoreIdPendingOrgStorePush,
+  fileStoreIdsPendingOrgStorePush,
+  getFileStoreIdPendingOrgStorePush,
+  markFileStoreOrgStorePushFailed,
+  markFileStoreOrgStorePushStarted,
+};
+
 export default pendingFileStoreCreations;

--- a/src/models/file-store/file-store.model.js
+++ b/src/models/file-store/file-store.model.js
@@ -10,10 +10,58 @@ import { sequelize } from '../../database';
 import { Organization } from '../';
 
 import datalayer from '../../datalayer';
+import pendingFileStoreCreations from '../../datalayer/pending-file-store-creations.js';
 import { encodeHex } from '../../utils/datalayer-utils';
 import { logger } from '../../config/logger.js';
 
 import ModelTypes from './file-store.modeltypes.js';
+
+/**
+ * Start file store creation for an org unless one is already running.
+ * Returns immediately; callers are expected to throw a retry-later error.
+ * @param {Object} myOrganization - Home organization row
+ */
+const startFileStoreCreation = (myOrganization) => {
+  const { orgUid } = myOrganization;
+
+  if (pendingFileStoreCreations.has(orgUid)) {
+    return;
+  }
+
+  pendingFileStoreCreations.add(orgUid);
+
+  const create = async () => {
+    await datalayer.waitForSpendableCoins(1);
+    const newFileStoreId = await datalayer.createDataLayerStoreWithRetry();
+    // Record the store before syncing. The store is already paid for on
+    // chain, so losing the id to a sync failure would mint another one on
+    // the next request; a sync can be retried against the persisted id.
+    await Organization.update(
+      { fileStoreId: newFileStoreId },
+      { where: { orgUid } },
+    );
+    try {
+      await datalayer.syncDataLayer(orgUid, { fileStoreId: newFileStoreId });
+    } catch (error) {
+      // The store id is persisted and usable by subsequent requests; only
+      // the org-store metadata push failed.
+      logger.error(
+        `File store ${newFileStoreId} for org ${orgUid} was created and recorded, ` +
+          `but registering it on the org store failed: ${error.message}`,
+      );
+    }
+  };
+
+  create()
+    .catch((error) => {
+      logger.error(
+        `Failed to create file store for org ${orgUid}: ${error.message}`,
+      );
+    })
+    .finally(() => {
+      pendingFileStoreCreations.delete(orgUid);
+    });
+};
 
 class FileStore extends Model {
   static async subscribeToFileStore(orgUid) {
@@ -68,18 +116,7 @@ class FileStore extends Model {
     const fileStoreId = myOrganization.fileStoreId;
 
     if (myOrganization && !fileStoreId) {
-      datalayer.waitForSpendableCoins(1).then(() =>
-        datalayer.createDataLayerStoreWithRetry()
-      ).then((newFileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId: newFileStoreId });
-        Organization.update(
-          { fileStoreId: newFileStoreId },
-          { where: { orgUid: myOrganization.orgUid } },
-        );
-      }).catch((error) => {
-        logger.error(`Failed to create file store: ${error.message}`);
-      });
-
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 
@@ -112,17 +149,7 @@ class FileStore extends Model {
     const fileStoreId = myOrganization?.fileStoreId;
 
     if (myOrganization && !fileStoreId) {
-      datalayer.waitForSpendableCoins(1).then(() =>
-        datalayer.createDataLayerStoreWithRetry()
-      ).then((newFileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId: newFileStoreId });
-        Organization.update(
-          { fileStoreId: newFileStoreId },
-          { where: { orgUid: myOrganization.orgUid } },
-        );
-      }).catch((error) => {
-        logger.error(`Failed to create file store: ${error.message}`);
-      });
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 
@@ -161,17 +188,7 @@ class FileStore extends Model {
     const fileStoreId = myOrganization.fileStoreId;
 
     if (!fileStoreId) {
-      datalayer.waitForSpendableCoins(1).then(() =>
-        datalayer.createDataLayerStoreWithRetry()
-      ).then((newFileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId: newFileStoreId });
-        Organization.update(
-          { fileStoreId: newFileStoreId },
-          { where: { orgUid: myOrganization.orgUid } },
-        );
-      }).catch((error) => {
-        logger.error(`Failed to create file store: ${error.message}`);
-      });
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 
@@ -190,12 +207,10 @@ class FileStore extends Model {
 
   static async getFileStoreItem(SHA256) {
     const myOrganization = await Organization.getHomeOrg();
-    let fileStoreId = myOrganization.fileStoreId;
+    const fileStoreId = myOrganization.fileStoreId;
 
     if (!fileStoreId) {
-      await datalayer.waitForSpendableCoins(1);
-      fileStoreId = await datalayer.createDataLayerStoreWithRetry();
-      datalayer.syncDataLayer(myOrganization.orgUid, { fileStoreId });
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 

--- a/src/models/file-store/file-store.model.js
+++ b/src/models/file-store/file-store.model.js
@@ -10,7 +10,13 @@ import { sequelize } from '../../database';
 import { Organization } from '../';
 
 import datalayer from '../../datalayer';
-import pendingFileStoreCreations from '../../datalayer/pending-file-store-creations.js';
+import pendingFileStoreCreations, {
+  claimFailedFileStoreOrgStorePush,
+  clearFileStoreIdPendingOrgStorePush,
+  getFileStoreIdPendingOrgStorePush,
+  markFileStoreOrgStorePushFailed,
+  markFileStoreOrgStorePushStarted,
+} from '../../datalayer/pending-file-store-creations.js';
 import { encodeHex } from '../../utils/datalayer-utils';
 import { logger } from '../../config/logger.js';
 
@@ -37,20 +43,27 @@ const findExistingFileStoreId = async (orgUid) => {
   try {
     // A static import of the v2 model from this v1 model would create a
     // circular module dependency, so resolve it lazily.
-    // eslint-disable-next-line no-restricted-syntax
-    const { default: OrganizationsV2 } = await import(
-      '../v2/organizations-v2.model.js'
-    );
+    const organizationsV2Module =
+      // eslint-disable-next-line no-restricted-syntax
+      await import('../v2/organizations-v2.model.js');
+    const { default: OrganizationsV2 } = organizationsV2Module;
     const v2Organization = await OrganizationsV2.findOne({
       where: { org_uid: orgUid },
       attributes: ['file_store_subscribed'],
       raw: true,
     });
-    return v2Organization?.file_store_subscribed || null;
+    if (v2Organization?.file_store_subscribed) {
+      return v2Organization.file_store_subscribed;
+    }
   } catch {
     // v2 tables may not exist in a v1-only deployment.
-    return null;
   }
+
+  // A store minted moments ago can be absent from both tables: v2 org
+  // reconciliation clears the id on the v2 org row consulted above for as long
+  // as the org store has no fileStoreId of its own, which lasts until the push
+  // that registers it lands.
+  return getFileStoreIdPendingOrgStorePush(orgUid);
 };
 
 /**
@@ -77,18 +90,26 @@ const startFileStoreCreation = (myOrganization) => {
         { fileStoreId: existingId },
         { where: { orgUid } },
       );
-      return null;
+      return claimFailedFileStoreOrgStorePush(orgUid);
     }
 
     await datalayer.waitForSpendableCoins(1);
     const newFileStoreId = await datalayer.createDataLayerStoreWithRetry();
+    // Recorded before the database write so the id stays reachable even if
+    // reconciliation clears the column before the push below completes.
+    markFileStoreOrgStorePushStarted(orgUid, newFileStoreId);
     // Record the store before syncing. The store is already paid for on
     // chain, so losing the id to a sync failure would mint another one on
     // the next request; subsequent requests use the persisted id.
-    await Organization.update(
-      { fileStoreId: newFileStoreId },
-      { where: { orgUid } },
-    );
+    try {
+      await Organization.update(
+        { fileStoreId: newFileStoreId },
+        { where: { orgUid } },
+      );
+    } catch (error) {
+      clearFileStoreIdPendingOrgStorePush(orgUid, newFileStoreId);
+      throw error;
+    }
     return newFileStoreId;
   };
 
@@ -115,9 +136,10 @@ const startFileStoreCreation = (myOrganization) => {
 
     try {
       await datalayer.syncDataLayer(orgUid, { fileStoreId: newFileStoreId });
+      await datalayer.waitForAllTransactionsToConfirm();
+      clearFileStoreIdPendingOrgStorePush(orgUid, newFileStoreId);
     } catch (error) {
-      // The store id is persisted and usable by subsequent requests; only
-      // the org-store metadata push failed.
+      markFileStoreOrgStorePushFailed(orgUid, newFileStoreId);
       logger.error(
         `File store ${newFileStoreId} for org ${orgUid} was created and recorded, ` +
           `but registering it on the org store failed: ${error.message}`,
@@ -170,9 +192,18 @@ class FileStore extends Model {
       );
     }
 
-    FileStore.destroy({ where: { orgUid: organization.orgUid } });
-    datalayer.unsubscribeFromDataLayerStore(organization.fileStoreId);
-    Organization.update({ fileStoreSubscribed: false });
+    const fileStoreId =
+      organization.fileStoreId || getFileStoreIdPendingOrgStorePush(orgUid);
+
+    await FileStore.destroy({ where: { orgUid: organization.orgUid } });
+    if (fileStoreId) {
+      await datalayer.unsubscribeFromDataLayerStore(fileStoreId);
+    }
+    await Organization.update(
+      { fileStoreSubscribed: false },
+      { where: { orgUid: organization.orgUid } },
+    );
+    clearFileStoreIdPendingOrgStorePush(orgUid, fileStoreId);
   }
 
   static async addFileToFileStore(SHA256, fileName, base64File) {

--- a/src/models/file-store/file-store.model.js
+++ b/src/models/file-store/file-store.model.js
@@ -67,7 +67,7 @@ const startFileStoreCreation = (myOrganization) => {
 
   pendingFileStoreCreations.add(orgUid);
 
-  const create = async () => {
+  const mintAndPersist = async () => {
     // The caller's org snapshot may predate a creation that has since
     // finished, and the v2 model may have recorded the store for an
     // upgraded org; adopt any persisted id instead of minting another.
@@ -77,7 +77,7 @@ const startFileStoreCreation = (myOrganization) => {
         { fileStoreId: existingId },
         { where: { orgUid } },
       );
-      return;
+      return null;
     }
 
     await datalayer.waitForSpendableCoins(1);
@@ -89,6 +89,30 @@ const startFileStoreCreation = (myOrganization) => {
       { fileStoreId: newFileStoreId },
       { where: { orgUid } },
     );
+    return newFileStoreId;
+  };
+
+  const run = async () => {
+    let newFileStoreId = null;
+    try {
+      newFileStoreId = await mintAndPersist();
+    } catch (error) {
+      logger.error(
+        `Failed to create file store for org ${orgUid}: ${error.message}`,
+      );
+    } finally {
+      // Released before the org-store push, which retries for up to half an
+      // hour. The guard only has to cover the mint, and the id is persisted by
+      // this point, so anything arriving later adopts it rather than minting.
+      // Holding it across the push would keep the v2 model from adopting the
+      // id for an upgraded org for that whole window.
+      pendingFileStoreCreations.delete(orgUid);
+    }
+
+    if (!newFileStoreId) {
+      return;
+    }
+
     try {
       await datalayer.syncDataLayer(orgUid, { fileStoreId: newFileStoreId });
     } catch (error) {
@@ -101,15 +125,11 @@ const startFileStoreCreation = (myOrganization) => {
     }
   };
 
-  create()
-    .catch((error) => {
-      logger.error(
-        `Failed to create file store for org ${orgUid}: ${error.message}`,
-      );
-    })
-    .finally(() => {
-      pendingFileStoreCreations.delete(orgUid);
-    });
+  run().catch((error) => {
+    logger.error(
+      `File store creation for org ${orgUid} failed unexpectedly: ${error?.message}`,
+    );
+  });
 };
 
 class FileStore extends Model {

--- a/src/models/file-store/file-store.model.js
+++ b/src/models/file-store/file-store.model.js
@@ -17,6 +17,43 @@ import { logger } from '../../config/logger.js';
 import ModelTypes from './file-store.modeltypes.js';
 
 /**
+ * Find a file store id already persisted for this org, checking this model's
+ * table first and then the v2 model's. An upgraded org keeps the same file
+ * store on both sides (see OrganizationsV2.upgradeFromV1), so an id recorded
+ * by either model means the store already exists and must not be re-minted.
+ * @param {string} orgUid
+ * @returns {Promise<string|null>}
+ */
+const findExistingFileStoreId = async (orgUid) => {
+  const organization = await Organization.findOne({
+    where: { orgUid },
+    attributes: ['fileStoreId'],
+    raw: true,
+  });
+  if (organization?.fileStoreId) {
+    return organization.fileStoreId;
+  }
+
+  try {
+    // A static import of the v2 model from this v1 model would create a
+    // circular module dependency, so resolve it lazily.
+    // eslint-disable-next-line no-restricted-syntax
+    const { default: OrganizationsV2 } = await import(
+      '../v2/organizations-v2.model.js'
+    );
+    const v2Organization = await OrganizationsV2.findOne({
+      where: { org_uid: orgUid },
+      attributes: ['file_store_subscribed'],
+      raw: true,
+    });
+    return v2Organization?.file_store_subscribed || null;
+  } catch {
+    // v2 tables may not exist in a v1-only deployment.
+    return null;
+  }
+};
+
+/**
  * Start file store creation for an org unless one is already running.
  * Returns immediately; callers are expected to throw a retry-later error.
  * @param {Object} myOrganization - Home organization row
@@ -31,11 +68,23 @@ const startFileStoreCreation = (myOrganization) => {
   pendingFileStoreCreations.add(orgUid);
 
   const create = async () => {
+    // The caller's org snapshot may predate a creation that has since
+    // finished, and the v2 model may have recorded the store for an
+    // upgraded org; adopt any persisted id instead of minting another.
+    const existingId = await findExistingFileStoreId(orgUid);
+    if (existingId) {
+      await Organization.update(
+        { fileStoreId: existingId },
+        { where: { orgUid } },
+      );
+      return;
+    }
+
     await datalayer.waitForSpendableCoins(1);
     const newFileStoreId = await datalayer.createDataLayerStoreWithRetry();
     // Record the store before syncing. The store is already paid for on
     // chain, so losing the id to a sync failure would mint another one on
-    // the next request; a sync can be retried against the persisted id.
+    // the next request; subsequent requests use the persisted id.
     await Organization.update(
       { fileStoreId: newFileStoreId },
       { where: { orgUid } },

--- a/src/models/v2/filestore-v2.model.js
+++ b/src/models/v2/filestore-v2.model.js
@@ -10,7 +10,13 @@ import { sequelizeV2 } from '../../database/v2/index.js';
 import OrganizationsV2 from './organizations-v2.model.js';
 
 import datalayer from '../../datalayer';
-import pendingFileStoreCreations from '../../datalayer/pending-file-store-creations.js';
+import pendingFileStoreCreations, {
+  claimFailedFileStoreOrgStorePush,
+  clearFileStoreIdPendingOrgStorePush,
+  getFileStoreIdPendingOrgStorePush,
+  markFileStoreOrgStorePushFailed,
+  markFileStoreOrgStorePushStarted,
+} from '../../datalayer/pending-file-store-creations.js';
 import { encodeHex } from '../../utils/datalayer-utils.js';
 import { loggerV2 } from '../../config/logger.js';
 import { getConfig } from '../../utils/config-loader.js';
@@ -55,19 +61,24 @@ const findExistingFileStoreId = async (orgUid) => {
   }
 
   try {
-    const { Organization } = await import(
-      '../organizations/organizations.model.js'
-    );
+    const { Organization } =
+      await import('../organizations/organizations.model.js');
     const v1Organization = await Organization.findOne({
       where: { orgUid },
       attributes: ['fileStoreId'],
       raw: true,
     });
-    return v1Organization?.fileStoreId || null;
+    if (v1Organization?.fileStoreId) {
+      return v1Organization.fileStoreId;
+    }
   } catch {
     // v1 tables may not be populated in a v2-only deployment.
-    return null;
   }
+
+  // A store minted moments ago can be absent from both tables: reconciliation
+  // clears the recorded id for as long as the org store has no fileStoreId of
+  // its own, which lasts until the push that registers it lands.
+  return getFileStoreIdPendingOrgStorePush(orgUid);
 };
 
 /**
@@ -94,18 +105,26 @@ const startFileStoreCreation = (myOrganization) => {
         { file_store_subscribed: existingId },
         { where: { org_uid: orgUid } },
       );
-      return null;
+      return claimFailedFileStoreOrgStorePush(orgUid);
     }
 
     await datalayer.waitForSpendableCoins(1);
     const newFileStoreId = await datalayer.createDataLayerStoreWithRetry();
+    // Recorded before the database write so the id stays reachable even if
+    // reconciliation clears the column before the push below completes.
+    markFileStoreOrgStorePushStarted(orgUid, newFileStoreId);
     // Record the store before syncing. The store is already paid for on
     // chain, so losing the id to a sync failure would mint another one on
     // the next request; subsequent requests use the persisted id.
-    await OrganizationsV2.update(
-      { file_store_subscribed: newFileStoreId },
-      { where: { org_uid: orgUid } },
-    );
+    try {
+      await OrganizationsV2.update(
+        { file_store_subscribed: newFileStoreId },
+        { where: { org_uid: orgUid } },
+      );
+    } catch (error) {
+      clearFileStoreIdPendingOrgStorePush(orgUid, newFileStoreId);
+      throw error;
+    }
     return newFileStoreId;
   };
 
@@ -132,9 +151,10 @@ const startFileStoreCreation = (myOrganization) => {
 
     try {
       await datalayer.syncDataLayer(orgUid, { fileStoreId: newFileStoreId });
+      await datalayer.waitForAllTransactionsToConfirm();
+      clearFileStoreIdPendingOrgStorePush(orgUid, newFileStoreId);
     } catch (error) {
-      // The store id is persisted and usable by subsequent requests; only
-      // the org-store metadata push failed.
+      markFileStoreOrgStorePushFailed(orgUid, newFileStoreId);
       loggerV2.error(
         `[v2]: File store ${newFileStoreId} for org ${orgUid} was created and recorded, ` +
           `but registering it on the org store failed: ${error.message}`,
@@ -152,31 +172,36 @@ const startFileStoreCreation = (myOrganization) => {
 class FilestoreV2 extends Model {
   static async create(values, options) {
     const result = await super.create(values, options);
-    if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
+    if (process.env.USE_SIMULATOR !== 'true')
+      await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async bulkCreate(values, options) {
     const result = await super.bulkCreate(values, options);
-    if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
+    if (process.env.USE_SIMULATOR !== 'true')
+      await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async update(values, options) {
     const result = await super.update(values, options);
-    if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
+    if (process.env.USE_SIMULATOR !== 'true')
+      await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async upsert(values, options) {
     const result = await super.upsert(values, options);
-    if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
+    if (process.env.USE_SIMULATOR !== 'true')
+      await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
   static async destroy(options) {
     const result = await super.destroy(options);
-    if (process.env.USE_SIMULATOR !== 'true') await new Promise((resolve) => setTimeout(resolve, 50));
+    if (process.env.USE_SIMULATOR !== 'true')
+      await new Promise((resolve) => setTimeout(resolve, 50));
     return result;
   }
 
@@ -223,7 +248,9 @@ class FilestoreV2 extends Model {
       );
     }
 
-    const fileStoreId = organization.file_store_subscribed;
+    const fileStoreId =
+      organization.file_store_subscribed ||
+      getFileStoreIdPendingOrgStorePush(orgUid);
 
     if (fileStoreId) {
       // Delete cached files for this organization
@@ -235,6 +262,7 @@ class FilestoreV2 extends Model {
         { file_store_subscribed: null },
         { where: { org_uid: orgUid } },
       );
+      clearFileStoreIdPendingOrgStorePush(orgUid, fileStoreId);
     }
   }
 
@@ -333,7 +361,9 @@ class FilestoreV2 extends Model {
           );
         })
         .catch((error) => {
-          loggerV2.warn('[v2]: Failed to sync file store data', { error: error.message });
+          loggerV2.warn('[v2]: Failed to sync file store data', {
+            error: error.message,
+          });
         });
     }
 
@@ -455,4 +485,3 @@ FilestoreV2.init(ModelTypes, {
 });
 
 export default FilestoreV2;
-

--- a/src/models/v2/filestore-v2.model.js
+++ b/src/models/v2/filestore-v2.model.js
@@ -10,6 +10,7 @@ import { sequelizeV2 } from '../../database/v2/index.js';
 import OrganizationsV2 from './organizations-v2.model.js';
 
 import datalayer from '../../datalayer';
+import pendingFileStoreCreations from '../../datalayer/pending-file-store-creations.js';
 import { encodeHex } from '../../utils/datalayer-utils.js';
 import { loggerV2 } from '../../config/logger.js';
 import { getConfig } from '../../utils/config-loader.js';
@@ -34,6 +35,53 @@ const getStoreDataPromise = async (storeId) => {
 };
 
 import ModelTypes from './filestore-v2.modeltypes.js';
+
+/**
+ * Start file store creation for an org unless one is already running.
+ * Returns immediately; callers are expected to throw a retry-later error.
+ * @param {Object} myOrganization - Home organization row
+ */
+const startFileStoreCreation = (myOrganization) => {
+  const orgUid = myOrganization.org_uid;
+
+  if (pendingFileStoreCreations.has(orgUid)) {
+    return;
+  }
+
+  pendingFileStoreCreations.add(orgUid);
+
+  const create = async () => {
+    await datalayer.waitForSpendableCoins(1);
+    const newFileStoreId = await datalayer.createDataLayerStoreWithRetry();
+    // Record the store before syncing. The store is already paid for on
+    // chain, so losing the id to a sync failure would mint another one on
+    // the next request; a sync can be retried against the persisted id.
+    await OrganizationsV2.update(
+      { file_store_subscribed: newFileStoreId },
+      { where: { org_uid: orgUid } },
+    );
+    try {
+      await datalayer.syncDataLayer(orgUid, { fileStoreId: newFileStoreId });
+    } catch (error) {
+      // The store id is persisted and usable by subsequent requests; only
+      // the org-store metadata push failed.
+      loggerV2.error(
+        `[v2]: File store ${newFileStoreId} for org ${orgUid} was created and recorded, ` +
+          `but registering it on the org store failed: ${error.message}`,
+      );
+    }
+  };
+
+  create()
+    .catch((error) => {
+      loggerV2.error(
+        `[v2]: Failed to create file store for org ${orgUid}: ${error.message}`,
+      );
+    })
+    .finally(() => {
+      pendingFileStoreCreations.delete(orgUid);
+    });
+};
 
 class FilestoreV2 extends Model {
   static async create(values, options) {
@@ -141,18 +189,7 @@ class FilestoreV2 extends Model {
     const fileStoreId = myOrganization.file_store_subscribed;
 
     if (myOrganization && !fileStoreId) {
-      datalayer.waitForSpendableCoins(1).then(() =>
-        datalayer.createDataLayerStoreWithRetry()
-      ).then((newFileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId: newFileStoreId });
-        OrganizationsV2.update(
-          { file_store_subscribed: newFileStoreId },
-          { where: { org_uid: myOrganization.org_uid } },
-        );
-      }).catch((error) => {
-        loggerV2.error(`[v2]: Failed to create file store: ${error.message}`);
-      });
-
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 
@@ -198,17 +235,7 @@ class FilestoreV2 extends Model {
     const fileStoreId = myOrganization.file_store_subscribed;
 
     if (!fileStoreId) {
-      datalayer.waitForSpendableCoins(1).then(() =>
-        datalayer.createDataLayerStoreWithRetry()
-      ).then((newFileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId: newFileStoreId });
-        OrganizationsV2.update(
-          { file_store_subscribed: newFileStoreId },
-          { where: { org_uid: myOrganization.org_uid } },
-        );
-      }).catch((error) => {
-        loggerV2.error(`[v2]: Failed to create file store: ${error.message}`);
-      });
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 
@@ -266,17 +293,7 @@ class FilestoreV2 extends Model {
     const fileStoreId = myOrganization.file_store_subscribed;
 
     if (!fileStoreId) {
-      datalayer.waitForSpendableCoins(1).then(() =>
-        datalayer.createDataLayerStoreWithRetry()
-      ).then((newFileStoreId) => {
-        datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId: newFileStoreId });
-        OrganizationsV2.update(
-          { file_store_subscribed: newFileStoreId },
-          { where: { org_uid: myOrganization.org_uid } },
-        );
-      }).catch((error) => {
-        loggerV2.error(`[v2]: Failed to create file store: ${error.message}`);
-      });
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 
@@ -308,16 +325,10 @@ class FilestoreV2 extends Model {
       throw new Error('No home org detected');
     }
 
-    let fileStoreId = myOrganization.file_store_subscribed;
+    const fileStoreId = myOrganization.file_store_subscribed;
 
     if (!fileStoreId) {
-      await datalayer.waitForSpendableCoins(1);
-      fileStoreId = await datalayer.createDataLayerStoreWithRetry();
-      datalayer.syncDataLayer(myOrganization.org_uid, { fileStoreId });
-      await OrganizationsV2.update(
-        { file_store_subscribed: fileStoreId },
-        { where: { org_uid: myOrganization.org_uid } },
-      );
+      startFileStoreCreation(myOrganization);
       throw new Error('New File store being created, please try again later.');
     }
 

--- a/src/models/v2/filestore-v2.model.js
+++ b/src/models/v2/filestore-v2.model.js
@@ -37,6 +37,40 @@ const getStoreDataPromise = async (storeId) => {
 import ModelTypes from './filestore-v2.modeltypes.js';
 
 /**
+ * Find a file store id already persisted for this org, checking this model's
+ * table first and then the v1 model's. An upgraded org keeps the same file
+ * store on both sides (see OrganizationsV2.upgradeFromV1), so an id recorded
+ * by either model means the store already exists and must not be re-minted.
+ * @param {string} orgUid
+ * @returns {Promise<string|null>}
+ */
+const findExistingFileStoreId = async (orgUid) => {
+  const organization = await OrganizationsV2.findOne({
+    where: { org_uid: orgUid },
+    attributes: ['file_store_subscribed'],
+    raw: true,
+  });
+  if (organization?.file_store_subscribed) {
+    return organization.file_store_subscribed;
+  }
+
+  try {
+    const { Organization } = await import(
+      '../organizations/organizations.model.js'
+    );
+    const v1Organization = await Organization.findOne({
+      where: { orgUid },
+      attributes: ['fileStoreId'],
+      raw: true,
+    });
+    return v1Organization?.fileStoreId || null;
+  } catch {
+    // v1 tables may not be populated in a v2-only deployment.
+    return null;
+  }
+};
+
+/**
  * Start file store creation for an org unless one is already running.
  * Returns immediately; callers are expected to throw a retry-later error.
  * @param {Object} myOrganization - Home organization row
@@ -51,11 +85,23 @@ const startFileStoreCreation = (myOrganization) => {
   pendingFileStoreCreations.add(orgUid);
 
   const create = async () => {
+    // The caller's org snapshot may predate a creation that has since
+    // finished, and the v1 model may have recorded the store for an
+    // upgraded org; adopt any persisted id instead of minting another.
+    const existingId = await findExistingFileStoreId(orgUid);
+    if (existingId) {
+      await OrganizationsV2.update(
+        { file_store_subscribed: existingId },
+        { where: { org_uid: orgUid } },
+      );
+      return;
+    }
+
     await datalayer.waitForSpendableCoins(1);
     const newFileStoreId = await datalayer.createDataLayerStoreWithRetry();
     // Record the store before syncing. The store is already paid for on
     // chain, so losing the id to a sync failure would mint another one on
-    // the next request; a sync can be retried against the persisted id.
+    // the next request; subsequent requests use the persisted id.
     await OrganizationsV2.update(
       { file_store_subscribed: newFileStoreId },
       { where: { org_uid: orgUid } },

--- a/src/models/v2/filestore-v2.model.js
+++ b/src/models/v2/filestore-v2.model.js
@@ -84,7 +84,7 @@ const startFileStoreCreation = (myOrganization) => {
 
   pendingFileStoreCreations.add(orgUid);
 
-  const create = async () => {
+  const mintAndPersist = async () => {
     // The caller's org snapshot may predate a creation that has since
     // finished, and the v1 model may have recorded the store for an
     // upgraded org; adopt any persisted id instead of minting another.
@@ -94,7 +94,7 @@ const startFileStoreCreation = (myOrganization) => {
         { file_store_subscribed: existingId },
         { where: { org_uid: orgUid } },
       );
-      return;
+      return null;
     }
 
     await datalayer.waitForSpendableCoins(1);
@@ -106,6 +106,30 @@ const startFileStoreCreation = (myOrganization) => {
       { file_store_subscribed: newFileStoreId },
       { where: { org_uid: orgUid } },
     );
+    return newFileStoreId;
+  };
+
+  const run = async () => {
+    let newFileStoreId = null;
+    try {
+      newFileStoreId = await mintAndPersist();
+    } catch (error) {
+      loggerV2.error(
+        `[v2]: Failed to create file store for org ${orgUid}: ${error.message}`,
+      );
+    } finally {
+      // Released before the org-store push, which retries for up to half an
+      // hour. The guard only has to cover the mint, and the id is persisted by
+      // this point, so anything arriving later adopts it rather than minting.
+      // Holding it across the push would keep the v1 model from adopting the
+      // id for an upgraded org for that whole window.
+      pendingFileStoreCreations.delete(orgUid);
+    }
+
+    if (!newFileStoreId) {
+      return;
+    }
+
     try {
       await datalayer.syncDataLayer(orgUid, { fileStoreId: newFileStoreId });
     } catch (error) {
@@ -118,15 +142,11 @@ const startFileStoreCreation = (myOrganization) => {
     }
   };
 
-  create()
-    .catch((error) => {
-      loggerV2.error(
-        `[v2]: Failed to create file store for org ${orgUid}: ${error.message}`,
-      );
-    })
-    .finally(() => {
-      pendingFileStoreCreations.delete(orgUid);
-    });
+  run().catch((error) => {
+    loggerV2.error(
+      `[v2]: File store creation for org ${orgUid} failed unexpectedly: ${error?.message}`,
+    );
+  });
 };
 
 class FilestoreV2 extends Model {

--- a/tests/v2/integration/file-store-creation-dedupe.spec.js
+++ b/tests/v2/integration/file-store-creation-dedupe.spec.js
@@ -1,0 +1,267 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { prepareV2Db } from '../../../src/database/v2/index.js';
+import { FilestoreV2, OrganizationsV2 } from '../../../src/models/v2/index.js';
+import { FileStore } from '../../../src/models/file-store/index.js';
+import { Organization } from '../../../src/models/organizations/index.js';
+import datalayer from '../../../src/datalayer/index.js';
+import pendingFileStoreCreations from '../../../src/datalayer/pending-file-store-creations.js';
+import { createV2TestHomeOrg } from '../utils/v2-test-helpers.js';
+
+const RETRY_LATER_MESSAGE =
+  'New File store being created, please try again later.';
+
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const waitFor = async (condition, timeoutMs = 5000) => {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('Timed out waiting for condition');
+    }
+    await new Promise((res) => setTimeout(res, 10));
+  }
+};
+
+const expectRetryLater = async (invoke) => {
+  try {
+    await invoke();
+    expect.fail('Should have thrown the retry-later error');
+  } catch (error) {
+    expect(error.message).to.equal(RETRY_LATER_MESSAGE);
+  }
+};
+
+describe('File store creation dedup', function () {
+  this.timeout(30000);
+
+  let sandbox;
+  let testOrgUid;
+
+  before(async function () {
+    await prepareV2Db();
+    await FilestoreV2.destroy({ where: {} });
+    const homeOrg = await createV2TestHomeOrg();
+    testOrgUid = homeOrg.org_uid;
+  });
+
+  beforeEach(async function () {
+    sandbox = sinon.createSandbox();
+    pendingFileStoreCreations.clear();
+    await OrganizationsV2.update(
+      { file_store_subscribed: null },
+      { where: { org_uid: testOrgUid } },
+    );
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    pendingFileStoreCreations.clear();
+  });
+
+  describe('v2 model', function () {
+    it('mints at most one store for concurrent callers, each of which gets the retry-later error', async function () {
+      const coinGate = deferred();
+      const waitForSpendableCoins = sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .returns(coinGate.promise);
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('new-store-id');
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .resolves();
+
+      await expectRetryLater(() =>
+        FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA=='),
+      );
+      await expectRetryLater(() =>
+        FilestoreV2.addFileToFileStore('sha-2', 'b.txt', 'dGVzdA=='),
+      );
+      await expectRetryLater(() => FilestoreV2.getFileStoreList());
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await expectRetryLater(() => FilestoreV2.deleteFileStoreItem('sha-1'));
+
+      expect(pendingFileStoreCreations.has(testOrgUid)).to.equal(true);
+      expect(waitForSpendableCoins.callCount).to.equal(1);
+
+      coinGate.resolve({ success: true, coinCount: 1 });
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(createStore.callCount).to.equal(1);
+      expect(syncDataLayer.callCount).to.equal(1);
+      expect(
+        syncDataLayer.calledWithExactly(testOrgUid, {
+          fileStoreId: 'new-store-id',
+        }),
+      ).to.equal(true);
+
+      const org = await OrganizationsV2.findOne({
+        where: { org_uid: testOrgUid },
+        raw: true,
+      });
+      expect(org.file_store_subscribed).to.equal('new-store-id');
+    });
+
+    it('persists the store id before syncing, so a sync failure does not cause a second mint', async function () {
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('store-abc');
+      const syncDataLayer = sandbox.stub(datalayer, 'syncDataLayer');
+      syncDataLayer.onFirstCall().rejects(new Error('push failed'));
+      syncDataLayer.resolves();
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      const org = await OrganizationsV2.findOne({
+        where: { org_uid: testOrgUid },
+        raw: true,
+      });
+      expect(org.file_store_subscribed).to.equal('store-abc');
+
+      // The persisted id must be used as-is; no new store may be created.
+      await FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA==');
+      expect(createStore.callCount).to.equal(1);
+    });
+
+    it('clears the pending entry after a failed creation so a later request can retry', async function () {
+      const waitForSpendableCoins = sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .rejects(new Error('Timeout waiting for coins'));
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('retry-store-id');
+      sandbox.stub(datalayer, 'syncDataLayer').resolves();
+
+      await expectRetryLater(() =>
+        FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA=='),
+      );
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(createStore.callCount).to.equal(0);
+      let org = await OrganizationsV2.findOne({
+        where: { org_uid: testOrgUid },
+        raw: true,
+      });
+      expect(org.file_store_subscribed).to.equal(null);
+
+      waitForSpendableCoins.resolves({ success: true, coinCount: 1 });
+
+      await expectRetryLater(() =>
+        FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA=='),
+      );
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(createStore.callCount).to.equal(1);
+      org = await OrganizationsV2.findOne({
+        where: { org_uid: testOrgUid },
+        raw: true,
+      });
+      expect(org.file_store_subscribed).to.equal('retry-store-id');
+    });
+
+    it('does not start a creation when another holder already has the org pending', async function () {
+      const waitForSpendableCoins = sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('should-not-exist');
+      sandbox.stub(datalayer, 'syncDataLayer').resolves();
+
+      pendingFileStoreCreations.add(testOrgUid);
+
+      await expectRetryLater(() =>
+        FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA=='),
+      );
+      await new Promise((res) => setTimeout(res, 50));
+
+      expect(waitForSpendableCoins.callCount).to.equal(0);
+      expect(createStore.callCount).to.equal(0);
+      expect(pendingFileStoreCreations.has(testOrgUid)).to.equal(true);
+    });
+  });
+
+  describe('v1 model', function () {
+    const v1OrgUid = 'v1-test-org-uid';
+
+    it('dedupes concurrent callers through the same pending set and persists before syncing', async function () {
+      sandbox
+        .stub(Organization, 'getHomeOrg')
+        .resolves({ orgUid: v1OrgUid, fileStoreId: null });
+      const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
+
+      const coinGate = deferred();
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .returns(coinGate.promise);
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('v1-store-id');
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .resolves();
+
+      await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+      await expectRetryLater(() =>
+        FileStore.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA=='),
+      );
+      await expectRetryLater(() => FileStore.getFileStoreList());
+      await expectRetryLater(() => FileStore.deleteFileStoreItem('sha-1'));
+
+      // Same set instance the v2 model consults, so an upgraded org cannot
+      // start one creation per model.
+      expect(pendingFileStoreCreations.has(v1OrgUid)).to.equal(true);
+
+      coinGate.resolve({ success: true, coinCount: 1 });
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(createStore.callCount).to.equal(1);
+      expect(
+        orgUpdate.calledWithExactly(
+          { fileStoreId: 'v1-store-id' },
+          { where: { orgUid: v1OrgUid } },
+        ),
+      ).to.equal(true);
+      expect(orgUpdate.calledBefore(syncDataLayer)).to.equal(true);
+      expect(
+        syncDataLayer.calledWithExactly(v1OrgUid, {
+          fileStoreId: 'v1-store-id',
+        }),
+      ).to.equal(true);
+    });
+
+    it('logs a creation failure and clears the pending entry', async function () {
+      sandbox
+        .stub(Organization, 'getHomeOrg')
+        .resolves({ orgUid: v1OrgUid, fileStoreId: null });
+      const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
+
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .rejects(new Error('store creation rejected'));
+      sandbox.stub(datalayer, 'syncDataLayer').resolves();
+
+      await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(orgUpdate.callCount).to.equal(0);
+      expect(pendingFileStoreCreations.has(v1OrgUid)).to.equal(false);
+    });
+  });
+});

--- a/tests/v2/integration/file-store-creation-dedupe.spec.js
+++ b/tests/v2/integration/file-store-creation-dedupe.spec.js
@@ -95,9 +95,9 @@ describe('File store creation dedup', function () {
 
       coinGate.resolve({ success: true, coinCount: 1 });
       await waitFor(() => pendingFileStoreCreations.size === 0);
+      await waitFor(() => syncDataLayer.callCount === 1);
 
       expect(createStore.callCount).to.equal(1);
-      expect(syncDataLayer.callCount).to.equal(1);
       expect(
         syncDataLayer.calledWithExactly(testOrgUid, {
           fileStoreId: 'new-store-id',
@@ -134,6 +134,55 @@ describe('File store creation dedup', function () {
       // The persisted id must be used as-is; no new store may be created.
       await FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA==');
       expect(createStore.callCount).to.equal(1);
+    });
+
+    it('releases the pending guard once the id is persisted, so the v1 model can adopt it while the org-store push is still running', async function () {
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('slow-sync-store');
+      const syncGate = deferred();
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .returns(syncGate.promise);
+
+      try {
+        await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+        await waitFor(() => syncDataLayer.callCount === 1);
+
+        // The push is still in flight, but the store is minted and recorded,
+        // so the guard has done its job and must no longer be held.
+        expect(pendingFileStoreCreations.has(testOrgUid)).to.equal(false);
+        const v2Org = await OrganizationsV2.findOne({
+          where: { org_uid: testOrgUid },
+          raw: true,
+        });
+        expect(v2Org.file_store_subscribed).to.equal('slow-sync-store');
+
+        // The v1 side of the same upgraded org adopts that id rather than
+        // waiting out the push or minting a second store.
+        sandbox
+          .stub(Organization, 'getHomeOrg')
+          .resolves({ orgUid: testOrgUid, fileStoreId: null });
+        sandbox.stub(Organization, 'findOne').resolves(null);
+        const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
+
+        await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+        await waitFor(() => pendingFileStoreCreations.size === 0);
+
+        expect(createStore.callCount).to.equal(1);
+        expect(syncDataLayer.callCount).to.equal(1);
+        expect(
+          orgUpdate.calledWithExactly(
+            { fileStoreId: 'slow-sync-store' },
+            { where: { orgUid: testOrgUid } },
+          ),
+        ).to.equal(true);
+      } finally {
+        syncGate.resolve();
+      }
     });
 
     it('clears the pending entry after a failed creation so a later request can retry', async function () {
@@ -286,6 +335,7 @@ describe('File store creation dedup', function () {
 
       coinGate.resolve({ success: true, coinCount: 1 });
       await waitFor(() => pendingFileStoreCreations.size === 0);
+      await waitFor(() => syncDataLayer.callCount === 1);
 
       expect(createStore.callCount).to.equal(1);
       expect(
@@ -300,6 +350,51 @@ describe('File store creation dedup', function () {
           fileStoreId: 'v1-store-id',
         }),
       ).to.equal(true);
+    });
+
+    it('releases the pending guard once the id is persisted, so a later caller adopts it while the org-store push is still running', async function () {
+      sandbox
+        .stub(Organization, 'getHomeOrg')
+        .resolves({ orgUid: v1OrgUid, fileStoreId: null });
+      const orgFindOne = sandbox.stub(Organization, 'findOne').resolves(null);
+      const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
+
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('v1-slow-sync-store');
+      const syncGate = deferred();
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .returns(syncGate.promise);
+
+      try {
+        await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+        await waitFor(() => syncDataLayer.callCount === 1);
+
+        // The push is still in flight, but the store is minted and recorded,
+        // so the guard has done its job and must no longer be held.
+        expect(pendingFileStoreCreations.has(v1OrgUid)).to.equal(false);
+        expect(
+          orgUpdate.calledWithExactly(
+            { fileStoreId: 'v1-slow-sync-store' },
+            { where: { orgUid: v1OrgUid } },
+          ),
+        ).to.equal(true);
+
+        // A request arriving during the push adopts the persisted id instead
+        // of minting a second store.
+        orgFindOne.resolves({ fileStoreId: 'v1-slow-sync-store' });
+        await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+        await waitFor(() => orgUpdate.callCount === 2);
+
+        expect(createStore.callCount).to.equal(1);
+        expect(syncDataLayer.callCount).to.equal(1);
+      } finally {
+        syncGate.resolve();
+      }
     });
 
     it('adopts a store id recorded by the v2 model for an upgraded org', async function () {

--- a/tests/v2/integration/file-store-creation-dedupe.spec.js
+++ b/tests/v2/integration/file-store-creation-dedupe.spec.js
@@ -91,7 +91,7 @@ describe('File store creation dedup', function () {
       await expectRetryLater(() => FilestoreV2.deleteFileStoreItem('sha-1'));
 
       expect(pendingFileStoreCreations.has(testOrgUid)).to.equal(true);
-      expect(waitForSpendableCoins.callCount).to.equal(1);
+      await waitFor(() => waitForSpendableCoins.callCount === 1);
 
       coinGate.resolve({ success: true, coinCount: 1 });
       await waitFor(() => pendingFileStoreCreations.size === 0);
@@ -172,6 +172,64 @@ describe('File store creation dedup', function () {
       expect(org.file_store_subscribed).to.equal('retry-store-id');
     });
 
+    it('adopts an id persisted after the caller read its org snapshot instead of minting another store', async function () {
+      // Simulate a caller holding a pre-creation snapshot while the id has
+      // already landed in the database.
+      await OrganizationsV2.update(
+        { file_store_subscribed: 'already-persisted-id' },
+        { where: { org_uid: testOrgUid } },
+      );
+      sandbox.stub(OrganizationsV2, 'getHomeOrg').resolves({
+        org_uid: testOrgUid,
+        file_store_subscribed: null,
+      });
+
+      const waitForSpendableCoins = sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('should-not-exist');
+      sandbox.stub(datalayer, 'syncDataLayer').resolves();
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(waitForSpendableCoins.callCount).to.equal(0);
+      expect(createStore.callCount).to.equal(0);
+      const org = await OrganizationsV2.findOne({
+        where: { org_uid: testOrgUid },
+        raw: true,
+      });
+      expect(org.file_store_subscribed).to.equal('already-persisted-id');
+    });
+
+    it('adopts a store id recorded by the v1 model for an upgraded org', async function () {
+      sandbox
+        .stub(Organization, 'findOne')
+        .resolves({ fileStoreId: 'v1-created-store' });
+
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('should-not-exist');
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      sandbox.stub(datalayer, 'syncDataLayer').resolves();
+
+      await expectRetryLater(() =>
+        FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA=='),
+      );
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(createStore.callCount).to.equal(0);
+      const org = await OrganizationsV2.findOne({
+        where: { org_uid: testOrgUid },
+        raw: true,
+      });
+      expect(org.file_store_subscribed).to.equal('v1-created-store');
+    });
+
     it('does not start a creation when another holder already has the org pending', async function () {
       const waitForSpendableCoins = sandbox
         .stub(datalayer, 'waitForSpendableCoins')
@@ -201,6 +259,7 @@ describe('File store creation dedup', function () {
       sandbox
         .stub(Organization, 'getHomeOrg')
         .resolves({ orgUid: v1OrgUid, fileStoreId: null });
+      sandbox.stub(Organization, 'findOne').resolves(null);
       const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
 
       const coinGate = deferred();
@@ -243,10 +302,43 @@ describe('File store creation dedup', function () {
       ).to.equal(true);
     });
 
+    it('adopts a store id recorded by the v2 model for an upgraded org', async function () {
+      sandbox
+        .stub(Organization, 'getHomeOrg')
+        .resolves({ orgUid: testOrgUid, fileStoreId: null });
+      sandbox.stub(Organization, 'findOne').resolves(null);
+      const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
+
+      await OrganizationsV2.update(
+        { file_store_subscribed: 'v2-created-store' },
+        { where: { org_uid: testOrgUid } },
+      );
+
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('should-not-exist');
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      sandbox.stub(datalayer, 'syncDataLayer').resolves();
+
+      await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+      await waitFor(() => pendingFileStoreCreations.size === 0);
+
+      expect(createStore.callCount).to.equal(0);
+      expect(
+        orgUpdate.calledWithExactly(
+          { fileStoreId: 'v2-created-store' },
+          { where: { orgUid: testOrgUid } },
+        ),
+      ).to.equal(true);
+    });
+
     it('logs a creation failure and clears the pending entry', async function () {
       sandbox
         .stub(Organization, 'getHomeOrg')
         .resolves({ orgUid: v1OrgUid, fileStoreId: null });
+      sandbox.stub(Organization, 'findOne').resolves(null);
       const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
 
       sandbox

--- a/tests/v2/integration/file-store-creation-dedupe.spec.js
+++ b/tests/v2/integration/file-store-creation-dedupe.spec.js
@@ -5,7 +5,9 @@ import { FilestoreV2, OrganizationsV2 } from '../../../src/models/v2/index.js';
 import { FileStore } from '../../../src/models/file-store/index.js';
 import { Organization } from '../../../src/models/organizations/index.js';
 import datalayer from '../../../src/datalayer/index.js';
-import pendingFileStoreCreations from '../../../src/datalayer/pending-file-store-creations.js';
+import pendingFileStoreCreations, {
+  fileStoreIdsPendingOrgStorePush,
+} from '../../../src/datalayer/pending-file-store-creations.js';
 import { createV2TestHomeOrg } from '../utils/v2-test-helpers.js';
 
 const RETRY_LATER_MESSAGE =
@@ -23,7 +25,7 @@ const deferred = () => {
 
 const waitFor = async (condition, timeoutMs = 5000) => {
   const start = Date.now();
-  while (!condition()) {
+  while (!(await condition())) {
     if (Date.now() - start > timeoutMs) {
       throw new Error('Timed out waiting for condition');
     }
@@ -56,6 +58,7 @@ describe('File store creation dedup', function () {
   beforeEach(async function () {
     sandbox = sinon.createSandbox();
     pendingFileStoreCreations.clear();
+    fileStoreIdsPendingOrgStorePush.clear();
     await OrganizationsV2.update(
       { file_store_subscribed: null },
       { where: { org_uid: testOrgUid } },
@@ -65,6 +68,7 @@ describe('File store creation dedup', function () {
   afterEach(function () {
     sandbox.restore();
     pendingFileStoreCreations.clear();
+    fileStoreIdsPendingOrgStorePush.clear();
   });
 
   describe('v2 model', function () {
@@ -76,9 +80,7 @@ describe('File store creation dedup', function () {
       const createStore = sandbox
         .stub(datalayer, 'createDataLayerStoreWithRetry')
         .resolves('new-store-id');
-      const syncDataLayer = sandbox
-        .stub(datalayer, 'syncDataLayer')
-        .resolves();
+      const syncDataLayer = sandbox.stub(datalayer, 'syncDataLayer').resolves();
 
       await expectRetryLater(() =>
         FilestoreV2.addFileToFileStore('sha-1', 'a.txt', 'dGVzdA=='),
@@ -182,6 +184,203 @@ describe('File store creation dedup', function () {
         ).to.equal(true);
       } finally {
         syncGate.resolve();
+      }
+    });
+
+    it('re-adopts the in-flight id when reconciliation clears the recorded id mid-push', async function () {
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('race-store-id');
+      const syncGate = deferred();
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .returns(syncGate.promise);
+
+      try {
+        await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+        await waitFor(() => syncDataLayer.callCount === 1);
+
+        // Reconciliation takes the org store as the source of truth, and the
+        // org store has no fileStoreId until the push above lands.
+        await OrganizationsV2.update(
+          { file_store_subscribed: null },
+          { where: { org_uid: testOrgUid } },
+        );
+
+        await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+        await waitFor(async () => {
+          const org = await OrganizationsV2.findOne({
+            where: { org_uid: testOrgUid },
+            raw: true,
+          });
+          return org?.file_store_subscribed === 'race-store-id';
+        });
+
+        // The store was already paid for, so it must be re-adopted rather
+        // than replaced.
+        expect(createStore.callCount).to.equal(1);
+        expect(syncDataLayer.callCount).to.equal(1);
+      } finally {
+        syncGate.resolve();
+      }
+    });
+
+    it('keeps the in-flight id when the org-store push fails, so the paid-for store is not replaced', async function () {
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('push-failed-store');
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .rejects(new Error('push failed'));
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(() => syncDataLayer.callCount === 1);
+
+      // A failed push means the org store never receives the id, so
+      // reconciliation keeps clearing the recorded one.
+      await OrganizationsV2.update(
+        { file_store_subscribed: null },
+        { where: { org_uid: testOrgUid } },
+      );
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(async () => {
+        const org = await OrganizationsV2.findOne({
+          where: { org_uid: testOrgUid },
+          raw: true,
+        });
+        return org?.file_store_subscribed === 'push-failed-store';
+      });
+
+      expect(createStore.callCount).to.equal(1);
+    });
+
+    it('retries a failed org-store push after re-adopting the paid-for store id', async function () {
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('retry-push-store');
+      const syncDataLayer = sandbox.stub(datalayer, 'syncDataLayer');
+      syncDataLayer.onFirstCall().rejects(new Error('push failed'));
+      syncDataLayer.resolves();
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(() => syncDataLayer.callCount === 1);
+
+      await OrganizationsV2.update(
+        { file_store_subscribed: null },
+        { where: { org_uid: testOrgUid } },
+      );
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(() => syncDataLayer.callCount === 2);
+
+      expect(createStore.callCount).to.equal(1);
+      expect(
+        syncDataLayer.alwaysCalledWithExactly(testOrgUid, {
+          fileStoreId: 'retry-push-store',
+        }),
+      ).to.equal(true);
+      expect(fileStoreIdsPendingOrgStorePush.has(testOrgUid)).to.equal(false);
+    });
+
+    it('drops the in-flight id on unsubscribe so it cannot be re-adopted', async function () {
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox.stub(
+        datalayer,
+        'createDataLayerStoreWithRetry',
+      );
+      createStore.onFirstCall().resolves('unsubscribed-store');
+      createStore.onSecondCall().resolves('replacement-store');
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .rejects(new Error('push failed'));
+      sandbox.stub(datalayer, 'unsubscribeFromDataLayerStore').resolves();
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(() => syncDataLayer.callCount === 1);
+
+      await FilestoreV2.unsubscribeFromFileStore(testOrgUid);
+
+      await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+      await waitFor(async () => {
+        const org = await OrganizationsV2.findOne({
+          where: { org_uid: testOrgUid },
+          raw: true,
+        });
+        return org?.file_store_subscribed === 'replacement-store';
+      });
+
+      expect(createStore.callCount).to.equal(2);
+    });
+
+    it('drops the in-flight id on unsubscribe after reconciliation clears the recorded id', async function () {
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox.stub(
+        datalayer,
+        'createDataLayerStoreWithRetry',
+      );
+      createStore.onFirstCall().resolves('cleared-before-unsubscribe');
+      createStore.onSecondCall().resolves('replacement-after-cleared');
+      const firstSyncGate = deferred();
+      const secondSyncGate = deferred();
+      const syncDataLayer = sandbox.stub(datalayer, 'syncDataLayer');
+      syncDataLayer.onFirstCall().returns(firstSyncGate.promise);
+      syncDataLayer.onSecondCall().returns(secondSyncGate.promise);
+      const unsubscribeFromDataLayerStore = sandbox
+        .stub(datalayer, 'unsubscribeFromDataLayerStore')
+        .resolves();
+
+      try {
+        await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+        await waitFor(() => syncDataLayer.callCount === 1);
+
+        await OrganizationsV2.update(
+          { file_store_subscribed: null },
+          { where: { org_uid: testOrgUid } },
+        );
+        await FilestoreV2.unsubscribeFromFileStore(testOrgUid);
+
+        expect(
+          unsubscribeFromDataLayerStore.calledWithExactly(
+            'cleared-before-unsubscribe',
+          ),
+        ).to.equal(true);
+        expect(fileStoreIdsPendingOrgStorePush.has(testOrgUid)).to.equal(false);
+
+        await expectRetryLater(() => FilestoreV2.getFileStoreItem('sha-1'));
+        await waitFor(async () => {
+          const org = await OrganizationsV2.findOne({
+            where: { org_uid: testOrgUid },
+            raw: true,
+          });
+          return org?.file_store_subscribed === 'replacement-after-cleared';
+        });
+
+        expect(createStore.callCount).to.equal(2);
+        firstSyncGate.resolve();
+        await waitFor(
+          () =>
+            fileStoreIdsPendingOrgStorePush.get(testOrgUid)?.fileStoreId ===
+            'replacement-after-cleared',
+        );
+        secondSyncGate.resolve();
+        await waitFor(() => !fileStoreIdsPendingOrgStorePush.has(testOrgUid));
+      } finally {
+        firstSyncGate.resolve();
+        secondSyncGate.resolve();
       }
     });
 
@@ -318,9 +517,7 @@ describe('File store creation dedup', function () {
       const createStore = sandbox
         .stub(datalayer, 'createDataLayerStoreWithRetry')
         .resolves('v1-store-id');
-      const syncDataLayer = sandbox
-        .stub(datalayer, 'syncDataLayer')
-        .resolves();
+      const syncDataLayer = sandbox.stub(datalayer, 'syncDataLayer').resolves();
 
       await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
       await expectRetryLater(() =>
@@ -392,6 +589,48 @@ describe('File store creation dedup', function () {
 
         expect(createStore.callCount).to.equal(1);
         expect(syncDataLayer.callCount).to.equal(1);
+      } finally {
+        syncGate.resolve();
+      }
+    });
+
+    it('re-adopts the in-flight id when the recorded id is cleared mid-push', async function () {
+      sandbox
+        .stub(Organization, 'getHomeOrg')
+        .resolves({ orgUid: v1OrgUid, fileStoreId: null });
+      // Never reports an id, standing in for a record cleared while the push
+      // that would register the store is still running.
+      sandbox.stub(Organization, 'findOne').resolves(null);
+      const orgUpdate = sandbox.stub(Organization, 'update').resolves([1]);
+
+      sandbox
+        .stub(datalayer, 'waitForSpendableCoins')
+        .resolves({ success: true, coinCount: 1 });
+      const createStore = sandbox
+        .stub(datalayer, 'createDataLayerStoreWithRetry')
+        .resolves('v1-race-store');
+      const syncGate = deferred();
+      const syncDataLayer = sandbox
+        .stub(datalayer, 'syncDataLayer')
+        .returns(syncGate.promise);
+
+      try {
+        await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+        await waitFor(() => syncDataLayer.callCount === 1);
+
+        await expectRetryLater(() => FileStore.getFileStoreItem('sha-1'));
+        await waitFor(() => orgUpdate.callCount === 2);
+
+        // The store was already paid for, so it must be re-adopted rather
+        // than replaced.
+        expect(createStore.callCount).to.equal(1);
+        expect(syncDataLayer.callCount).to.equal(1);
+        expect(
+          orgUpdate.alwaysCalledWithExactly(
+            { fileStoreId: 'v1-race-store' },
+            { where: { orgUid: v1OrgUid } },
+          ),
+        ).to.equal(true);
       } finally {
         syncGate.resolve();
       }


### PR DESCRIPTION
## Summary

- File store creation is detached from the request that triggers it, so every retry of the "try again later" error minted another DataLayer store — each costing coins and orphaning the previous one. In-flight creations are now tracked in a pending set shared between the v1 and v2 file store models (an upgraded org keeps the same file store on both sides), so at most one creation starts per org.
- The minted store id is persisted to the org record **before** the org-store sync, so a sync failure can no longer cause the next request to mint a replacement. Post-persist sync failures are logged distinctly from mint failures.
- The creation flow re-checks both models' persisted ids before minting and adopts an existing id instead: this closes the stale-snapshot race (a caller holding a pre-creation org snapshot arriving just after a creation finished) and the sequential cross-model double-mint (v1 request mints, v2 request minutes later would have minted again).

## Behavior notes

- The v1 `get_file` endpoint previously blocked the HTTP request through coin-wait + store mint (and never persisted the id, so every such call minted another store). It now returns the same retry-later error the other filestore endpoints already return.
- Known residual gap (pre-existing, narrowed by this PR): if the org-store push fails after the id is persisted, nothing re-pushes it until the org next syncs, and v2 reconciliation treats the org store as source of truth. This PR prevents the duplicate mint in that window but does not add a push retry.

## Test plan

- [x] New integration spec `tests/v2/integration/file-store-creation-dedupe.spec.js` (9 tests): concurrent-caller dedup for v1 and v2, persist-before-sync, failed-creation retry, pending-set guard, stale-snapshot adoption, and cross-model adoption in both directions.
- [x] Full v1 suite: 208 passing. Full v2 suite: 1879 passing.

## Merge order

Independent of the other two coin-management PRs; can merge anytime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain store minting and org-store registration timing across v1/v2; incorrect dedupe or push retry logic could still orphan stores or leave orgs without a registered file store, though the goal is to reduce duplicate coin spend.
> 
> **Overview**
> Stops **retry-later** file store traffic from minting multiple paid DataLayer stores per org by routing v1 and v2 through a shared **`startFileStoreCreation`** flow backed by process-local **`pending-file-store-creations`**.
> 
> **One mint per org:** a shared pending set blocks overlapping creation for the same org across v1 and v2. Callers still get the existing retry-later error immediately instead of waiting on coins or mint.
> 
> **Persist before org-store sync:** the new store id is written to the org row before **`syncDataLayer`** registers it on the org store, with a separate map tracking ids pending that push. Later requests **adopt** an id from either model’s DB row or that map (including when v2 reconciliation clears the column mid-push), and can **retry a failed push** without minting again.
> 
> **v1 `getFileStoreItem`** now matches other filestore endpoints: starts creation in the background and throws retry-later instead of blocking the HTTP request through mint.
> 
> **Unsubscribe** on both models now awaits datalayer/DB work, considers in-flight pending-push ids, and clears pending-push state so unsubscribed stores are not re-adopted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627cf310d8f622ee38ed436fde1b7d527724267b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->