### PR TITLE
ci: migrate Windows binary signing from DigiCert to Azure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,9 @@ jobs:
             artifact-name: cadt-windows-x64
             build-command: npm run create-win-x64-dist
             sqlite-path: ./node_modules/sqlite3/build/Release/
+            environment: windows-code-signing
+
+    environment: ${{ matrix.environment }}
 
     steps:
       - name: Checkout Code
@@ -220,27 +223,108 @@ jobs:
         shell: bash
         run: |
           unset HAS_SIGNING_SECRET
+          unset HAS_APPLE_SIGNING_SECRET
 
           if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
+          if [ -n "$APPLE_SIGNING_SECRET" ]; then HAS_APPLE_SIGNING_SECRET='true' ; fi
           echo "HAS_SIGNING_SECRET=${HAS_SIGNING_SECRET}" >> "$GITHUB_OUTPUT"
+          echo "HAS_APPLE_SIGNING_SECRET=${HAS_APPLE_SIGNING_SECRET}" >> "$GITHUB_OUTPUT"
         env:
-          SIGNING_SECRET: "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}"
+          SIGNING_SECRET: "${{ secrets.AZURE_SIGNING_CLIENT_ID }}"
+          APPLE_SIGNING_SECRET: "${{ secrets.APPLE_DEV_ID_APP }}"
 
-      # Windows Code Signing
+      # Windows Code Signing (Azure Artifact Signing)
+      - name: Install Azure Artifact Signing client
+        if: matrix.runs-on == 'windows-latest' && steps.check_secrets.outputs.HAS_SIGNING_SECRET
+        shell: pwsh
+        run: |
+          $toolsDir = Join-Path $env:RUNNER_TEMP "artifact-signing-client"
+          New-Item -ItemType Directory -Path $toolsDir -Force | Out-Null
+          Push-Location $toolsDir
+
+          Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile nuget.exe
+          .\nuget.exe install Microsoft.ArtifactSigning.Client -x -OutputDirectory .
+
+          $dlib = Get-ChildItem -Recurse -Filter "Azure.CodeSigning.Dlib.dll" |
+            Where-Object { $_.FullName -match '[\\/]x64[\\/]' } |
+            Select-Object -First 1
+          if (-not $dlib) {
+            throw "Azure.CodeSigning.Dlib.dll (x64) not found after installing Microsoft.ArtifactSigning.Client"
+          }
+
+          $metadataPath = Join-Path $toolsDir "metadata.json"
+          @{
+            Endpoint = "https://wus2.codesigning.azure.net/"
+            CodeSigningAccountName = "ChiaNetworkInc"
+            CertificateProfileName = "ChiaNetworkInc"
+            CorrelationId = "github-actions-$env:GITHUB_RUN_ID"
+          } | ConvertTo-Json | Set-Content -Path $metadataPath
+
+          Add-Content -Path $env:GITHUB_ENV -Value "AZURE_CODE_SIGNING_DLIB=$($dlib.FullName)"
+          Add-Content -Path $env:GITHUB_ENV -Value "AZURE_CODE_SIGNING_METADATA=$metadataPath"
+
+          Write-Output "dlib=$($dlib.FullName)"
+          Write-Output "metadata=$metadataPath"
+          Get-Content $metadataPath
+          Pop-Location
+
       - name: Sign windows artifacts
         if: matrix.runs-on == 'windows-latest' && steps.check_secrets.outputs.HAS_SIGNING_SECRET
