### PR TITLE
fix: write uncaught exceptions and rejections to the application log

### DIFF
--- a/src/config/logger.js
+++ b/src/config/logger.js
@@ -45,11 +45,22 @@ const getChiaRoot = () => {
 
 const chiaRoot = getChiaRoot();
 
+// Crash records carry the raw Error, which may hold circular references (an
+// Express error decorated with req/res is one). Rendering runs inside
+// winston's crash handler, so it must never throw.
+const renderMetadata = (metadata) => {
+  try {
+    return JSON.stringify(metadata);
+  } catch {
+    return '[unserializable metadata]';
+  }
+};
+
 const logFormat = format.printf(
   (info) =>
     `${info.timestamp} [${packageJson.version}] [${info.level}]: ${info.message} ${
       Object.keys(info.metadata || {}).length > 0
-        ? JSON.stringify(info.metadata)
+        ? renderMetadata(info.metadata)
         : ''
     }`,
 );
@@ -66,10 +77,16 @@ const MAX_LOG_FILE_RETENTION = '30d';
  * rotated equivalents, so they don't accumulate unbounded on hosts upgrading
  * across versions.
  *
- *   error.log, combined.log                  -> merged into application-%DATE%.log
- *   exceptions.log, rejections.log           -> merged into their rotated siblings
+ *   error.log, combined.log                  -> superseded by application-%DATE%.log
+ *   exceptions.log, rejections.log           -> superseded by application-%DATE%.log
  *   debug-%DATE%.log{,.gz,.N}                -> application-%DATE%.log now
  *                                               captures debug-level output
+ *   exceptions-%DATE%.log, rejections-%DATE%.log
+ *                                            -> deleted; crash records go to
+ *                                               application-%DATE%.log from
+ *                                               now on. These files were never
+ *                                               written to, so no history is
+ *                                               lost.
  *
  * Runs best-effort: missing files are ignored and per-file failures are
  * collected rather than thrown so a cleanup error never takes down startup.
@@ -104,12 +121,15 @@ const cleanupObsoleteLogFiles = (logDir) => {
     }
   }
 
