### PR TITLE
fix: redact credential headers from the request log

### DIFF
--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -5,8 +5,30 @@ import os from 'os';
 import path from 'path';
 import packageJson from '../../package.json' with { type: 'json' };
 import { getConfig } from '../utils/config-loader.js';
+import { redactHeaders } from '../utils/log-redaction.js';
 
 const { format, transports, createLogger } = winston;
+
+// Strip credential values from a record's top-level `headers` field before any
+// transport sees it. Only the `info.headers` and `info.metadata.headers` shapes
+// are covered — a header map nested deeper than that still reaches the log
+// stream. Both shapes are handled so this stays correct wherever it sits in the
+// chain relative to format.metadata(), which relocates extra fields under
+// info.metadata.
+const redactSensitiveFields = format((info) => {
+  if (info.headers) {
+    info.headers = redactHeaders(info.headers);
+  }
+  if (info.metadata?.headers) {
+    // Copy rather than assign into info.metadata: when this format runs before
+    // format.metadata(), info.metadata is still the caller's own object.
+    info.metadata = {
+      ...info.metadata,
+      headers: redactHeaders(info.metadata.headers),
+    };
+  }
+  return info;
+});
 
 const getChiaRoot = () => {
   let chiaRoot;
@@ -121,6 +143,7 @@ const createVersionLogger = (version) => {
   const versionLogger = createLogger({
     level: getConfig().APP.LOG_LEVEL || 'info',
     format: format.combine(
+      redactSensitiveFields(),
       logFormat,
       format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
       format.metadata({ fillExcept: ['message', 'level', 'timestamp'] }),

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -20,6 +20,7 @@ import { Organization } from './models';
 import { OrganizationsV2 } from './models/v2/index.js';
 import { logger } from './config/logger.js';
 import { sendReadOnlyError } from './utils/read-only-response.js';
+import { redactHeaders } from './utils/log-redaction.js';
 import { getRateLimitRetryAfterSeconds } from './utils/rate-limit.js';
 import { resolveTrustProxyHops } from './utils/trust-proxy.js';
 import {
@@ -150,7 +151,7 @@ app.use((req, res, next) => {
   logger.verbose(`Received request: ${req.method} ${req.originalUrl}`, {
     method: req.method,
     url: req.originalUrl,
-    headers: req.headers,
+    headers: redactHeaders(req.headers),
     timestamp: new Date().toISOString(),
   });
 

--- a/src/utils/log-redaction.js
+++ b/src/utils/log-redaction.js
@@ -1,0 +1,39 @@
+export const REDACTED = '[REDACTED]';
+
+// Header names whose values must never reach a log transport. Compared
+// lowercased: Node lowercases inbound header names, but header maps built
+// elsewhere in the codebase are not guaranteed to be normalized.
+const SENSITIVE_HEADERS = new Set([
+  'x-api-key',
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'set-cookie',
+]);
+
+/**
+ * Copy a header map with the values of sensitive headers replaced by a
+ * placeholder. The header name is preserved so logs still show that
+ * credentials were supplied.
+ *
+ * Expects a plain object of own enumerable properties, as `req.headers` is.
+ * Containers that hold entries elsewhere (a `Headers` instance, a `Map`) copy
+ * as empty rather than leaking their values.
+ *
+ * @param {Object} headers - Header map, typically `req.headers`.
+ * @returns {Object} Copy safe to log.
+ */
+export const redactHeaders = (headers) => {
+  if (headers == null || typeof headers !== 'object') {
+    return headers;
+  }
+
+  const redacted = {};
+  for (const [name, value] of Object.entries(headers)) {
+    redacted[name] = SENSITIVE_HEADERS.has(name.toLowerCase())
+      ? REDACTED
+      : value;
+  }
+
+  return redacted;
+};

--- a/tests/integration/log-redaction.spec.js
+++ b/tests/integration/log-redaction.spec.js
@@ -1,0 +1,175 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+import { Writable } from 'stream';
+import winston from 'winston';
+import { redactHeaders, REDACTED } from '../../src/utils/log-redaction.js';
+import { logger } from '../../src/config/logger.js';
+import app from '../../src/server';
+
+const API_KEY = 'super-secret-api-key-value';
+
+const attachCapture = (sink) => {
+  const stream = new Writable({
+    write(chunk, encoding, callback) {
+      sink.push(chunk.toString());
+      callback();
+    },
+  });
+
+  const transport = new winston.transports.Stream({
+    stream,
+    level: 'silly',
+    format: winston.format.json(),
+  });
+
+  logger.add(transport);
+  return transport;
+};
+
+describe('redactHeaders', function () {
+  it('replaces the x-api-key value', function () {
+    const redacted = redactHeaders({ 'x-api-key': API_KEY });
+    expect(redacted['x-api-key']).to.equal(REDACTED);
+  });
+
+  it('matches header names case-insensitively', function () {
+    const redacted = redactHeaders({
+      'X-Api-Key': API_KEY,
+      Authorization: 'Bearer t',
+    });
+    expect(redacted['X-Api-Key']).to.equal(REDACTED);
+    expect(redacted.Authorization).to.equal(REDACTED);
+  });
+
+  it('preserves non-sensitive headers', function () {
+    const redacted = redactHeaders({
+      'content-type': 'application/json',
+      'user-agent': 'curl/8.0.0',
+    });
+    expect(redacted['content-type']).to.equal('application/json');
+    expect(redacted['user-agent']).to.equal('curl/8.0.0');
+  });
+
+  it('does not mutate the source header map', function () {
+    const headers = { 'x-api-key': API_KEY };
+    redactHeaders(headers);
+    expect(headers['x-api-key']).to.equal(API_KEY);
+  });
+
+  it('passes through non-object input', function () {
+    expect(redactHeaders(undefined)).to.equal(undefined);
+    expect(redactHeaders(null)).to.equal(null);
+  });
+});
+
+describe('logger credential redaction', function () {
+  let captured;
+  let captureTransport;
+
+  beforeEach(function () {
+    captured = [];
+    captureTransport = attachCapture(captured);
+  });
+
+  afterEach(function () {
+    logger.remove(captureTransport);
+  });
+
+  // The transports in src/config/logger.js are pinned to 'debug', so verbose
+  // records reach the log stream regardless of APP.LOG_LEVEL.
+  it('keeps an api key out of a verbose record carrying headers', function () {
+    logger.verbose('Received request: GET /v1/projects', {
+      method: 'GET',
+      headers: { 'x-api-key': API_KEY, 'content-type': 'application/json' },
+    });
+
+    const output = captured.join('\n');
+    expect(output).to.not.include(API_KEY);
+    expect(output).to.include(REDACTED);
+    expect(output).to.include('application/json');
+  });
+
+  it('keeps an api key out of records at other levels', function () {
+    const levels = ['error', 'warn', 'info', 'debug', 'silly'];
+    for (const level of levels) {
+      logger[level]('request detail', { headers: { 'x-api-key': API_KEY } });
+    }
+
+    expect(captured).to.have.lengthOf(levels.length);
+    expect(captured.join('\n')).to.not.include(API_KEY);
+  });
+
+  it('redacts a caller-supplied metadata object without mutating it', function () {
+    const callerMetadata = { headers: { 'x-api-key': API_KEY } };
+    logger.info('nested metadata', { metadata: callerMetadata });
+
+    expect(captured.join('\n')).to.not.include(API_KEY);
+    expect(callerMetadata.headers['x-api-key']).to.equal(API_KEY);
+  });
+});
+
+// Records the metadata passed to logger.verbose. Returns an undo function;
+// winston defines the level methods on the logger's prototype, so the patch is
+// removed by deleting the shadowing own property rather than reassigning.
+const recordVerboseCalls = (sink) => {
+  const hadOwnProperty = Object.hasOwn(logger, 'verbose');
+  const original = logger.verbose;
+
+  logger.verbose = function (...args) {
+    sink.push(args[1]);
+    return original.apply(this, args);
+  };
+
+  return () => {
+    if (hadOwnProperty) {
+      logger.verbose = original;
+    } else {
+      delete logger.verbose;
+    }
+  };
+};
+
+describe('request logger', function () {
+  let captured;
+  let captureTransport;
+  let restoreVerbose;
+
+  beforeEach(function () {
+    captured = [];
+    captureTransport = attachCapture(captured);
+    restoreVerbose = null;
+  });
+
+  // Restores in a hook rather than the test body so a timeout, which abandons
+  // the test without running its remaining statements, cannot leave the patched
+  // method installed for sibling tests.
+  afterEach(function () {
+    logger.remove(captureTransport);
+    if (restoreVerbose) {
+      restoreVerbose();
+    }
+  });
+
+  it('does not log the x-api-key sent with a request', async function () {
+    await supertest(app).get('/health').set('x-api-key', API_KEY);
+
+    const output = captured.join('\n');
+    expect(output).to.include('Received request: GET /health');
+    expect(output).to.not.include(API_KEY);
+    expect(output).to.include(REDACTED);
+  });
+
+  // Asserted against the record handed to the logger rather than the emitted
+  // output, so this covers the call site on its own: the logger's redaction
+  // format would otherwise scrub the key even if the middleware passed it in.
+  it('hands the logger a record that is already redacted', async function () {
+    const records = [];
+    restoreVerbose = recordVerboseCalls(records);
+
+    await supertest(app).get('/health').set('x-api-key', API_KEY);
+
+    const requestRecord = records.find((meta) => meta?.headers);
+    expect(requestRecord, 'no request record with headers was logged').to.exist;
+    expect(requestRecord.headers['x-api-key']).to.equal(REDACTED);
+  });
+});


### PR DESCRIPTION
## Problem

The request logger middleware attached the entire inbound header map to its log record:

```js
logger.verbose(`Received request: ${req.method} ${req.originalUrl}`, {
  method: req.method,
  url: req.originalUrl,
  headers: req.headers,   // includes x-api-key
  timestamp: new Date().toISOString(),
});
```

Every authenticated request therefore wrote the plaintext `x-api-key` to
`application-%DATE%.log` and, in production, to stdout — which is what log shippers
forward to aggregators.

`APP.LOG_LEVEL` did not suppress this. In winston 3 a transport's own level overrides
the logger's level rather than being capped by it, and both relevant transports in
`src/config/logger.js` are pinned to `level: 'debug'`, so the `verbose` record was
emitted even at `LOG_LEVEL: info`. Verified against the installed winston 3.19.0: a
transport at `debug` receives `verbose` records while the logger level is `info`.

## Change

- New `src/utils/log-redaction.js` with a `redactHeaders` helper that returns a copy
  with sensitive values replaced by `[REDACTED]`. The header *name* is preserved, so
  logs still show that a credential was supplied.
- `src/middleware.js` passes `redactHeaders(req.headers)` — this closes the leak.
- `src/config/logger.js` adds the same redaction as a winston format at the front of
  the shared chain, so a future record elsewhere that carries a header map is scrubbed
  too. It handles both `info.headers` and `info.metadata.headers` so reordering the
  chain later cannot silently reopen the hole.

### Scope note for reviewers

The redaction set is deliberately wider than `x-api-key`: `authorization`,
`proxy-authorization`, `cookie` and `set-cookie` are also redacted. Since the request
logger logs the full header map on every request, this means those values no longer
appear in verbose request logs or in the log artifacts CI uploads. That is an
intentional trade-off — flagging it in case anyone relies on those fields for auth
debugging.

Redaction covers the top-level `headers` field only; a header map nested deeper in a
log record still reaches the log stream. The limitation is documented in the code.

## Operational follow-up (not addressed by this PR)

Deployments whose logs were already shipped should rotate `CADT_API_KEY` and purge the
existing `application-*.log` files, including the gzipped archives, since the rotated
logs retain 30 days of history.

## Test plan

- [x] New `tests/integration/log-redaction.spec.js`: 10 tests covering the helper, the
      winston format at every log level, non-mutation of caller-supplied objects, and an
      end-to-end request through the app asserting the key never reaches the output.
- [x] Confirmed non-vacuous: reverting the middleware line fails
      `hands the logger a record that is already redacted`; reverting the format fails
      the logger-level tests; reverting the metadata copy fails the non-mutation test.
- [x] `npm run test:v1` — 163 passing, 5 pending
- [x] v2 integration suite — 1751 passing
- [x] `eslint` and `prettier --check` clean on all touched files. Note `src/middleware.js`
      has pre-existing `no-unused-vars` errors and Prettier drift on the base branch;
      both reproduce on the unmodified file and were left alone to keep this diff small.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive logging change that reduces credential exposure; no auth or request-handling logic changes beyond what gets logged.
> 
> **Overview**
> Stops **plaintext API keys and other credentials** from being written to application logs and production stdout on every authenticated request.
> 
> The request logger previously attached the full `req.headers` map to verbose records; with transports pinned to `debug`, those records still shipped even when `APP.LOG_LEVEL` was `info`. This PR adds **`redactHeaders`** in `log-redaction.js` (sensitive names include `x-api-key`, `authorization`, cookies) and uses it in **middleware** at the call site. A **Winston format** at the start of the shared logger chain also scrubs `info.headers` and `info.metadata.headers` so other log sites are covered.
> 
> Header names stay in logs with values replaced by `[REDACTED]`. Redaction applies only to top-level `headers` shapes documented in code. Integration tests cover the helper, all log levels, non-mutation of caller metadata, and end-to-end requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af85c767a8f54667ecd546e104473817575ca07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->