### PR TITLE
fix: stop discarding a pending root on "Key already present"

### DIFF
--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -884,15 +884,16 @@ const pushChangeListToDataLayer = async (
         continue;
       }
 
-      // DataLayer rejects a push with a root already pending before it touches
-      // the tree, and the rejected call stages nothing, so this error means the
-      // key is in the committed tree and the desired end state already holds.
-      // No pending root of ours can be responsible, and discarding one that
-      // appeared since would only destroy a concurrent push's changelist.
+      // A key collision is raised inside DataLayer's writer transaction, and
+      // the pending-root check runs before it, so this error can neither have
+      // staged a root of ours nor have been caused by one. Any root present now
+      // belongs to a concurrent push and would lose its changelist if cleared.
+      // Note the batch is rejected as a unit, so this error does not establish
+      // that the rest of the changelist landed.
       if (data.error && data.error.includes('Key already present')) {
         logger.info(
           `Key already present in datalayer for storeId: ${storeId}. ` +
-            `This indicates the data already exists. Treating as success.`,
+            `Treating as success.`,
         );
         return true;
       }

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -861,9 +861,9 @@ const pushChangeListToDataLayer = async (
         // A first sighting gets the benefit of the doubt, since a concurrent
         // push to this store may still be between staging its root and creating
         // the transaction that publishes it. Count sightings of this error
-        // rather than reading `attempts`, which sibling branches also advance
-        // and which therefore says nothing about how often this store reported
-        // a pending root. Clearing again after that would only repeat the same
+        // rather than reading `attempts`, which a successful clear refunds and
+        // which therefore says nothing about how often this store reported a
+        // pending root. Clearing again after that would only repeat the same
         // gamble, so a push discards at most one root.
         if (
           pendingRootSightings > 1 &&
@@ -884,24 +884,17 @@ const pushChangeListToDataLayer = async (
         continue;
       }
 
+      // DataLayer rejects a push with a root already pending before it touches
+      // the tree, and the rejected call stages nothing, so this error means the
+      // key is in the committed tree and the desired end state already holds.
+      // No pending root of ours can be responsible, and discarding one that
+      // appeared since would only destroy a concurrent push's changelist.
       if (data.error && data.error.includes('Key already present')) {
-        logger.info('Pending root detected, waiting 5 seconds and retrying');
-        const rootsCleared = await clearPendingRoots(storeId);
-
-        if (rootsCleared) {
-          attempts++;
-          await new Promise((resolve) => setTimeout(resolve, 5000));
-          continue; // Retry
-        } else {
-          // If clearing pending roots didn't help, the key already exists in the datalayer
-          // This can happen when trying to INSERT a record that already exists
-          // Treat this as success since the desired end state (record exists) is already achieved
-          logger.info(
-            `Key already present in datalayer for storeId: ${storeId}. ` +
-              `This indicates the data already exists. Treating as success.`,
-          );
-          return true;
-        }
+        logger.info(
+          `Key already present in datalayer for storeId: ${storeId}. ` +
+            `This indicates the data already exists. Treating as success.`,
+        );
+        return true;
       }
 
       // Handle "no change to tree data" error - this means the changelist wouldn't

--- a/src/models/organizations/organizations.model.js
+++ b/src/models/organizations/organizations.model.js
@@ -747,8 +747,7 @@ class Organization extends Model {
    *
    * Interaction with pushChangeListToDataLayer's internal retry loop:
    *  - pushChangeListToDataLayer has its own bounded retry loop, but only
-   *    retries on "Already have a pending root" and "Key already present"
-   *    errors.
+   *    retries on "Already have a pending root" errors.
    *  - The target failure mode here ("Wallet needs to be fully synced")
    *    falls through to the final `return false` after a single attempt.
    *  - Because we've already waited for unconfirmed txs to clear in

--- a/tests/v2/integration/datalayer-push-error-handling.spec.js
+++ b/tests/v2/integration/datalayer-push-error-handling.spec.js
@@ -257,14 +257,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     expect(clearPending.callCount).to.equal(1);
   });
 
-  it('should not let a sibling retry consume the first-sighting grace', async function () {
-    this.timeout(60000);
-
-    sinon.stub(wallet, 'getDLWalletId').resolves('2');
-    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
-
-    // "Key already present" advances the shared attempt counter and clears
-    // pending roots on its own, so the grace period has to survive it.
+  it('should treat "Key already present" as success without discarding a root', async function () {
     const batchUpdate = superagentPostStub.withArgs(
       sinon.match(/batch_update/),
     );
@@ -274,13 +267,46 @@ describe('pushChangeListToDataLayer - error handling', function () {
         error: 'Key already present',
       }),
     );
-    batchUpdate.onCall(1).returns(
+
+    const clearPending = superagentPostStub
+      .withArgs(sinon.match(/clear_pending_roots/))
+      .returns(createSuperagentMock({ success: true }));
+
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+
+    // The key is in the committed tree, so the desired end state already holds.
+    // Any pending root now present belongs to a concurrent push and must
+    // survive: discarding it would destroy that push's changelist.
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(0);
+    expect(batchUpdate.callCount).to.equal(1);
+  });
+
+  it('should treat "Key already present" as success when it follows a pending-root retry', async function () {
+    this.timeout(60000);
+
+    // Settled wallets would let the discard gate fire, so a clear here would be
+    // a real discard rather than a check that happened to fail.
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    // Our root confirms, we retry, and by then a concurrent push has written
+    // our key -- so the retry is the call that reports it already present.
+    const batchUpdate = superagentPostStub.withArgs(
+      sinon.match(/batch_update/),
+    );
+    batchUpdate.onCall(0).returns(
       createSuperagentMock({
         success: false,
         error: 'Already have a pending root waiting for confirmation',
       }),
     );
-    batchUpdate.onCall(2).returns(createSuperagentMock({ success: true }));
+    batchUpdate.onCall(1).returns(
+      createSuperagentMock({
+        success: false,
+        error: 'Key already present',
+      }),
+    );
 
     const clearPending = superagentPostStub
       .withArgs(sinon.match(/clear_pending_roots/))
@@ -289,9 +315,8 @@ describe('pushChangeListToDataLayer - error handling', function () {
     const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
 
     expect(result).to.be.true;
-    // Only the "Key already present" branch cleared; the pending root was on
-    // its first sighting and must have been left alone.
-    expect(clearPending.callCount).to.equal(1);
+    expect(clearPending.callCount).to.equal(0);
+    expect(batchUpdate.callCount).to.equal(2);
   });
 
   it('should leave a pending root alone when only the DataLayer wallet is unsettled', async function () {

--- a/tests/v2/integration/datalayer-push-error-handling.spec.js
+++ b/tests/v2/integration/datalayer-push-error-handling.spec.js
@@ -274,9 +274,8 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
 
-    // The key is in the committed tree, so the desired end state already holds.
-    // Any pending root now present belongs to a concurrent push and must
-    // survive: discarding it would destroy that push's changelist.
+    // clear_pending_roots is stubbed to succeed, so a discard would register
+    // here; zero calls pins that the branch returns without attempting one.
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
     expect(batchUpdate.callCount).to.equal(1);


### PR DESCRIPTION
Stacked on #1726 — review that one first; this PR's diff is its last two commits.

## Problem

When `batch_update` failed with `Key already present`, `pushChangeListToDataLayer` called `clear_pending_roots` and retried:

```js
const rootsCleared = await clearPendingRoots(storeId);
if (rootsCleared) { attempts++; await sleep(5000); continue; }
else { /* treat as success */ return true; }
```

`clear_pending_roots` reports `success` only when a root was actually removed (`data_layer_rpc_api.py`: `success = root is not None`), so the two paths mean:

- **No pending root** — returns `false`, we fall into the `else` and treat the error as success. This is the common case.
- **A pending root existed** — we deleted it, slept 5s, retried, and then returned `true` anyway.

The second path can only be reached by destroying another writer's work. DataLayer raises the *pending root* error before it touches the tree (`data_layer.py`, at the comment `# check before any DL changes`), so a call that got as far as `Key already present` had no `Status.PENDING` root when it started; and the collision is raised inside `db_wrapper.writer()`, which rolls back via savepoint, so that call stages nothing either. Any root present afterwards therefore belongs to a **concurrent push**, and its changelist is lost when we clear it. Concurrent pushes to one store are reachable in practice — `syncDataLayer` is invoked un-awaited against the same org store from several `file-store` paths while staging commits push to `registryId`.

## Fix

Return without clearing. There is no root of ours to clear, and any root that is there must survive.

This also removes an RPC round trip and a 5s sleep from the path, and it means the sibling pending-root branch keeps its full attempt budget, since the two branches can no longer interleave within one call.

## Tests

`tests/v2/integration/datalayer-push-error-handling.spec.js` — 20 passing.

- `should treat "Key already present" as success without discarding a root` — asserts `clear_pending_roots` is never called and no retry occurs.
- `should treat "Key already present" as success when it follows a pending-root retry` — the same error arriving on a later attempt, after a pending-root wait. Wallets are stubbed settled so the discard gate *would* fire, making the assertion a real check rather than one that passes because a wallet lookup failed.

Both fail against the previous code. Replaces the old `should not let a sibling retry consume the first-sighting grace` test, whose scenario (this branch stealing the sibling's grace) is now unreachable.

The pre-existing eslint (15) and prettier (2 files) findings on the touched files are unchanged — verified by re-running both at `HEAD` with the changes stashed.

## Two pre-existing problems this PR deliberately does not change

Both were found while verifying the above. Neither is introduced here, and fixing either changes behaviour beyond this PR's purpose, so they are called out rather than folded in.

**1. `return true` cannot be inferred from this error.** The collision is raised from inside the per-change loop at `data_store.py:1423`, within the `db_wrapper.writer()` opened at :1374 — a savepoint that rolls back on exception. So the *entire* changelist is discarded, not just the colliding entry, while CADT records the push as complete. This matters because CADT's changelists are routinely multi-key and insert-only, with no preceding delete:

```js
const changeList = Object.keys(data).map((key) => ({ action: 'insert', ... }));  // writeService.js:203
```

`upsertDataLayer` prepends a `delete` only `if (homeOrg[key])`, so a key present in DataLayer but missing from the in-memory `homeOrg` collides the same way. Treating that as success is long-standing behaviour and was already the dominant outcome (the `else` branch above), so this PR leaves it in place — but the honest fix is to verify the end state before returning `true`, or to fail closed and let the caller's retry loop own the outcome.

**2. The branch appears unreachable on the Chia version CADT documents.** We match `data.error.includes('Key already present')`, but current Chia raises `KeyAlreadyPresentError(kid)`, which carries a `KeyId` rather than a message, and the RPC layer builds the legacy error string from `str(e.args[0])` (`rpc_errors.py:103`). Executed against the installed `chia_rs`:

```
str(e)       = 'KeyId(7)'
legacy error = 'KeyId(7)'
```

So `data.error` is `"KeyId(1234)"` and the substring never appears in any casing — a case-insensitive match would not help. The old message was removed in `c6d78c38fe`; `git tag --contains` puts its first release at **2.5.7**, and this repo's README installs `chia-blockchain-cli=2.7.2-rc2`. If that is what deployments run, a real collision already falls through to the generic `return false` today, which bounds the severity of (1). Verifying against the deployed node is the next step; matching `data.traceback` on `KeyAlreadyPresentError` is the likely repair.