-  // Orphaned debug-%DATE%.log{,.N,.gz} files from the retired debug transport.
-  const debugPattern = /^debug-.*\.log(\.\d+)?(\.gz)?$/;
+  // Rotated files left behind by retired transports. Anchored to the
+  // YYYY-MM-DD stamp those transports actually produced so an operator's own
+  // exceptions-incident-copy.log is not caught by the sweep.
+  const obsoletePattern =
+    /^(debug|exceptions|rejections)-\d{4}-\d{2}-\d{2}\.log(\.\d+)?(\.gz)?$/;
   try {
     const entries = fs.readdirSync(logDir);
     for (const entry of entries) {
-      if (debugPattern.test(entry)) {
+      if (obsoletePattern.test(entry)) {
         const filePath = path.join(logDir, entry);
         try {
           fs.unlinkSync(filePath);
@@ -140,50 +160,51 @@ const createVersionLogger = (version) => {
 
   const legacyCleanup = cleanupObsoleteLogFiles(logDir);
 
+  // Single rotated application log. Transport-level 'debug' makes this
+  // capture the full debug+verbose+info+warn+error stream regardless of
+  // APP.LOG_LEVEL, matching the behaviour of the previous debug-%DATE%.log
+  // file that this transport replaces.
+  const applicationTransport = new DailyRotateFile({
+    filename: `${logDir}/application-%DATE%.log`,
+    datePattern: 'YYYY-MM-DD',
+    level: 'debug',
+    zippedArchive: true,
+    maxSize: MAX_LOG_FILE_SIZE,
+    maxFiles: MAX_LOG_FILE_RETENTION,
+    utc: true,
+    format: format.combine(format.json()),
+  });
+
+  // Uncaught exceptions and unhandled rejections land in the application log
+  // rather than in dedicated files, so crash records sit in timeline order
+  // alongside the requests that led to them. Registering a handler is also
+  // what installs winston's process-level hooks, which combined with
+  // exitOnError keeps the service alive across them.
+  //
+  // Set after construction on purpose: winston-daily-rotate-file names its
+  // rotation audit after a hash of the constructor options, and the audit is
+  // the only thing maxFiles prunes against. Passing these as options would
+  // orphan the existing audit and strand every current log file on disk.
+  applicationTransport.handleExceptions = true;
+  applicationTransport.handleRejections = true;
+
   const versionLogger = createLogger({
     level: getConfig().APP.LOG_LEVEL || 'info',
+    // No renderer at this level: every transport declares its own format.
+    // A transport added without one writes `undefined` per line, since this
+    // chain produces no rendered message.
     format: format.combine(
       redactSensitiveFields(),
-      logFormat,
       format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-      format.metadata({ fillExcept: ['message', 'level', 'timestamp'] }),
+      // Winston's crash-routing flags. `exception` must stay top-level: it is
+      // what lets a transport without handleExceptions skip crash records.
+      // `rejection` is hoisted alongside it so both stay greppable in the
+      // JSON output.
+      format.metadata({
+        fillExcept: ['message', 'level', 'timestamp', 'exception', 'rejection'],
+      }),
     ),
-    transports: [
-      // Single rotated application log. Transport-level 'debug' makes this
-      // capture the full debug+verbose+info+warn+error stream regardless of
-      // APP.LOG_LEVEL, matching the behaviour of the previous
-      // debug-%DATE%.log file that this transport replaces.
-      new DailyRotateFile({
-        filename: `${logDir}/application-%DATE%.log`,
-        datePattern: 'YYYY-MM-DD',
-        level: 'debug',
-        zippedArchive: true,
-        maxSize: MAX_LOG_FILE_SIZE,
-        maxFiles: MAX_LOG_FILE_RETENTION,
-        utc: true,
-        format: format.combine(format.json()),
-      }),
-    ],
-    exceptionHandlers: [
-      new DailyRotateFile({
-        filename: `${logDir}/exceptions-%DATE%.log`,
-        datePattern: 'YYYY-MM-DD',
-        zippedArchive: true,
-        maxSize: MAX_LOG_FILE_SIZE,
-        maxFiles: MAX_LOG_FILE_RETENTION,
-        utc: true,
-      }),
-    ],
-    rejectionHandlers: [
-      new DailyRotateFile({
-        filename: `${logDir}/rejections-%DATE%.log`,
-        datePattern: 'YYYY-MM-DD',
-        zippedArchive: true,
-        maxSize: MAX_LOG_FILE_SIZE,
-        maxFiles: MAX_LOG_FILE_RETENTION,
-        utc: true,
-      }),
-    ],
+    transports: [applicationTransport],
     exitOnError: false,
   });
 
@@ -195,6 +216,8 @@ const createVersionLogger = (version) => {
           format.prettyPrint(),
           logFormat,
         ),
+        handleExceptions: true,
+        handleRejections: true,
       }),
     );
   } else {
@@ -215,6 +238,8 @@ const createVersionLogger = (version) => {
         level: 'debug',
         stderrLevels: ['error'],
         format: format.combine(format.json()),
+        handleExceptions: true,
+        handleRejections: true,
       }),
     );
   }


### PR DESCRIPTION
## Problem

`exceptions-%DATE%.log` and `rejections-%DATE%.log` have never contained a single byte. On a six-month-old install, all 116 of those files across the v1 and v2 log directories are 0 bytes, while the same crashes appear in the application log by the hundreds (265 `uncaughtException` records in `v1/logs/application-2026-07-30.log` alone).

The cause is the logger-level `format.combine`. `format.metadata({ fillExcept: [...] })` keeps only `message`, `level` and `timestamp` at the top level and moves everything else into a nested `metadata` object — including `exception` and `rejection`, which are the properties winston uses to route crash records. `ExceptionStream._write` and `RejectionStream._write` gate on those exact top-level properties, find nothing, and discard the record.

Because the same relocation defeats the inverse guard in `winston-transport` (`info.exception === true && !this.handleExceptions`), crash records instead fall through to every ordinary transport. Nothing was lost; it was just filed in the wrong place.

A second, latent defect sat in the same `format.combine`: `logFormat` (a `printf`) ran before `format.timestamp()` and `format.metadata()`, so the rendered line began with the literal string `undefined` and never included metadata. It never reached disk, because every transport that actually received records re-derives its own output via `format.json()` or a transport-level `printf`.

