### PR TITLE
chore: drop unused chai-http and socket.io-client devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "@yao-pkg/pkg": "^6.21.0",
         "babel-plugin-module-resolver": "^5.0.2",
         "chai": "^6.2.0",
-        "chai-http": "^5.1.2",
         "cross-env": "^10.1.0",
         "eslint": "^10.7.0",
         "eslint-plugin-mocha": "^11.3.0",
@@ -62,7 +61,6 @@
         "prettier": "^3.9.5",
         "semver": "^7.8.5",
         "sinon": "^21.0.1",
-        "socket.io-client": "^4.8.3",
         "supertest": "^7.2.2"
       },
       "engines": {
@@ -3060,13 +3058,6 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
-    "node_modules/@types/cookiejar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
-      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -3106,13 +3097,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/methods": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
-      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -3127,19 +3111,6 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
-      }
-    },
-    "node_modules/@types/superagent": {
-      "version": "8.1.9",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
-      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cookiejar": "^2.1.5",
-        "@types/methods": "^1.1.4",
-        "@types/node": "*",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/triple-beam": {
@@ -4430,25 +4401,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chai-http": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-5.1.2.tgz",
-      "integrity": "sha512-UFup7mUGkkjmi9bGA7F6vfp3lzGQZjtL//CEd+a4C+vlynSv756XHDUK8PoYk/UpTBBXqSghjQaJOUMUxJXNaA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/superagent": "^8.1.7",
-        "charset": "^1.0.1",
-        "cookiejar": "^2.1.4",
-        "is-ip": "^5.0.1",
-        "methods": "^1.1.2",
-        "qs": "^6.12.1",
-        "superagent": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4477,16 +4429,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/charset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
-      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/chokidar": {
@@ -4642,22 +4584,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/clone-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
-      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-regexp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color": {
@@ -4860,19 +4786,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/convert-hrtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
-      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4948,7 +4861,6 @@
       "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -5341,20 +5253,6 @@
       },
       "engines": {
         "node": ">=10.2.0"
-      }
-    },
-    "node_modules/engine.io-client": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
-      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.21.0",
-        "xmlhttprequest-ssl": "~2.1.1"
       }
     },
     "node_modules/engine.io-parser": {
@@ -6269,19 +6167,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/function-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
-      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -6718,19 +6603,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6815,23 +6687,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-ip": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.1.tgz",
-      "integrity": "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6890,19 +6745,6 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
-    },
-    "node_modules/is-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -9231,22 +9073,6 @@
         "ws": "~8.21.0"
       }
     },
-    "node_modules/socket.io-client": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
-      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.4.1",
-        "engine.io-client": "~6.6.1",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
@@ -9573,24 +9399,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/super-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
-      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-regexp": "^3.0.0",
-        "function-timeout": "^0.1.0",
-        "time-span": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -9733,22 +9541,6 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
-    },
-    "node_modules/time-span": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
-      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "convert-hrtime": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
@@ -10339,15 +10131,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@yao-pkg/pkg": "^6.21.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "chai": "^6.2.0",
-    "chai-http": "^5.1.2",
     "cross-env": "^10.1.0",
     "eslint": "^10.7.0",
     "eslint-plugin-mocha": "^11.3.0",
@@ -117,7 +116,6 @@
     "prettier": "^3.9.5",
     "semver": "^7.8.5",
     "sinon": "^21.0.1",
-    "socket.io-client": "^4.8.3",
     "supertest": "^7.2.2"
   },
   "overrides": {


### PR DESCRIPTION
Follow-up to #1745, which deleted the last consumers of both packages.

Based on `test/v1-cleanup-redundant-specs` rather than `v2-rc2`, because the
dependencies are still in use on `v2-rc2` — removing them there would break the
suite. GitHub will retarget this to `v2-rc2` automatically once #1745 merges.
**Merge #1745 first.**

## Why these two

- `chai-http` — only consumer was `tests/utils/request-utils.js`, a helper with
  zero importers. HTTP assertions everywhere else in the suite go through
  `supertest`, which stays.
- `socket.io-client` — only consumer was `tests/resources/updates.spec.js`,
  socket.io library boilerplate that never imported CADT code.

A repo-wide search (excluding `node_modules` and `package-lock.json`) finds no
remaining reference to `chai-http`, `chai.request`, or `socket.io-client`.

The runtime `socket.io` dependency used by `src/server.js` is untouched.

## Lockfile

`npm uninstall --save-dev` produced deletions only — no version churn on any
other package. Sixteen entries drop out, `chai-http` and `socket.io-client` plus
their exclusive transitives:

`@types/cookiejar`, `@types/methods`, `@types/superagent`, `chai-http`,
`charset`, `clone-regexp`, `convert-hrtime`, `engine.io-client`,
`function-timeout`, `ip-regex`, `is-ip`, `is-regexp`, `socket.io-client`,
`super-regex`, `time-span`, `xmlhttprequest-ssl`

## Verification

- `npm ci` from the regenerated lockfile succeeds, so `package.json` and
  `package-lock.json` agree
- `npm run test:v1` — 153 passing, 5 pending
- `npm run test:v2` — 1751 passing
- Both `package.json` and `package-lock.json` parse as valid JSON

## Note

`oss-attribution/attributions.txt` still lists `socket.io-client`, but that file
is a stale generated snapshot — it records both `socket.io` and
`socket.io-client` at 4.5.1 while `package.json` pins `^4.8.3`. It is clearly
regenerated out of band rather than per-PR, so it is left alone here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency cleanup with no runtime or test-code changes; packages had no remaining importers.
> 
> **Overview**
> Removes unused `chai-http` and `socket.io-client` from `devDependencies` after their last consumers were deleted.
> 
> Also drops their exclusive transitive packages from the lockfile. Runtime `socket.io` is unchanged; HTTP tests continue to use `supertest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126dafbdd94b504d9c70e3c78273960c3d7d3854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->