### PR TITLE
fix: fall back to sequential store creation when coins are scarce

### DIFF
--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -924,15 +924,29 @@ const clearRejectedTransactions = async (walletId, txIds, context) => {
   return { cleared: true, reason: `Cleared ${health.rejected.length} rejected transaction(s)` };
 };
 
+// Errors the wallet raises when coin selection cannot fund a spend right now,
+// typically because coins are tied up in unconfirmed transactions. These clear
+// on their own as transactions confirm, so callers may retry on a time budget
+// (see chia's coin_selection.py and data_layer_wallet.py for the sources).
+const COIN_SHORTAGE_ERRORS = [
+  'No spendable coins',
+  "Can't select amount higher than our spendable balance",
+  'greater than max spendable balance in a block',
+  'Not enough coins to create new data layer singleton',
+];
+
+const isCoinShortageError = (error) =>
+  COIN_SHORTAGE_ERRORS.some((msg) => error.message?.includes(msg));
+
 const TRANSIENT_WALLET_ERRORS = [
   'Wallet needs to be fully synced',
   'DataLayerWallet not available',
   'DataLayer Wallet already exists',
-  'No spendable coins',
   'UNIQUE constraint failed',
 ];
 
 const isTransientWalletError = (error) =>
+  isCoinShortageError(error) ||
   TRANSIENT_WALLET_ERRORS.some((msg) => error.message?.includes(msg));
 
 const __test_resetDLWalletCache = () => {
@@ -957,6 +971,7 @@ export default {
   getCoinRecords,
   splitCoins,
   isTransientWalletError,
+  isCoinShortageError,
   getTransactionHealth,
   getDLWalletId,
   clearRejectedTransactions,

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -536,17 +536,51 @@ const splitCoins = async (targetCoinId, numberOfCoins, amountPerCoin, fee = 0) =
  * @param {number} minMojosPerCoin - Minimum mojos per coin (default: DEFAULT_COIN_AMOUNT + DEFAULT_FEE, must cover operation and fee)
  * @param {number} maxWaitMs - Maximum wait time in milliseconds (default: 5 minutes)
  * @param {number} pollIntervalMs - Polling interval in milliseconds (default: 10 seconds)
+ * @param {number} minTotalMojos - Minimum combined amount across usable coins (default: 0). Lets a
+ *   caller relaxing requiredCoins to 1 still require the wallet can fund a whole batch of spends.
  * @returns {Promise<{success: boolean, coinCount?: number, error?: string}>}
  */
 const DEFAULT_COIN_AMOUNT = CONFIG.DEFAULT_COIN_AMOUNT || 300;
 const DEFAULT_COIN_FEE = CONFIG.DEFAULT_FEE || 3000;
 const MIN_USABLE_COIN_SIZE = DEFAULT_COIN_AMOUNT + DEFAULT_COIN_FEE;
 
+/**
+ * Pure sufficiency check over wallet coin records: enough separate unspent
+ * coins of a usable size, whose combined amount can fund the whole batch.
+ * @param {Array<Object>} coinRecords - Records from get_coin_records
+ * @param {number} requiredCoins - Number of separate coins needed
+ * @param {number} minMojosPerCoin - Minimum mojos per coin
+ * @param {number} minTotalMojos - Minimum combined mojos across usable coins
+ * @returns {{sufficient: boolean, usableCoins: Array<Object>, totalBalance: number}}
+ */
+const evaluateSpendableCoins = (
+  coinRecords,
+  requiredCoins,
+  minMojosPerCoin,
+  minTotalMojos = 0,
+) => {
+  const usableCoins = coinRecords.filter((coin) => {
+    const isUnspent = !coin.spent_height || coin.spent_height === 0;
+    const hasSufficientBalance = coin.amount >= minMojosPerCoin;
+    return isUnspent && hasSufficientBalance;
+  });
+
+  const totalBalance = usableCoins.reduce((sum, coin) => sum + coin.amount, 0);
+
+  return {
+    sufficient:
+      usableCoins.length >= requiredCoins && totalBalance >= minTotalMojos,
+    usableCoins,
+    totalBalance,
+  };
+};
+
 const waitForSpendableCoins = async (
   requiredCoins = 4,
   minMojosPerCoin = MIN_USABLE_COIN_SIZE,
   maxWaitMs = 300000,
   pollIntervalMs = 10000,
+  minTotalMojos = 0,
 ) => {
   if (USE_SIMULATOR) {
     return { success: true, coinCount: 10, balance: 999000000000000 };
@@ -587,15 +621,12 @@ const waitForSpendableCoins = async (
         continue;
       }
 
-      // Count coins that are unspent and have sufficient balance
-      // Filter to coins that are unspent (spent_height === 0 or undefined)
-      const usableCoins = coinResult.coin_records.filter((coin) => {
-        const isUnspent = !coin.spent_height || coin.spent_height === 0;
-        const hasSufficientBalance = coin.amount >= minMojosPerCoin;
-        return isUnspent && hasSufficientBalance;
-      });
-
-      const totalBalance = usableCoins.reduce((sum, coin) => sum + coin.amount, 0);
+      const { sufficient, usableCoins, totalBalance } = evaluateSpendableCoins(
+        coinResult.coin_records,
+        requiredCoins,
+        minMojosPerCoin,
+        minTotalMojos,
+      );
 
       // Log status every 30 seconds or when count changes
       if (Date.now() - lastLogTime > 30000) {
@@ -611,7 +642,7 @@ const waitForSpendableCoins = async (
         }
       }
 
-      if (usableCoins.length >= requiredCoins) {
+      if (sufficient) {
         logger.info(
           `[wallet]: Sufficient coins available: ${usableCoins.length} coins of ${minMojosPerCoin}+ mojos (need ${requiredCoins})`,
         );
@@ -619,11 +650,18 @@ const waitForSpendableCoins = async (
       }
 
       // Not enough coins yet - check if we should warn about coin management
-      if (elapsed > 60 && usableCoins.length < requiredCoins) {
-        logger.warn(
-          `[wallet]: Only ${usableCoins.length}/${requiredCoins} usable coins available after ${elapsed}s. ` +
-          `Coin management may need to split coins first.`,
-        );
+      if (elapsed > 60) {
+        if (usableCoins.length < requiredCoins) {
+          logger.warn(
+            `[wallet]: Only ${usableCoins.length}/${requiredCoins} usable coins available after ${elapsed}s. ` +
+            `Coin management may need to split coins first.`,
+          );
+        } else {
+          logger.warn(
+            `[wallet]: Usable coins total ${totalBalance} mojos but ${minTotalMojos} are needed ` +
+            `after ${elapsed}s. The wallet may need more funds.`,
+          );
+        }
       }
     } catch (error) {
       logger.warn(`[wallet]: Error checking coin availability: ${error.message}`);
@@ -633,7 +671,9 @@ const waitForSpendableCoins = async (
   }
 
   const elapsed = Math.floor((Date.now() - startTime) / 1000);
-  const msg = `Timeout waiting for ${requiredCoins} coins of ${minMojosPerCoin}+ mojos after ${elapsed}s`;
+  const totalRequirement =
+    minTotalMojos > 0 ? ` totalling at least ${minTotalMojos} mojos` : '';
+  const msg = `Timeout waiting for ${requiredCoins} coins of ${minMojosPerCoin}+ mojos${totalRequirement} after ${elapsed}s`;
   logger.error(`[wallet]: ${msg}`);
   throw new Error(msg);
 };
@@ -978,5 +1018,7 @@ export default {
   formatDuration,
   findDLWalletInResponse,
   CHIA_WALLET_TYPE_DATA_LAYER,
+  MIN_USABLE_COIN_SIZE,
+  evaluateSpendableCoins,
   __test_resetDLWalletCache,
 };

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -57,10 +57,10 @@ import {
   hasInProgressCreation,
   createIncrementalStateWriter,
 } from '../../utils/organization-creation-state.js';
+import { createStoreWithRetryBudget } from '../../utils/store-creation-retry.js';
 import { mirrorOrgStores } from '../../tasks/mirror-check.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
-const { isTransientWalletError } = wallet;
 
 class Organization extends Model {
   static async getHomeOrg(includeAddress = true) {
@@ -225,7 +225,10 @@ class Organization extends Model {
       }
 
       if (!USE_SIMULATOR) {
-        const coinCheck = await wallet.waitForSpendableCoins(4);
+        // One coin is enough to start: with fewer coins than stores, the
+        // parallel store creations serialize themselves, each retrying until
+        // the previous spend's change confirms and frees a coin.
+        const coinCheck = await wallet.waitForSpendableCoins(1);
         logger.info(`[v1]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
       }
 
@@ -281,8 +284,10 @@ class Organization extends Model {
 
     const neededCoins = getStoresToCreate(state).length;
     if (!USE_SIMULATOR && neededCoins > 0) {
-      const coinCheck = await wallet.waitForSpendableCoins(neededCoins);
-      logger.info(`[v1]: Resuming org creation, ${coinCheck.coinCount} coins available (need ${neededCoins})`);
+      // One coin is enough to resume; scarce coins serialize the remaining
+      // store creations (see _createStoresInParallel).
+      const coinCheck = await wallet.waitForSpendableCoins(1);
+      logger.info(`[v1]: Resuming org creation, ${coinCheck.coinCount} coins available (${neededCoins} stores to create)`);
     }
 
     return await Organization._executeOrganizationCreation(state, lockToken);
@@ -499,9 +504,6 @@ class Organization extends Model {
       return state;
     }
 
-    const maxRetries = 10;
-    const retryDelayMs = 30000;
-
     // Persist each successful store creation immediately so the
     // /v1/organizations/creation-status endpoint reflects partial progress.
     // Without this, all 4 stores stay marked pending until the slowest
@@ -510,45 +512,17 @@ class Organization extends Model {
     const stateWriter = createIncrementalStateWriter(state, Meta);
 
     // Create all stores in parallel, each with independent retry logic.
-    // The persist call is wrapped in its own try so that a transient
-    // saveCreationState failure (DB busy, sequelize hiccup) does NOT
-    // mask a successful on-chain store creation as a creation failure;
-    // any missing persist will be reconciled in a final save below.
-    const createPromises = storesToCreate.map(async (storeType) => {
-      for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        try {
-          logState(stateWriter.getCurrent(), `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
-          const storeId = await datalayer.createDataLayerStoreWithRetry();
-          logState(stateWriter.getCurrent(), `Created ${storeType} store: ${storeId}`);
-          try {
-            await stateWriter.persistStoreCreated(storeType, storeId);
-          } catch (persistError) {
-            logState(
-              stateWriter.getCurrent(),
-              `Created ${storeType} store ${storeId} but failed to persist incremental progress: ` +
-                `${persistError.message}. Store id retained in result; final save will reconcile.`,
-              'warn',
-            );
-          }
-          return { storeType, storeId, success: true };
-        } catch (error) {
-          if (isTransientWalletError(error) && attempt < maxRetries) {
-            logState(
-              stateWriter.getCurrent(),
-              `Transient error creating ${storeType} store ` +
-                `(attempt ${attempt}/${maxRetries}): ${error.message}. ` +
-                `Retrying in ${retryDelayMs / 1000}s...`,
-              'warn',
-            );
-            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
-            continue;
-          }
-          logState(stateWriter.getCurrent(), `Failed to create ${storeType} store: ${error.message}`, 'error');
-          return { storeType, storeId: null, success: false, error: error.message };
-        }
-      }
-      return { storeType, storeId: null, success: false, error: 'Retry loop exhausted without result' };
-    });
+    // Coin shortages serialize the creations instead of failing them
+    // (see createStoreWithRetryBudget).
+    const createPromises = storesToCreate.map((storeType) =>
+      createStoreWithRetryBudget(storeType, {
+        createStore: () => datalayer.createDataLayerStoreWithRetry(),
+        persistStoreCreated: (storeId) =>
+          stateWriter.persistStoreCreated(storeType, storeId),
+        log: (message, level) =>
+          logState(stateWriter.getCurrent(), message, level),
+      }),
+    );
 
     const results = await Promise.all(createPromises);
 

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -61,7 +61,6 @@ import { createStoreWithRetryBudget } from '../../utils/store-creation-retry.js'
 import { mirrorOrgStores } from '../../tasks/mirror-check.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
-
 class Organization extends Model {
   static async getHomeOrg(includeAddress = true) {
     const { READ_ONLY } = getConfig();
@@ -227,8 +226,16 @@ class Organization extends Model {
       if (!USE_SIMULATOR) {
         // One coin is enough to start: with fewer coins than stores, the
         // parallel store creations serialize themselves, each retrying until
-        // the previous spend's change confirms and frees a coin.
-        const coinCheck = await wallet.waitForSpendableCoins(1);
+        // the previous spend's change confirms and frees a coin. The combined
+        // balance must still cover every store, or creation would spend part
+        // of the batch and then strand the org with orphaned stores.
+        const coinCheck = await wallet.waitForSpendableCoins(
+          1,
+          undefined,
+          undefined,
+          undefined,
+          getStoresToCreate(state).length * wallet.MIN_USABLE_COIN_SIZE,
+        );
         logger.info(`[v1]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
       }
 
@@ -285,8 +292,15 @@ class Organization extends Model {
     const neededCoins = getStoresToCreate(state).length;
     if (!USE_SIMULATOR && neededCoins > 0) {
       // One coin is enough to resume; scarce coins serialize the remaining
-      // store creations (see _createStoresInParallel).
-      const coinCheck = await wallet.waitForSpendableCoins(1);
+      // store creations (see _createStoresInParallel). The combined balance
+      // must still cover every remaining store.
+      const coinCheck = await wallet.waitForSpendableCoins(
+        1,
+        undefined,
+        undefined,
+        undefined,
+        neededCoins * wallet.MIN_USABLE_COIN_SIZE,
+      );
       logger.info(`[v1]: Resuming org creation, ${coinCheck.coinCount} coins available (${neededCoins} stores to create)`);
     }
 

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -15,7 +15,8 @@ import {
   destroyByPrimaryKeyBatches,
   resolveDeleteBatchSize,
 } from '../../utils/batched-delete.js';
-const { USE_SIMULATOR, AUTO_SUBSCRIBE_FILESTORE } = getConfig().APP;
+const APP_CONFIG = getConfig().APP;
+const { USE_SIMULATOR, AUTO_SUBSCRIBE_FILESTORE } = APP_CONFIG;
 
 import ModelTypes from './organizations.modeltypes.js';
 import { assertStoreIsOwned } from '../../utils/data-assertions';
@@ -56,6 +57,7 @@ import {
   clearCreationState,
   hasInProgressCreation,
   createIncrementalStateWriter,
+  getStoreCreationMinTotalMojos,
 } from '../../utils/organization-creation-state.js';
 import { createStoreWithRetryBudget } from '../../utils/store-creation-retry.js';
 import { mirrorOrgStores } from '../../tasks/mirror-check.js';
@@ -224,17 +226,21 @@ class Organization extends Model {
       }
 
       if (!USE_SIMULATOR) {
+        const storesToCreate = getStoresToCreate(state);
         // One coin is enough to start: with fewer coins than stores, the
         // parallel store creations serialize themselves, each retrying until
         // the previous spend's change confirms and frees a coin. The combined
-        // balance must still cover every store, or creation would spend part
-        // of the batch and then strand the org with orphaned stores.
+        // balance must still cover every store and configured mirror.
         const coinCheck = await wallet.waitForSpendableCoins(
           1,
           undefined,
           undefined,
           undefined,
-          getStoresToCreate(state).length * wallet.MIN_USABLE_COIN_SIZE,
+          getStoreCreationMinTotalMojos(
+            storesToCreate,
+            wallet.MIN_USABLE_COIN_SIZE,
+            APP_CONFIG,
+          ),
         );
         logger.info(`[v1]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
       }
@@ -289,17 +295,22 @@ class Organization extends Model {
       await saveCreationState(state, Meta);
     }
 
-    const neededCoins = getStoresToCreate(state).length;
+    const storesToCreate = getStoresToCreate(state);
+    const neededCoins = storesToCreate.length;
     if (!USE_SIMULATOR && neededCoins > 0) {
       // One coin is enough to resume; scarce coins serialize the remaining
       // store creations (see _createStoresInParallel). The combined balance
-      // must still cover every remaining store.
+      // must still cover every remaining store and configured mirror.
       const coinCheck = await wallet.waitForSpendableCoins(
         1,
         undefined,
         undefined,
         undefined,
-        neededCoins * wallet.MIN_USABLE_COIN_SIZE,
+        getStoreCreationMinTotalMojos(
+          storesToCreate,
+          wallet.MIN_USABLE_COIN_SIZE,
+          APP_CONFIG,
+        ),
       );
       logger.info(`[v1]: Resuming org creation, ${coinCheck.coinCount} coins available (${neededCoins} stores to create)`);
     }

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -11,7 +11,8 @@ import * as simulator from '../../datalayer/simulator.js';
 import { loggerV2 } from '../../config/logger.js';
 import { getConfig, getConfigV2 } from '../../utils/config-loader';
 import { decodeHex, decodeDataLayerResponse } from '../../utils/datalayer-utils.js';
-const { USE_SIMULATOR, AUTO_SUBSCRIBE_FILESTORE } = getConfig().APP;
+const APP_CONFIG = getConfig().APP;
+const { USE_SIMULATOR, AUTO_SUBSCRIBE_FILESTORE } = APP_CONFIG;
 
 // Helper to get store data - returns raw format with keys_values for both modes
 // Uses simulator in simulator mode, otherwise uses persistance.getStoreData directly
@@ -76,6 +77,7 @@ import {
   clearCreationState,
   hasInProgressCreation,
   createIncrementalStateWriter,
+  getStoreCreationMinTotalMojos,
 } from '../../utils/organization-creation-state.js';
 import { createStoreWithRetryBudget } from '../../utils/store-creation-retry.js';
 
@@ -265,17 +267,21 @@ class OrganizationsV2 extends Model {
         });
       }
 
+      const storesToCreate = getStoresToCreate(state);
       // One coin is enough to start: with fewer coins than stores, the
       // parallel store creations serialize themselves, each retrying until
       // the previous spend's change confirms and frees a coin. The combined
-      // balance must still cover every store, or creation would spend part
-      // of the batch and then strand the org with orphaned stores.
+      // balance must still cover every store and configured mirror.
       const coinCheck = await wallet.waitForSpendableCoins(
         1,
         undefined,
         undefined,
         undefined,
-        getStoresToCreate(state).length * wallet.MIN_USABLE_COIN_SIZE,
+        getStoreCreationMinTotalMojos(
+          storesToCreate,
+          wallet.MIN_USABLE_COIN_SIZE,
+          APP_CONFIG,
+        ),
       );
       loggerV2.info(`[v2]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
 
@@ -330,17 +336,22 @@ class OrganizationsV2 extends Model {
       await saveCreationState(state, MetaV2);
     }
 
-    const neededCoins = getStoresToCreate(state).length;
+    const storesToCreate = getStoresToCreate(state);
+    const neededCoins = storesToCreate.length;
     if (neededCoins > 0) {
       // One coin is enough to resume; scarce coins serialize the remaining
       // store creations (see _createStoresInParallel). The combined balance
-      // must still cover every remaining store.
+      // must still cover every remaining store and configured mirror.
       const coinCheck = await wallet.waitForSpendableCoins(
         1,
         undefined,
         undefined,
         undefined,
-        neededCoins * wallet.MIN_USABLE_COIN_SIZE,
+        getStoreCreationMinTotalMojos(
+          storesToCreate,
+          wallet.MIN_USABLE_COIN_SIZE,
+          APP_CONFIG,
+        ),
       );
       loggerV2.info(`[v2]: Resuming org creation, ${coinCheck.coinCount} coins available (${neededCoins} stores to create)`);
     }

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -77,6 +77,7 @@ import {
   hasInProgressCreation,
   createIncrementalStateWriter,
 } from '../../utils/organization-creation-state.js';
+import { createStoreWithRetryBudget } from '../../utils/store-creation-retry.js';
 
 import ModelTypes from './organizations-v2.modeltypes.js';
 import { mirrorOrgStoresV2 } from '../../tasks/mirror-check-v2.js';
@@ -266,9 +267,10 @@ class OrganizationsV2 extends Model {
         });
       }
 
-      // Wait for sufficient spendable coins before starting store creation
-      // We need 4 SEPARATE coins (one per parallel store creation), each large enough to cover COIN_SIZE + fee
-      const coinCheck = await wallet.waitForSpendableCoins(4);
+      // One coin is enough to start: with fewer coins than stores, the
+      // parallel store creations serialize themselves, each retrying until
+      // the previous spend's change confirms and frees a coin.
+      const coinCheck = await wallet.waitForSpendableCoins(1);
       loggerV2.info(`[v2]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
 
       // Execute the creation process
@@ -324,8 +326,10 @@ class OrganizationsV2 extends Model {
 
     const neededCoins = getStoresToCreate(state).length;
     if (neededCoins > 0) {
-      const coinCheck = await wallet.waitForSpendableCoins(neededCoins);
-      loggerV2.info(`[v2]: Resuming org creation, ${coinCheck.coinCount} coins available (need ${neededCoins})`);
+      // One coin is enough to resume; scarce coins serialize the remaining
+      // store creations (see _createStoresInParallel).
+      const coinCheck = await wallet.waitForSpendableCoins(1);
+      loggerV2.info(`[v2]: Resuming org creation, ${coinCheck.coinCount} coins available (${neededCoins} stores to create)`);
     }
 
     return await OrganizationsV2._executeOrganizationCreation(state, MetaV2, lockToken);
@@ -526,9 +530,6 @@ class OrganizationsV2 extends Model {
       return state;
     }
 
-    const maxRetries = 10;
-    const retryDelayMs = 30000;
-
     // Persist each successful store creation immediately so the
     // /v2/organizations/creation-status endpoint reflects partial progress.
     // Without this, all 4 stores stay marked pending until the slowest
@@ -537,45 +538,17 @@ class OrganizationsV2 extends Model {
     const stateWriter = createIncrementalStateWriter(state, MetaV2);
 
     // Create all stores in parallel, each with independent retry logic.
-    // The persist call is wrapped in its own try so that a transient
-    // saveCreationState failure (DB busy, sequelize hiccup) does NOT
-    // mask a successful on-chain store creation as a creation failure;
-    // any missing persist will be reconciled in a final save below.
-    const createPromises = storesToCreate.map(async (storeType) => {
-      for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        try {
-          logState(stateWriter.getCurrent(), `Creating ${storeType} store (attempt ${attempt}/${maxRetries})`);
-          const storeId = await datalayer.createDataLayerStoreWithRetry();
-          logState(stateWriter.getCurrent(), `Created ${storeType} store: ${storeId}`);
-          try {
-            await stateWriter.persistStoreCreated(storeType, storeId);
-          } catch (persistError) {
-            logState(
-              stateWriter.getCurrent(),
-              `Created ${storeType} store ${storeId} but failed to persist incremental progress: ` +
-                `${persistError.message}. Store id retained in result; final save will reconcile.`,
-              'warn',
-            );
-          }
-          return { storeType, storeId, success: true };
-        } catch (error) {
-          if (isTransientWalletError(error) && attempt < maxRetries) {
-            logState(
-              stateWriter.getCurrent(),
-              `Transient error creating ${storeType} store ` +
-                `(attempt ${attempt}/${maxRetries}): ${error.message}. ` +
-                `Retrying in ${retryDelayMs / 1000}s...`,
-              'warn',
-            );
-            await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
-            continue;
-          }
-          logState(stateWriter.getCurrent(), `Failed to create ${storeType} store: ${error.message}`, 'error');
-          return { storeType, storeId: null, success: false, error: error.message };
-        }
-      }
-      return { storeType, storeId: null, success: false, error: 'Retry loop exhausted without result' };
-    });
+    // Coin shortages serialize the creations instead of failing them
+    // (see createStoreWithRetryBudget).
+    const createPromises = storesToCreate.map((storeType) =>
+      createStoreWithRetryBudget(storeType, {
+        createStore: () => datalayer.createDataLayerStoreWithRetry(),
+        persistStoreCreated: (storeId) =>
+          stateWriter.persistStoreCreated(storeType, storeId),
+        log: (message, level) =>
+          logState(stateWriter.getCurrent(), message, level),
+      }),
+    );
 
     const results = await Promise.all(createPromises);
 

--- a/src/models/v2/organizations-v2.model.js
+++ b/src/models/v2/organizations-v2.model.js
@@ -83,8 +83,6 @@ import ModelTypes from './organizations-v2.modeltypes.js';
 import { mirrorOrgStoresV2 } from '../../tasks/mirror-check-v2.js';
 import { updateOrgLockStatus } from '../../utils/org-operation-lock.js';
 
-const { isTransientWalletError } = wallet;
-
 class OrganizationsV2 extends Model {
   static async create(values, options) {
     await mirrorWriteV2(async () => {
@@ -269,8 +267,16 @@ class OrganizationsV2 extends Model {
 
       // One coin is enough to start: with fewer coins than stores, the
       // parallel store creations serialize themselves, each retrying until
-      // the previous spend's change confirms and frees a coin.
-      const coinCheck = await wallet.waitForSpendableCoins(1);
+      // the previous spend's change confirms and frees a coin. The combined
+      // balance must still cover every store, or creation would spend part
+      // of the batch and then strand the org with orphaned stores.
+      const coinCheck = await wallet.waitForSpendableCoins(
+        1,
+        undefined,
+        undefined,
+        undefined,
+        getStoresToCreate(state).length * wallet.MIN_USABLE_COIN_SIZE,
+      );
       loggerV2.info(`[v2]: Proceeding with org creation, ${coinCheck.coinCount} coins available`);
 
       // Execute the creation process
@@ -327,8 +333,15 @@ class OrganizationsV2 extends Model {
     const neededCoins = getStoresToCreate(state).length;
     if (neededCoins > 0) {
       // One coin is enough to resume; scarce coins serialize the remaining
-      // store creations (see _createStoresInParallel).
-      const coinCheck = await wallet.waitForSpendableCoins(1);
+      // store creations (see _createStoresInParallel). The combined balance
+      // must still cover every remaining store.
+      const coinCheck = await wallet.waitForSpendableCoins(
+        1,
+        undefined,
+        undefined,
+        undefined,
+        neededCoins * wallet.MIN_USABLE_COIN_SIZE,
+      );
       loggerV2.info(`[v2]: Resuming org creation, ${coinCheck.coinCount} coins available (${neededCoins} stores to create)`);
     }
 
@@ -953,27 +966,21 @@ class OrganizationsV2 extends Model {
       if (USE_SIMULATOR) {
         newV2RegistryStoreId = 'v2-registry-' + Date.now();
       } else {
-        const maxStoreCreateRetries = 10;
-        const storeCreateRetryDelayMs = 30000;
-
-        for (let attempt = 1; attempt <= maxStoreCreateRetries; attempt++) {
-          try {
+        // Same retry policy as org creation: coin shortages get a time
+        // budget, other transient wallet errors an attempt budget.
+        const result = await createStoreWithRetryBudget('V2 registry', {
+          createStore: async () => {
             await wallet.waitForSpendableCoins(1);
-            newV2RegistryStoreId = await datalayer.createDataLayerStoreWithRetry();
-            break;
-          } catch (error) {
-            if (isTransientWalletError(error) && attempt < maxStoreCreateRetries) {
-              loggerV2.warn(
-                `[v2]: Wallet not ready during V2 registry store creation ` +
-                `(attempt ${attempt}/${maxStoreCreateRetries}): ${error.message}. ` +
-                `Retrying in ${storeCreateRetryDelayMs / 1000}s...`,
-              );
-              await new Promise((resolve) => setTimeout(resolve, storeCreateRetryDelayMs));
-              continue;
-            }
-            throw error;
-          }
+            return await datalayer.createDataLayerStoreWithRetry();
+          },
+          persistStoreCreated: async () => {},
+          log: (message, level = 'info') =>
+            loggerV2[level](`[v2]: ${message}`),
+        });
+        if (!result.success) {
+          throw new Error(result.error);
         }
+        newV2RegistryStoreId = result.storeId;
       }
 
       // CRITICAL: Use existing dataModelVersionStoreId singleton (do NOT create new one)

--- a/src/utils/organization-creation-state.js
+++ b/src/utils/organization-creation-state.js
@@ -66,6 +66,12 @@ export const ORG_CREATION_CONFIG = {
   // block confirmation apart, so the budget must cover several confirmations
   // rather than a fixed attempt count. Other transient wallet errors keep the
   // attempt-based budget.
+  //
+  // The deadline is checked between attempts, so an attempt that blocks on
+  // confirmation waits can overrun it; the deadline bounds when new attempts
+  // start, not total wall time. It also counts against the same
+  // STORE_CONFIRMATION_TIMEOUT_MS window as the data pushes above, so keep
+  // it well under that bound.
   STORE_CREATE_RETRY_DELAY_MS: 30 * 1000, // 30 seconds
   STORE_CREATE_MAX_ATTEMPTS: 10,
   COIN_SHORTAGE_RETRY_DEADLINE_MS: 15 * 60 * 1000, // 15 minutes

--- a/src/utils/organization-creation-state.js
+++ b/src/utils/organization-creation-state.js
@@ -60,6 +60,15 @@ export const ORG_CREATION_CONFIG = {
   // bound changes.
   DATA_PUSH_WALLET_SYNC_WAIT_MS: 2 * 60 * 1000, // 2 minutes
   MAX_DATA_PUSH_SYNC_RETRIES: 3,
+
+  // Store-creation retry budgets. Coin shortages get a time budget: with
+  // fewer spendable coins than stores, the parallel creations serialize one
+  // block confirmation apart, so the budget must cover several confirmations
+  // rather than a fixed attempt count. Other transient wallet errors keep the
+  // attempt-based budget.
+  STORE_CREATE_RETRY_DELAY_MS: 30 * 1000, // 30 seconds
+  STORE_CREATE_MAX_ATTEMPTS: 10,
+  COIN_SHORTAGE_RETRY_DEADLINE_MS: 15 * 60 * 1000, // 15 minutes
 };
 
 /**

--- a/src/utils/organization-creation-state.js
+++ b/src/utils/organization-creation-state.js
@@ -210,8 +210,29 @@ export const allDataWritten = (state) => {
  */
 export const getStoresToCreate = (state) => {
   return Object.entries(state.stores)
-    .filter(([_, store]) => store.id === null)
+    .filter(([, store]) => store.id === null)
     .map(([type]) => type);
+};
+
+/**
+ * Minimum combined wallet balance needed to create the remaining org stores.
+ * A configured mirror adds one extra wallet spend after each store creation.
+ * @param {string[]} storesToCreate - Store types that still need creation
+ * @param {number} minUsableCoinSize - Coin size that funds one wallet spend
+ * @param {Object} appConfig - APP config values that affect mirror spending
+ * @returns {number}
+ */
+export const getStoreCreationMinTotalMojos = (
+  storesToCreate,
+  minUsableCoinSize,
+  appConfig = {},
+) => {
+  const mirrorRequiresSpend = Boolean(appConfig.DATALAYER_FILE_SERVER_URL) &&
+    !appConfig.USE_SIMULATOR &&
+    !appConfig.USE_DEVELOPMENT_MODE;
+  const spendsPerStore = mirrorRequiresSpend ? 2 : 1;
+
+  return storesToCreate.length * minUsableCoinSize * spendsPerStore;
 };
 
 /**
@@ -221,7 +242,7 @@ export const getStoresToCreate = (state) => {
  */
 export const getStoresAwaitingConfirmation = (state) => {
   return Object.entries(state.stores)
-    .filter(([_, store]) => store.id !== null && !store.confirmed)
+    .filter(([, store]) => store.id !== null && !store.confirmed)
     .map(([type]) => type);
 };
 

--- a/src/utils/store-creation-retry.js
+++ b/src/utils/store-creation-retry.js
@@ -1,0 +1,75 @@
+import { ORG_CREATION_CONFIG } from './organization-creation-state.js';
+import wallet from '../datalayer/wallet.js';
+
+const { isTransientWalletError, isCoinShortageError } = wallet;
+
+/**
+ * Create one DataLayer store, retrying transient wallet errors.
+ *
+ * Coin shortages are retried on a time budget: with fewer spendable coins
+ * than parallel creations, each creation waits for an earlier spend's change
+ * to confirm, so scarce coins serialize the creations instead of failing
+ * them. The budget must cover several block confirmations, hence time-based.
+ * Other transient wallet errors keep an attempt-based budget.
+ *
+ * @param {string} storeType - Which store this creation is for (used in logs and the result)
+ * @param {Object} deps
+ * @param {() => Promise<string>} deps.createStore - Performs one creation attempt, resolves the store id
+ * @param {(storeId: string) => Promise<void>} deps.persistStoreCreated - Persists incremental progress
+ * @param {(message: string, level?: string) => void} deps.log - State-aware logger
+ * @returns {Promise<{storeType: string, storeId: string|null, success: boolean, error?: string}>}
+ */
+export const createStoreWithRetryBudget = async (
+  storeType,
+  { createStore, persistStoreCreated, log },
+) => {
+  const retryDelayMs = ORG_CREATION_CONFIG.STORE_CREATE_RETRY_DELAY_MS;
+  const maxAttempts = ORG_CREATION_CONFIG.STORE_CREATE_MAX_ATTEMPTS;
+  const coinShortageDeadline =
+    Date.now() + ORG_CREATION_CONFIG.COIN_SHORTAGE_RETRY_DEADLINE_MS;
+  let transientAttempts = 0;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      log(`Creating ${storeType} store (attempt ${attempt})`);
+      const storeId = await createStore();
+      log(`Created ${storeType} store: ${storeId}`);
+      try {
+        // The persist call is wrapped in its own try so that a transient
+        // persistence failure (DB busy, sequelize hiccup) does NOT mask a
+        // successful on-chain store creation as a creation failure; the
+        // caller reconciles any missing persist from the returned result.
+        await persistStoreCreated(storeId);
+      } catch (persistError) {
+        log(
+          `Created ${storeType} store ${storeId} but failed to persist incremental progress: ` +
+            `${persistError.message}. Store id retained in result; final save will reconcile.`,
+          'warn',
+        );
+      }
+      return { storeType, storeId, success: true };
+    } catch (error) {
+      const retryable = isCoinShortageError(error)
+        ? Date.now() + retryDelayMs < coinShortageDeadline
+        : isTransientWalletError(error) && ++transientAttempts < maxAttempts;
+
+      if (!retryable) {
+        log(`Failed to create ${storeType} store: ${error.message}`, 'error');
+        return {
+          storeType,
+          storeId: null,
+          success: false,
+          error: error.message,
+        };
+      }
+
+      log(
+        `Transient error creating ${storeType} store ` +
+          `(attempt ${attempt}): ${error.message}. ` +
+          `Retrying in ${retryDelayMs / 1000}s...`,
+        'warn',
+      );
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+};

--- a/tests/v2/integration/store-creation-retry.spec.js
+++ b/tests/v2/integration/store-creation-retry.spec.js
@@ -1,0 +1,240 @@
+import { expect } from 'chai';
+import { createStoreWithRetryBudget } from '../../../src/utils/store-creation-retry.js';
+import { ORG_CREATION_CONFIG } from '../../../src/utils/organization-creation-state.js';
+import wallet from '../../../src/datalayer/wallet.js';
+
+const { isCoinShortageError, isTransientWalletError } = wallet;
+
+// Real messages chia raises when coin selection cannot fund a spend
+// (coin_selection.py and data_layer_wallet.py).
+const SELECT_AMOUNT_ERROR =
+  "Can't select amount higher than our spendable balance.  Amount: 3001, spendable: 0";
+const MAX_BLOCK_BALANCE_ERROR =
+  'Transaction for 3001 is greater than max spendable balance in a block of 0. ' +
+  'There may be other transactions pending or our minimum coin amount is too high.';
+const DL_SINGLETON_ERROR = 'Not enough coins to create new data layer singleton';
+
+describe('Store creation retry budget', function () {
+  this.timeout(30000);
+
+  const savedConfig = {};
+
+  before(function () {
+    Object.assign(savedConfig, ORG_CREATION_CONFIG);
+  });
+
+  beforeEach(function () {
+    // Fast budgets so boundary behavior is observable in test time.
+    ORG_CREATION_CONFIG.STORE_CREATE_RETRY_DELAY_MS = 10;
+    ORG_CREATION_CONFIG.STORE_CREATE_MAX_ATTEMPTS = 10;
+    ORG_CREATION_CONFIG.COIN_SHORTAGE_RETRY_DEADLINE_MS = 5000;
+  });
+
+  afterEach(function () {
+    Object.assign(ORG_CREATION_CONFIG, savedConfig);
+  });
+
+  const noopLog = () => {};
+  const okPersist = async () => {};
+
+  describe('coin shortage classification', function () {
+    it('classifies the wallet coin-selection errors as coin shortages', function () {
+      for (const message of [
+        SELECT_AMOUNT_ERROR,
+        MAX_BLOCK_BALANCE_ERROR,
+        DL_SINGLETON_ERROR,
+        'No spendable coins',
+      ]) {
+        expect(isCoinShortageError(new Error(message))).to.equal(true);
+        expect(isTransientWalletError(new Error(message))).to.equal(true);
+      }
+    });
+
+    it('does not classify unrelated errors as coin shortages', function () {
+      for (const message of [
+        'Wallet needs to be fully synced',
+        'store creation was rejected by the network',
+        'boom',
+      ]) {
+        expect(isCoinShortageError(new Error(message))).to.equal(false);
+      }
+    });
+  });
+
+  describe('sequential fallback', function () {
+    it('serializes four parallel creations sharing a single coin', async function () {
+      // One-coin wallet: a successful creation consumes the coin; its change
+      // becomes spendable again after a simulated confirmation delay.
+      let availableCoins = 1;
+      let mintedCount = 0;
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const confirmationDelayMs = 50;
+
+      const createStore = async () => {
+        if (availableCoins < 1) {
+          throw new Error(SELECT_AMOUNT_ERROR);
+        }
+        availableCoins -= 1;
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        setTimeout(() => {
+          availableCoins += 1;
+          inFlight -= 1;
+        }, confirmationDelayMs);
+        mintedCount += 1;
+        return `store-${mintedCount}`;
+      };
+
+      const storeTypes = ['orgUid', 'registry', 'dataModelVersion', 'fileStore'];
+      const results = await Promise.all(
+        storeTypes.map((storeType) =>
+          createStoreWithRetryBudget(storeType, {
+            createStore,
+            persistStoreCreated: okPersist,
+            log: noopLog,
+          }),
+        ),
+      );
+
+      expect(results.every((result) => result.success)).to.equal(true);
+      const storeIds = results.map((result) => result.storeId);
+      expect(new Set(storeIds).size).to.equal(4);
+      expect(maxInFlight).to.equal(1);
+    });
+
+    it('retries coin shortages beyond the fixed attempt budget', async function () {
+      let calls = 0;
+      const failuresBeforeSuccess =
+        ORG_CREATION_CONFIG.STORE_CREATE_MAX_ATTEMPTS + 5;
+
+      const createStore = async () => {
+        calls += 1;
+        if (calls <= failuresBeforeSuccess) {
+          throw new Error(MAX_BLOCK_BALANCE_ERROR);
+        }
+        return 'store-after-shortage';
+      };
+
+      const result = await createStoreWithRetryBudget('registry', {
+        createStore,
+        persistStoreCreated: okPersist,
+        log: noopLog,
+      });
+
+      expect(result.success).to.equal(true);
+      expect(result.storeId).to.equal('store-after-shortage');
+      expect(calls).to.equal(failuresBeforeSuccess + 1);
+    });
+
+    it('fails once the coin-shortage deadline is exhausted', async function () {
+      ORG_CREATION_CONFIG.COIN_SHORTAGE_RETRY_DEADLINE_MS = 60;
+      ORG_CREATION_CONFIG.STORE_CREATE_RETRY_DELAY_MS = 25;
+
+      let calls = 0;
+      const createStore = async () => {
+        calls += 1;
+        throw new Error(SELECT_AMOUNT_ERROR);
+      };
+
+      const result = await createStoreWithRetryBudget('registry', {
+        createStore,
+        persistStoreCreated: okPersist,
+        log: noopLog,
+      });
+
+      expect(result.success).to.equal(false);
+      expect(result.error).to.include("Can't select amount");
+      // Slow confirmation past the deadline stops retrying instead of
+      // spinning forever.
+      expect(calls).to.be.at.least(2);
+      expect(calls).to.be.at.most(4);
+    });
+  });
+
+  describe('other error classes', function () {
+    it('keeps the attempt budget for non-coin transient errors', async function () {
+      ORG_CREATION_CONFIG.STORE_CREATE_MAX_ATTEMPTS = 3;
+
+      let calls = 0;
+      const createStore = async () => {
+        calls += 1;
+        throw new Error('Wallet needs to be fully synced');
+      };
+
+      const result = await createStoreWithRetryBudget('registry', {
+        createStore,
+        persistStoreCreated: okPersist,
+        log: noopLog,
+      });
+
+      expect(result.success).to.equal(false);
+      expect(calls).to.equal(3);
+    });
+
+    it('fails immediately when a rejection follows a shortage', async function () {
+      let calls = 0;
+      const createStore = async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error(SELECT_AMOUNT_ERROR);
+        }
+        throw new Error(
+          'Store creation was rejected by the network: minting singleton failed',
+        );
+      };
+
+      const result = await createStoreWithRetryBudget('registry', {
+        createStore,
+        persistStoreCreated: okPersist,
+        log: noopLog,
+      });
+
+      expect(result.success).to.equal(false);
+      expect(result.error).to.include('rejected by the network');
+      expect(calls).to.equal(2);
+    });
+
+    it('fails immediately on non-transient errors', async function () {
+      let calls = 0;
+      const createStore = async () => {
+        calls += 1;
+        throw new Error('boom');
+      };
+
+      const result = await createStoreWithRetryBudget('registry', {
+        createStore,
+        persistStoreCreated: okPersist,
+        log: noopLog,
+      });
+
+      expect(result.success).to.equal(false);
+      expect(result.error).to.equal('boom');
+      expect(calls).to.equal(1);
+    });
+  });
+
+  describe('persistence', function () {
+    it('reports success with the store id even when the incremental persist fails', async function () {
+      const warnings = [];
+
+      const result = await createStoreWithRetryBudget('registry', {
+        createStore: async () => 'store-persist-fail',
+        persistStoreCreated: async () => {
+          throw new Error('SQLITE_BUSY');
+        },
+        log: (message, level) => {
+          if (level === 'warn') {
+            warnings.push(message);
+          }
+        },
+      });
+
+      expect(result.success).to.equal(true);
+      expect(result.storeId).to.equal('store-persist-fail');
+      expect(warnings.some((msg) => msg.includes('final save will reconcile'))).to.equal(
+        true,
+      );
+    });
+  });
+});

--- a/tests/v2/integration/store-creation-retry.spec.js
+++ b/tests/v2/integration/store-creation-retry.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
 import { createStoreWithRetryBudget } from '../../../src/utils/store-creation-retry.js';
-import { ORG_CREATION_CONFIG } from '../../../src/utils/organization-creation-state.js';
+import {
+  ORG_CREATION_CONFIG,
+  getStoreCreationMinTotalMojos,
+} from '../../../src/utils/organization-creation-state.js';
 import wallet from '../../../src/datalayer/wallet.js';
 
 const { isCoinShortageError, isTransientWalletError } = wallet;
@@ -288,6 +291,47 @@ describe('Store creation retry budget', function () {
       );
 
       expect(result.sufficient).to.equal(true);
+    });
+
+    it('budgets one spend per store when mirrors are not configured', function () {
+      const result = getStoreCreationMinTotalMojos(
+        ['orgUid', 'registry', 'dataModelVersion', 'fileStore'],
+        MIN_USABLE_COIN_SIZE,
+        { DATALAYER_FILE_SERVER_URL: null },
+      );
+
+      expect(result).to.equal(4 * MIN_USABLE_COIN_SIZE);
+    });
+
+    it('budgets store and mirror spends when mirror creation uses the wallet', function () {
+      const result = getStoreCreationMinTotalMojos(
+        ['orgUid', 'registry', 'dataModelVersion', 'fileStore'],
+        MIN_USABLE_COIN_SIZE,
+        { DATALAYER_FILE_SERVER_URL: 'https://mirror.example.com' },
+      );
+
+      expect(result).to.equal(8 * MIN_USABLE_COIN_SIZE);
+    });
+
+    it('does not reserve mirror spends in simulator or development mode', function () {
+      for (const appConfig of [
+        {
+          DATALAYER_FILE_SERVER_URL: 'https://mirror.example.com',
+          USE_SIMULATOR: true,
+        },
+        {
+          DATALAYER_FILE_SERVER_URL: 'https://mirror.example.com',
+          USE_DEVELOPMENT_MODE: true,
+        },
+      ]) {
+        const result = getStoreCreationMinTotalMojos(
+          ['orgUid', 'registry'],
+          MIN_USABLE_COIN_SIZE,
+          appConfig,
+        );
+
+        expect(result).to.equal(2 * MIN_USABLE_COIN_SIZE);
+      }
     });
   });
 

--- a/tests/v2/integration/store-creation-retry.spec.js
+++ b/tests/v2/integration/store-creation-retry.spec.js
@@ -128,8 +128,10 @@ describe('Store creation retry budget', function () {
     });
 
     it('fails once the coin-shortage deadline is exhausted', async function () {
-      ORG_CREATION_CONFIG.COIN_SHORTAGE_RETRY_DEADLINE_MS = 60;
-      ORG_CREATION_CONFIG.STORE_CREATE_RETRY_DELAY_MS = 25;
+      // Wide deadline/delay ratio so event-loop lag on a loaded runner
+      // cannot flake the lower bound.
+      ORG_CREATION_CONFIG.COIN_SHORTAGE_RETRY_DEADLINE_MS = 200;
+      ORG_CREATION_CONFIG.STORE_CREATE_RETRY_DELAY_MS = 50;
 
       let calls = 0;
       const createStore = async () => {
@@ -148,7 +150,7 @@ describe('Store creation retry budget', function () {
       // Slow confirmation past the deadline stops retrying instead of
       // spinning forever.
       expect(calls).to.be.at.least(2);
-      expect(calls).to.be.at.most(4);
+      expect(calls).to.be.at.most(5);
     });
   });
 
@@ -211,6 +213,81 @@ describe('Store creation retry budget', function () {
       expect(result.success).to.equal(false);
       expect(result.error).to.equal('boom');
       expect(calls).to.equal(1);
+    });
+  });
+
+  describe('spendable coin sufficiency', function () {
+    const { evaluateSpendableCoins, MIN_USABLE_COIN_SIZE } = wallet;
+    const coin = (amount, spentHeight = 0) => ({
+      amount,
+      spent_height: spentHeight,
+    });
+
+    it('accepts a single large coin that can fund the whole batch', function () {
+      const result = evaluateSpendableCoins(
+        [coin(10 * MIN_USABLE_COIN_SIZE)],
+        1,
+        MIN_USABLE_COIN_SIZE,
+        4 * MIN_USABLE_COIN_SIZE,
+      );
+
+      expect(result.sufficient).to.equal(true);
+      expect(result.usableCoins).to.have.length(1);
+    });
+
+    it('rejects a single coin that passes the per-coin gate but cannot fund the batch', function () {
+      const result = evaluateSpendableCoins(
+        [coin(MIN_USABLE_COIN_SIZE + 100)],
+        1,
+        MIN_USABLE_COIN_SIZE,
+        4 * MIN_USABLE_COIN_SIZE,
+      );
+
+      expect(result.sufficient).to.equal(false);
+      expect(result.usableCoins).to.have.length(1);
+      expect(result.totalBalance).to.equal(MIN_USABLE_COIN_SIZE + 100);
+    });
+
+    it('accepts several small coins whose combined balance funds the batch', function () {
+      const coins = Array.from({ length: 4 }, () =>
+        coin(MIN_USABLE_COIN_SIZE),
+      );
+      const result = evaluateSpendableCoins(
+        coins,
+        1,
+        MIN_USABLE_COIN_SIZE,
+        4 * MIN_USABLE_COIN_SIZE,
+      );
+
+      expect(result.sufficient).to.equal(true);
+      expect(result.totalBalance).to.equal(4 * MIN_USABLE_COIN_SIZE);
+    });
+
+    it('ignores spent and undersized coins for both gates', function () {
+      const result = evaluateSpendableCoins(
+        [
+          coin(10 * MIN_USABLE_COIN_SIZE, 12345), // spent
+          coin(MIN_USABLE_COIN_SIZE - 1), // below per-coin minimum
+          coin(MIN_USABLE_COIN_SIZE),
+        ],
+        1,
+        MIN_USABLE_COIN_SIZE,
+        0,
+      );
+
+      expect(result.sufficient).to.equal(true);
+      expect(result.usableCoins).to.have.length(1);
+      expect(result.totalBalance).to.equal(MIN_USABLE_COIN_SIZE);
+    });
+
+    it('defaults to no total requirement', function () {
+      const result = evaluateSpendableCoins(
+        [coin(MIN_USABLE_COIN_SIZE)],
+        1,
+        MIN_USABLE_COIN_SIZE,
+      );
+
+      expect(result.sufficient).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- Org creation required 4 spendable coins upfront and timed out when a freshly funded wallet held a single coin. One coin is now enough to start: the parallel store creations already retry transient wallet errors, so scarce coins serialize them, each waiting for the previous spend's change to confirm. With plenty of coins the four creations still run fully in parallel.
- The wallet's real coin-selection errors ("Can't select amount higher than our spendable balance", "greater than max spendable balance in a block", "Not enough coins to create new data layer singleton" — see chia's `coin_selection.py` / `data_layer_wallet.py`) are now classified as retryable coin shortages. The previous "No spendable coins" pattern matches no current chia error; it is retained defensively.
- Coin shortages retry on a **time budget** (15 minutes) instead of a fixed attempt count, since a serialized sequence must survive several block confirmations. Other transient wallet errors keep the attempt budget. The shared `createStoreWithRetryBudget` helper replaces the duplicated v1/v2 retry loops and is also used by the V2-upgrade registry store creation, so the policy is uniform.
- The relaxed gate still requires the wallet's **combined** usable balance to cover every remaining store (new pure `evaluateSpendableCoins` check): a wallet whose single coin funds one store but not four fails fast instead of spending part of the batch and stranding the org with orphaned stores.

## Test plan

- [x] New spec `tests/v2/integration/store-creation-retry.spec.js` (14 tests): shortage classification, sequential fallback with four creations sharing one coin, time-budget retries beyond the attempt budget, deadline exhaustion, attempt budget for non-coin transient errors, persist-failure isolation, and the combined-balance sufficiency gate.
- [x] Full v1 suite: 208 passing. Full v2 suite: 1884 passing.
- [ ] Live API run: freshly faucet-funded wallet (naturally a single coin) successfully creates an org — the sequential fallback and the split-vs-spend race are only exercisable against a real wallet, since simulator mode skips coin management.

## Merge order

Merge this before the coin-management single-loop PR: it removes the hard 4-coin gate that the new 5-minute cadence would otherwise need to satisfy in time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet coin gating and on-chain org creation retry policy; mitigated by combined-balance fail-fast, shared helper, and integration tests, but live wallet timing can still differ from simulator behavior.
> 
> **Overview**
> Org creation no longer blocks on **four separate spendable coins**. The pre-flight gate now requires **one usable coin** plus a **combined balance** that covers every remaining store (and optional mirror spends via `getStoreCreationMinTotalMojos`), so a single freshly funded coin can start creation while under-funded wallets still fail before partial on-chain work.
> 
> **Wallet layer:** `waitForSpendableCoins` adds optional `minTotalMojos` and uses a new pure helper `evaluateSpendableCoins` for per-coin count and total-amount checks. Chia coin-selection failure messages are classified as **coin shortages** (`isCoinShortageError`) and retried on a **15-minute time budget**; other transient wallet errors keep the **10-attempt** budget.
> 
> **Store creation:** Duplicated v1/v2 parallel retry loops are replaced by shared `createStoreWithRetryBudget`, which serializes parallel creations when coins are scarce (retry until change confirms). V2 upgrade registry creation uses the same helper.
> 
> **Tests:** `tests/v2/integration/store-creation-retry.spec.js` covers classification, sequential single-coin behavior, budgets, sufficiency gates, and persist-failure isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4478b83d82a3d68658625ca8d8ce12ab5afdcf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->