-        uses: chia-network/actions/digicert/windows-sign@main
-        with:
-          sm_certkey_alias: ${{ secrets.SM_CERTKEY_ALIAS }}
-          sm_api_key: ${{ secrets.SM_API_KEY }}
-          sm_client_cert_file_b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
-          sm_client_cert_password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-          sm_code_signing_cert_sha1_hash: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
-          file: ${{ github.workspace }}/dist/cadt.exe
+        shell: pwsh
+        env:
+          # prod chain: EnvironmentCredential / WorkloadIdentity (not Azure CLI).
+          AZURE_TOKEN_CREDENTIALS: prod
+          AZURE_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
+        run: |
+          $env:path = "C:\Program Files (x86)\Windows Kits\10\App Certification Kit;$env:path"
+          $filePath = Join-Path $env:GITHUB_WORKSPACE "dist\cadt.exe"
+
+          # Request a fresh GitHub OIDC token immediately before signing.
+          if (-not $env:ACTIONS_ID_TOKEN_REQUEST_URL -or -not $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN) {
+            throw "ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN not available; ensure permissions.id-token: write is set"
+          }
+          if (-not $env:AZURE_TENANT_ID -or -not $env:AZURE_CLIENT_ID) {
+            throw "AZURE_TENANT_ID and AZURE_CLIENT_ID must be set for AZURE_TOKEN_CREDENTIALS=prod"
+          }
+
+          $tokenUrl = "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=api://AzureADTokenExchange"
+          $headers = @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" }
+          $response = Invoke-RestMethod -Uri $tokenUrl -Headers $headers -Method GET
+          if (-not $response.value) {
+            throw "Failed to obtain GitHub OIDC token for Azure federated credential"
+          }
+
+          $tokenFile = Join-Path $env:RUNNER_TEMP "azure-federated-token"
+          Set-Content -Path $tokenFile -Value $response.value -NoNewline
+          $env:AZURE_FEDERATED_TOKEN_FILE = $tokenFile
+          Write-Output "Wrote Azure federated token to $tokenFile"
+
+          if (-not $env:AZURE_CODE_SIGNING_DLIB -or -not (Test-Path $env:AZURE_CODE_SIGNING_DLIB)) {
+            throw "AZURE_CODE_SIGNING_DLIB is not set or does not exist: $env:AZURE_CODE_SIGNING_DLIB"
+          }
+          if (-not $env:AZURE_CODE_SIGNING_METADATA -or -not (Test-Path $env:AZURE_CODE_SIGNING_METADATA)) {
+            throw "AZURE_CODE_SIGNING_METADATA is not set or does not exist: $env:AZURE_CODE_SIGNING_METADATA"
+          }
+
+          Write-Output "Signing $filePath"
+          signtool.exe sign /v /fd SHA256 /tr "http://timestamp.acs.microsoft.com" /td SHA256 `
+            /dlib $env:AZURE_CODE_SIGNING_DLIB `
+            /dmdf $env:AZURE_CODE_SIGNING_METADATA `
+            $filePath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Azure Artifact Signing failed for $filePath with exit code $LASTEXITCODE"
+          }
+
+          Write-Output "Verify signature"
+          signtool.exe verify /v /pa $filePath
+          if ($LASTEXITCODE -ne 0) {
+            throw "Signature verification failed for $filePath"
+          }
 
       # Mac .pkg build + sign
       - name: Import Apple installer signing certificate
-        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_SIGNING_SECRET && contains( github.ref, '-rc')
+        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_APPLE_SIGNING_SECRET && contains( github.ref, '-rc')
         uses: Apple-Actions/import-codesign-certs@v7
         with:
           keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
@@ -248,7 +332,7 @@ jobs:
           p12-password: ${{ secrets.APPLE_DEV_ID_INSTALLER_PASS }}
 
       - name: Import Apple Application signing certificate
-        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_SIGNING_SECRET && contains( github.ref, '-rc')
+        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_APPLE_SIGNING_SECRET && contains( github.ref, '-rc')
         uses: Apple-Actions/import-codesign-certs@v7
         with:
           create-keychain: false # Created when importing the first cert
@@ -263,7 +347,7 @@ jobs:
           cp -r ${{ github.workspace }}/dist ${{ github.workspace }}/build-scripts/macos/application
 
       - name: Sign Mac binaries
-        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_SIGNING_SECRET && contains( github.ref, '-rc')
+        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_APPLE_SIGNING_SECRET && contains( github.ref, '-rc')
         run: |
           echo "Signing the binaries"
           codesign -f -s "Developer ID Application: Chia Network Inc." --timestamp --options=runtime --entitlements ${{ github.workspace }}/build-scripts/macos/entitlements.mac.plist ${{ github.workspace }}/build-scripts/macos/application/cadt
@@ -280,7 +364,7 @@ jobs:
           cp ${{ github.workspace }}/build-scripts/macos/target/pkg/CADT-macos-installer-x64.pkg ${{ github.workspace }}/build-scripts/macos/target/ready-to-upload/${{ matrix.artifact-name }}-installer.pkg
 
       - name: Notarize Mac .pkg
-        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_SIGNING_SECRET && contains( github.ref, '-rc')
+        if: startsWith(matrix.runs-on , 'macos') && steps.check_secrets.outputs.HAS_APPLE_SIGNING_SECRET && contains( github.ref, '-rc')
         run: |
           mkdir -p ${{ github.workspace }}/build-scripts/macos/target/pkg-signed
 


### PR DESCRIPTION
## Summary
- Replace DigiCert Signing Manager Windows signing with Azure Artifact Signing (OIDC + `signtool` / dlib), matching [chia-blockchain#21116](https://github.com/Chia-Network/chia-blockchain/pull/21116)
- Run the Windows matrix entry under the `windows-code-signing` environment and gate signing on `AZURE_SIGNING_CLIENT_ID`
- Gate macOS signing/notarization on `APPLE_DEV_ID_APP` instead of the DigiCert secret (required for CADT's multi-OS matrix)

## Test plan
- [ ] Confirm org secrets `AZURE_SIGNING_CLIENT_ID` and `AZURE_SIGNING_TENANT_ID` are available to CADT (and Azure federated credential includes `repo:Chia-Network/cadt:environment:windows-code-signing`)
- [ ] PR build: Windows job skips signing when secrets are unavailable (forks) and still produces `cadt.exe`
- [ ] Tag/RC build: Windows job installs Artifact Signing client, signs `dist/cadt.exe`, and `signtool verify` succeeds
- [ ] Tag/RC build: macOS signing and notarization still run when Apple secrets are present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release signing infrastructure and OIDC/Azure federation; misconfiguration could block signed Windows builds or leave unsigned artifacts, but application runtime code is untouched.
> 
> **Overview**
> **Windows signing** moves from the DigiCert Signing Manager action to **Azure Artifact Signing**: the workflow installs `Microsoft.ArtifactSigning.Client`, configures the Azure dlib/metadata, exchanges a GitHub OIDC token for Azure credentials, then signs `dist/cadt.exe` with `signtool` and verifies the signature.
> 
> The Windows matrix job now uses the **`windows-code-signing`** GitHub environment so Azure secrets and federated auth can be scoped correctly.
> 
> **Secret gating is split** so a multi-OS matrix does not tie macOS to DigiCert: Windows signing still keys off `AZURE_SIGNING_CLIENT_ID`, while macOS sign/notarize steps use a new **`HAS_APPLE_SIGNING_SECRET`** flag from `APPLE_DEV_ID_APP` instead of the shared Windows signing secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3ad921c32775addf0cf996bd94193faf0e18ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->