## Change

- Keep `exception` and `rejection` top-level in `fillExcept`.
- Remove the `exceptionHandlers` / `rejectionHandlers` blocks. Crash records go to `application-%DATE%.log`, in timeline order alongside the requests that caused them.
- Opt the application log and both console transports into `handleExceptions` / `handleRejections`, so crashes stay visible through `journalctl`, pm2 and docker, and so winston still installs the process-level hooks that keep the service alive under `exitOnError: false`.
- Drop the misplaced `printf` from the logger-level format. Rendering belongs to the transports, which each already declare their own.
- Guard metadata rendering so a circular `Error` (an Express error decorated with `req`/`res`, for example) cannot throw out of the crash handler and kill the process. This was reachable before this change too.
- Extend the existing obsolete-file sweep to remove the orphaned `exceptions-*` / `rejections-*` files, anchored to the `YYYY-MM-DD` stamp the retired transports produced so operator-named files are left alone.

### Note on `handleExceptions` placement

The two flags are assigned to the application transport **after** construction rather than passed as constructor options. `winston-daily-rotate-file` derives its rotation audit filename from a hash of the constructor options, and `maxFiles: '30d'` only prunes files recorded in that audit. Passing the flags as options changes the hash, orphans the existing audit, and leaves every current log file on disk permanently. Verified: the audit filename is identical before and after this change for the same log directory (`.e216ed21a96002ba1ccf135a8f1c84222c3e9308-audit.json`).

## Validation

Exercised the real module via the project's `extensionless` loader with `CHIA_ROOT` pointed at a temporary directory, in both `NODE_ENV=local` and `NODE_ENV=production`:

- Uncaught exceptions and unhandled rejections are recorded in `application-%DATE%.log`, with `"exception":true` at the top level of the JSON line.
- The process keeps logging normally after a crash.
- Crash records remain visible on the console in both dev and production rendering.
- No `undefined` prefix anywhere in the output.
- A circular `Error` no longer terminates the process; previously it exited with code 7 outside production.
- Cleanup sweep: seeded `exceptions-2026-08-01.log`, `rejections-2026-08-01.log`, `exceptions-2026-07-31.log.gz`, `exceptions-2026-07-30.log.1`, `debug-2026-08-01.log` and `exceptions.log` are all removed, while `application-2026-08-01.log`, `exceptions-incident-copy.log` and `debug-notes-from-support.log` are preserved.
- Rotation audit filename unchanged, confirmed by running the pre-change and post-change code against the same directory.

`npx eslint src/config/logger.js` and `npx prettier --check src/config/logger.js` both pass.

## Out of scope

Crash records are logged twice, once by the v1 logger and once by the v2 logger, since each registers its own process hooks. This predates the change and is unaffected by it (176 vs 178 records for the same day in the v1 and v2 application logs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-level crash logging and log file layout—operators must look in application logs for crashes, but behavior aligns with where records were already appearing and reduces risk of silent drops or crash-handler throws.
> 
> **Overview**
> Fixes Winston crash routing so **uncaught exceptions and unhandled rejections** land in **`application-%DATE%.log`** (and on console transports) in timeline order, instead of being dropped by dedicated empty exception/rejection files.
> 
> **Routing:** `exception` and `rejection` stay top-level via `fillExcept`; dedicated `exceptionHandlers` / `rejectionHandlers` transports are removed. The daily-rotate application transport and both console transports opt into `handleExceptions` / `handleRejections` (flags set on the file transport **after** construction so rotation audit hashes and `maxFiles` pruning stay unchanged).
> 
> **Formatting:** Logger-level `logFormat` / misplaced `printf` is removed so transports own rendering; metadata in console `logFormat` uses **`renderMetadata`** so circular error metadata cannot throw inside Winston’s crash handler.
> 
> **Cleanup:** Obsolete-file sweep also removes dated `exceptions-*` / `rejections-*` rotated files (regex anchored to `YYYY-MM-DD` so operator-named copies are not deleted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1285d16f929636dd99f0df6e420e11acdeb6be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->