### PR TITLE
fix: remove the 15s floor under every datalayer write

### DIFF
--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -901,7 +901,11 @@ const pushChangeListToDataLayer = async (
           continue;
         }
 
-        await new Promise((resolve) => setTimeout(resolve, pendingRootGraceMs));
+        // Only worth waiting if another attempt remains; on the last sighting the
+        // loop exits immediately and the delay would just postpone the failure.
+        if (attempts < maxAttempts) {
+          await new Promise((resolve) => setTimeout(resolve, pendingRootGraceMs));
+        }
         continue;
       }
 

--- a/src/datalayer/persistance.js
+++ b/src/datalayer/persistance.js
@@ -773,10 +773,19 @@ const getRoots = async (storeIds) => {
   }
 };
 
+// Grace period between pending-root sightings. A concurrent push that has staged a
+// root but has not yet published it is invisible to the wallet check in
+// clearOrphanedPendingRoot, so elapsed time is the only thing keeping its changelist
+// from being discarded. Must stay well inside the maxAttempts budget below.
+const PENDING_ROOT_GRACE_MS = 45000;
+
 const pushChangeListToDataLayer = async (
   storeId,
   changelist,
-  { skipTransactionWait = false } = {},
+  {
+    skipTransactionWait = false,
+    pendingRootGraceMs = PENDING_ROOT_GRACE_MS,
+  } = {},
 ) => {
   let attempts = 0;
   let pendingRootSightings = 0;
@@ -892,7 +901,7 @@ const pushChangeListToDataLayer = async (
           continue;
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 10000));
+        await new Promise((resolve) => setTimeout(resolve, pendingRootGraceMs));
         continue;
       }
 

--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -220,9 +220,12 @@ const waitForAllTransactionsToConfirm = async (startTime = null, maxWaitMs = 180
 
   try {
     const anyUnconfirmed = await hasAnyUnconfirmedTransactions();
-    await new Promise((resolve) => setTimeout(resolve, 15000));
 
     if (anyUnconfirmed) {
+      // Poll interval before re-checking. It must stay inside this branch: a settled wallet
+      // has nothing to wait for, and delaying here puts a 15s floor under every caller.
+      await new Promise((resolve) => setTimeout(resolve, 15000));
+
       const elapsedAfterSleep = Date.now() - startTime;
       if (elapsedAfterSleep > 300000 && elapsedAfterSleep % 60000 < 15000) {
         try {

--- a/tests/v2/integration/datalayer-push-error-handling.spec.js
+++ b/tests/v2/integration/datalayer-push-error-handling.spec.js
@@ -35,6 +35,10 @@ describe('pushChangeListToDataLayer - error handling', function () {
     { action: 'insert', key: '0xabc', value: '0xdef' },
   ];
 
+  // The production grace period between pending-root sightings is measured in tens
+  // of seconds. Shorten it so retry paths don't dominate the suite's runtime.
+  const testOptions = { pendingRootGraceMs: 10 };
+
   beforeEach(function () {
     // Stub wallet so it doesn't actually wait for transactions
     walletWaitStub = sinon.stub(wallet, 'waitForAllTransactionsToConfirm').resolves();
@@ -54,7 +58,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     const mock = createSuperagentMock({ success: true });
     superagentPostStub.returns(mock);
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
   });
@@ -67,7 +71,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     });
     superagentPostStub.returns(mock);
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
   });
@@ -79,7 +83,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     });
     superagentPostStub.returns(mock);
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
   });
@@ -91,7 +95,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     });
     superagentPostStub.returns(mock);
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.false;
   });
@@ -103,7 +107,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     });
     superagentPostStub.returns(mock);
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.false;
   });
@@ -117,7 +121,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     };
     superagentPostStub.returns(mock);
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.false;
   });
