### PR TITLE
docs: start services before editing the cadt config in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ System recommendation:
    chia init
    ```
 
-1. Use testnet for development work (skip if this is your production setup).
-
-   ```bash
-   chia-tools network switch testneta
-   yq -y -i '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
-   sudo systemctl restart cadt@ubuntu chia-full-node@ubuntu chia-wallet@ubuntu chia-data-layer@ubuntu
-   ```
-
 1. Configure the Datalayer public directory.
 
    ```bash
@@ -79,6 +71,13 @@ System recommendation:
    sudo nginx -t && sudo systemctl restart nginx
    ```
 
+1. Start and enable Chia, CADT, and Nginx.
+
+   ```bash
+   sudo systemctl enable nginx cadt@ubuntu chia-full-node@ubuntu chia-wallet@ubuntu chia-data-layer@ubuntu
+   sudo systemctl start cadt@ubuntu chia-full-node@ubuntu chia-wallet@ubuntu chia-data-layer@ubuntu
+   ```
+
 1. Configure CADT with the Datalayer address.
 
    Please use a domain name if possible instead of the IP address. Replace the `curl` part in `()` with your domain name if you can. Otherwise this will automatically use the IP address. **Note this IP address *MUST* be a static IP**.
@@ -86,6 +85,7 @@ System recommendation:
    ```bash
    DATALAYER_FILE_SERVER_URL="http://$(curl -fsS https://ip.chia.net | tr -d '[:space:]')/data/"
    yq -y -i ".APP.DATALAYER_FILE_SERVER_URL = \"$DATALAYER_FILE_SERVER_URL\"" ~/.chia/mainnet/cadt/config.yaml
+   sudo systemctl restart cadt@ubuntu
    ```
 
 1. Set your API key.
@@ -94,13 +94,15 @@ System recommendation:
 
    ```bash
    KEY=$(openssl rand -hex 10) yq -yi ".V1.CADT_API_KEY = \"$KEY\" | .V2.CADT_API_KEY = \"$KEY\"" ~/.chia/mainnet/cadt/config.yaml
+   sudo systemctl restart cadt@ubuntu
    ```
 
-1. Start and enable Chia, CADT, and Nginx.
+1. Use testnet for development work (skip if this is your production setup).
 
    ```bash
-   sudo systemctl enable nginx cadt@ubuntu chia-full-node@ubuntu chia-wallet@ubuntu chia-data-layer@ubuntu
-   sudo systemctl start cadt@ubuntu chia-full-node@ubuntu chia-wallet@ubuntu chia-data-layer@ubuntu
+   chia-tools network switch testneta
+   yq -y -i '.APP.CHIA_NETWORK = "testnet"' ~/.chia/mainnet/cadt/config.yaml
+   sudo systemctl restart cadt@ubuntu chia-full-node@ubuntu chia-wallet@ubuntu chia-data-layer@ubuntu
    ```
 
 1. Fund your Chia wallet (mainnet only).


### PR DESCRIPTION
## Summary

The Quickstart had three steps that edit `~/.chia/mainnet/cadt/config.yaml` with `yq` before CADT had ever run. CADT creates that file on first run, and the `cadt` deb package ships only `cadt@.service` with no `postinst` that starts it, so nothing created the config between `apt-get install cadt` and the explicit `systemctl start` further down the list. All three `yq` calls would fail on a missing file.

- Move "Start and enable Chia, CADT, and Nginx" ahead of the three config-editing steps.
- Add `sudo systemctl restart cadt@ubuntu` to the Datalayer address and API key steps so each edit takes effect.
- The testnet step keeps its existing full-service restart, unchanged.

This is a reordering only. No step text or command was removed.

## Test plan

- [ ] Read the Quickstart top to bottom and confirm the order is: install → `chia init` → Datalayer directory → Nginx → start and enable → Datalayer address → API key → testnet → fund wallet → monitor.
- [ ] Confirm every step still has its copy-pasteable `bash` block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only reordering and added restart commands; no application code or runtime behavior changes.
> 
> **Overview**
> Reorders the **Quickstart** so `systemctl enable` / `start` for Nginx, CADT, and Chia run **before** any `yq` edits to `~/.chia/mainnet/cadt/config.yaml`. CADT creates that file on first start; the prior order could fail on a fresh install when the config did not exist yet.
> 
> The **testnet** step is moved to after Datalayer URL and API key setup (still with the same full-service restart). **Datalayer address** and **API key** steps now include `sudo systemctl restart cadt@ubuntu` so each change is applied without waiting for later steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b1dcc2b559e28ea7567c31f519c6178ca03f10c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->