### PR TITLE
docs: mark Socket.IO as deprecated and unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,9 @@ npm run create-linux-x64-dist
 
 #### Connecting to Socket.IO
 
+> **Deprecated:** Socket.IO is legacy and unmaintained. It is no longer used and
+> can be skipped in testing and future maintenance.
+
 CADT exposes Socket.IO namespaces at `http://localhost:31310/v1/ws` and `http://localhost:31310/v2/ws`.
 
 After connecting, emit `'/subscribe'` with the feed you want to receive:

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@
 import 'regenerator-runtime/runtime.js';
 import rootRouter, { initializeDatabases } from './routes';
 import http from 'http';
+// DEPRECATED: Socket.IO is legacy and unmaintained; skip in testing/maintenance.
 import { Server } from 'socket.io';
 import { connection } from './websocket';
 import { getConfig } from './utils/config-loader';
@@ -28,6 +29,7 @@ initializeDatabases()
       console.log(`Server listening at http://${bindAddress}:${port}`);
     });
 
+    // DEPRECATED: Socket.IO namespaces — legacy, unmaintained, no longer used.
     const io = new Server(server);
     io.of('/v1/ws').on('connection', connection);
     io.of('/v2/ws').on('connection', connection);

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -1,5 +1,10 @@
 'use strict';
 
+/**
+ * @deprecated Socket.IO is legacy and unmaintained. No longer used; skip in
+ * testing and future maintenance.
+ */
+
 import { Project, Unit, Staging } from './models/index.js';
 import { ProjectV2, UnitV2, StagingV2 } from './models/v2/index.js';
 import { logger } from './config/logger.js';

--- a/tests/resources/updates.spec.js
+++ b/tests/resources/updates.spec.js
@@ -1,3 +1,4 @@
+// DEPRECATED: Socket.IO is legacy and unmaintained; skip in testing/maintenance.
 import { assert } from 'chai';
 import { createServer } from 'http';
 import { io as Client } from 'socket.io-client';

--- a/tests/v2/integration/websocket-v2.spec.js
+++ b/tests/v2/integration/websocket-v2.spec.js
@@ -16,6 +16,9 @@ import * as rxjs from 'rxjs';
 /**
  * Phase 29: Websocket Support for V2 Tests
  *
+ * DEPRECATED: Socket.IO is legacy and unmaintained. No longer used; skip in
+ * testing and future maintenance.
+ *
  * Tests for websocket change notifications in V2 models
  */
 describe('Phase 29: Websocket Support for V2 Tests', function () {


### PR DESCRIPTION
## Summary
- Mark Socket.IO as deprecated/legacy in source, tests, and README
- Clarifies it is unmaintained, no longer used, and can be skipped in testing and future maintenance

## Test plan
- [ ] Confirm comments appear in `src/websocket.js`, `src/server.js`, Socket.IO tests, and README
- [ ] No runtime behavior changes expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation-only changes; Socket.IO server behavior is unchanged.
> 
> **Overview**
> Documents that **Socket.IO is legacy, unmaintained, and no longer used**, so integrators and maintainers can treat it as optional and skip related testing.
> 
> Adds matching **deprecation callouts** in the README “Connecting to Socket.IO” section, inline comments in `server.js` where Socket.IO is imported and namespaces are registered, a `@deprecated` JSDoc block on `websocket.js`, and header notes on Socket.IO-related test files (`updates.spec.js`, `websocket-v2.spec.js`). **No removal of Socket.IO wiring or test suites** in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6fedea761d7464d98eb7fdaee2a6d99dd2cdc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->