@@ -136,7 +140,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
       .onFirstCall().returns(pendingMock)
       .onSecondCall().returns(successMock);
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     // Should have called post twice (initial + retry)
@@ -202,7 +206,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     const { batchUpdate, clearPending } = stubPendingRootThenSuccess();
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(1);
@@ -219,10 +223,32 @@ describe('pushChangeListToDataLayer - error handling', function () {
     // concurrent-push case that must not lose data.
     const { clearPending } = stubPendingRootThenSuccess({ succeedOnCall: 2 });
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
+  });
+
+  it('should wait the grace period before a pending root can be cleared', async function () {
+    this.timeout(60000);
+
+    sinon.stub(wallet, 'getDLWalletId').resolves('2');
+    sinon.stub(wallet, 'getTransactionHealth').resolves(settledWallet());
+
+    const { clearPending } = stubPendingRootThenSuccess();
+
+    // Elapsed time is the only thing protecting a concurrent push that has staged
+    // a root but not yet published it, so the delay must survive refactoring.
+    const graceMs = 300;
+    const startedAt = Date.now();
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, {
+      pendingRootGraceMs: graceMs,
+    });
+    const elapsed = Date.now() - startedAt;
+
+    expect(result).to.be.true;
+    expect(clearPending.callCount).to.equal(1);
+    expect(elapsed).to.be.at.least(graceMs);
   });
 
   it('should leave a pending root alone while a transaction is still unconfirmed', async function () {
@@ -235,7 +261,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     const { clearPending } = stubPendingRootThenSuccess();
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
@@ -249,7 +275,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     const { clearPending } = stubPendingRootThenSuccess();
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     // A rejected transaction can never confirm the root, so it is not a reason
     // to keep it.
@@ -272,7 +298,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
       .withArgs(sinon.match(/clear_pending_roots/))
       .returns(createSuperagentMock({ success: true }));
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     // clear_pending_roots is stubbed to succeed, so a discard would register
     // here; zero calls pins that the branch returns without attempting one.
@@ -311,7 +337,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
       .withArgs(sinon.match(/clear_pending_roots/))
       .returns(createSuperagentMock({ success: true }));
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
@@ -328,7 +354,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     const { clearPending } = stubPendingRootThenSuccess();
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
@@ -342,7 +368,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     const { clearPending } = stubPendingRootThenSuccess();
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
@@ -358,7 +384,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
 
     const { clearPending } = stubPendingRootThenSuccess();
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(0);
@@ -375,7 +401,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
       succeedOnCall: 99,
     });
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.false;
     expect(clearPending.callCount).to.equal(1);
@@ -394,7 +420,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
       clearSucceeds: false,
     });
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     // Nothing was discarded, so the one-per-push cap does not apply.
@@ -415,7 +441,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     // the push that the clear unblocked still has to be tried.
     clearPending.onCall(3).returns(createSuperagentMock({ success: true }));
 
-    const result = await pushChangeListToDataLayer(testStoreId, testChangelist);
+    const result = await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
 
     expect(result).to.be.true;
     expect(clearPending.callCount).to.equal(4);
@@ -435,7 +461,7 @@ describe('pushChangeListToDataLayer - error handling', function () {
     superagentPostStub.returns(mock);
 
     try {
-      await pushChangeListToDataLayer(testStoreId, testChangelist);
+      await pushChangeListToDataLayer(testStoreId, testChangelist, testOptions);
       expect.fail('Should have thrown a permanent error');
     } catch (error) {
       expect(error.message).to.include('not owned');


### PR DESCRIPTION
## Summary

Governance writes were returning `upstream request timeout` even when the wallet was completely idle. The cause is a sleep in `waitForAllTransactionsToConfirm` that ran on every call, including when there was nothing to wait for:

```js
const anyUnconfirmed = await hasAnyUnconfirmedTransactions();
await new Promise((resolve) => setTimeout(resolve, 15000));
```

The check already happened before the sleep, so the delay protected nothing — it just put a 15 second floor under all 15 call sites. Envoy's default upstream timeout is also 15 seconds, which is why these writes sat exactly on the edge of a 504.

This moves the sleep into the branch that actually polls again. The retry cadence and the overall wait budget are unchanged when transactions are pending; a settled wallet now returns after a single wallet RPC.

## Pending-root grace period

The removed sleep turned out to be load-bearing in one place. In `pushChangeListToDataLayer`, a second "Already have a pending root" sighting authorizes `clearOrphanedPendingRoot`, which discards the store's pending root and its changelist. The first sighting is deliberately forgiven to protect a concurrent push that has staged a root but has not yet published it, and that protection is purely temporal — a staged-but-unpublished root is invisible to any wallet check.

Three of the four delays in that window were `waitForAllTransactionsToConfirm` calls, so the fix above would have shrunk it from roughly 55 seconds to the bare 10 second sleep. The narrowing would also have applied *only* in the settled-wallet case, which is exactly the state that permits the clear.

So the retry loop now owns its grace period explicitly (`PENDING_ROOT_GRACE_MS`, 45s) rather than inheriting it from unrelated wallet timing. It is overridable per call so the test suite does not pay for it.

Two smaller items in the same path:

- The final sighting slept the full grace period and then fell straight out of the loop. Since `pushChangesWhenStoreIsAvailable` retries an exhausted push up to 60 times, that dead wait was paid repeatedly. It is now skipped when no attempts remain.
- The mirror-check sweep previously paid 15 seconds per (org × store) iteration with no throttle of its own. It will now complete far faster, which is the intended effect of the first change.

## Test plan

- [x] `npm run test:v2` — 1752 passing
- [x] `npm run test:v1` — 153 passing, 5 pending
- [x] `npx eslint` on all changed files — no new findings against the pre-existing baseline
- [x] New test `should wait the grace period before a pending root can be cleared` verified as a real regression guard: setting the delay to zero fails it with `expected 9 to be at least 300`
- [x] Before/after control-flow comparison of `waitForAllTransactionsToConfirm`: settled wallet 15040ms to 40ms; unconfirmed case identical at 60160ms and 1804800ms against 60s and 30m budgets

Note that `waitForAllTransactionsToConfirm` returns at its `USE_SIMULATOR` guard under the test config, so no automated test exercises that function's real path in either direction. The timing above was verified separately.

## Notes for the reviewer

Confirmed that no caller holds a mutex or database transaction across `pushChangeListToDataLayer`, so the longer worst case lands only inside retry loops that were already measured in hours.

Unrelated, spotted while testing and left alone: `src/utils/config-loader.js:151` enables simulator mode for *any* value of the `USE_SIMULATOR` env var, so `USE_SIMULATOR=false` turns the simulator on. Also, the timing budget comment at `src/utils/organization-creation-state.js:56` only accounts for the wallet-readiness wait and never counted push internals; the arithmetic it states is still correct but the gap is now wider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing on the DataLayer push and wallet-wait hot path; wrong grace could clear pending roots too early, but behavior is guarded by tests and wallet settlement checks before clear.
> 
> **Overview**
> Fixes governance writes timing out at Envoy’s ~15s upstream limit when the wallet was idle, by **not sleeping** after `hasAnyUnconfirmedTransactions()` returns false in `waitForAllTransactionsToConfirm`. The 15s poll interval now runs only while transactions are still unconfirmed.
> 
> `pushChangeListToDataLayer` no longer relies on that incidental timing for pending-root safety. It introduces **`PENDING_ROOT_GRACE_MS` (45s)** and a **`pendingRootGraceMs`** option, replacing the fixed 10s wait between “pending root” sightings so concurrent staged-but-unpublished roots still get time before `clearOrphanedPendingRoot` can run.
> 
> On the **last** pending-root attempt (no retries left), the grace sleep is skipped so outer retry loops don’t pay a dead delay. Integration tests pass **`pendingRootGraceMs: 10`** and add a test that elapsed time must meet the configured grace before a clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6af0cead5158c7d80685440313ae5d1e27d6e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->