### PR TITLE
fix: treat USE_SIMULATOR=false as disabling simulator mode

### DIFF
--- a/src/datalayer/wallet.js
+++ b/src/datalayer/wallet.js
@@ -503,9 +503,11 @@ const getWalletBalanceMojos = async () => {
  * @returns {Promise<{success: boolean, error?: string}>} Result of the split operation
  */
 const splitCoins = async (targetCoinId, numberOfCoins, amountPerCoin, fee = 0) => {
-  // Check simulator mode - check both config AND env var directly
-  // (env var check needed because config may be memoized before env var was set)
-  const isSimulator = getWalletConfig().USE_SIMULATOR || process.env.USE_SIMULATOR === 'true';
+  // Env, when set, wins over memoized config so USE_SIMULATOR=false disables.
+  const isSimulator =
+    typeof process.env.USE_SIMULATOR === 'string'
+      ? process.env.USE_SIMULATOR === 'true'
+      : getWalletConfig().USE_SIMULATOR;
   if (isSimulator) {
     logger.info(`[SIMULATOR] Would split coin into ${numberOfCoins} new coins`);
     return { success: true };

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -147,14 +147,18 @@ const loadConfigForVersion = (dataModelVersion) => {
     );
   }
 
-  // Handle USE_SIMULATOR environment variable override
+  // Env override: "true" enables simulator mode; any other set value disables
+  // it. Unset leaves the YAML/default value unchanged.
   if (typeof process.env.USE_SIMULATOR === 'string') {
-    mergedConfig.APP.USE_SIMULATOR = true;
-    mergedConfig.APP.CHIA_NETWORK = 'testnet';
-    if (mergedConfig.APP.TASKS) {
-      mergedConfig.APP.TASKS.AUDIT_SYNC_TASK_INTERVAL = 30;
+    const useSimulator = process.env.USE_SIMULATOR === 'true';
+    mergedConfig.APP.USE_SIMULATOR = useSimulator;
+    if (useSimulator) {
+      mergedConfig.APP.CHIA_NETWORK = 'testnet';
+      if (mergedConfig.APP.TASKS) {
+        mergedConfig.APP.TASKS.AUDIT_SYNC_TASK_INTERVAL = 30;
+      }
+      console.log(`ENV FILE OVERRIDE: RUNNING IN SIMULATOR MODE`);
     }
-    console.log(`ENV FILE OVERRIDE: RUNNING IN SIMULATOR MODE`);
   }
 
   return mergedConfig;

--- a/tests/v2/integration/governance-sync-subscribe-first.spec.js
+++ b/tests/v2/integration/governance-sync-subscribe-first.spec.js
@@ -46,10 +46,8 @@ describe('GovernanceV2.sync subscribe-first ordering', function () {
   });
 
   beforeEach(function () {
-    // The config-loader forces USE_SIMULATOR=true whenever process.env
-    // contains *any* string value for that key (see src/utils/config-loader.js
-    // "Handle USE_SIMULATOR environment variable override").  Delete it so
-    // withConfigOverride({ APP: { USE_SIMULATOR: false } }) actually sticks.
+    // The test runner sets USE_SIMULATOR=true, which still overrides YAML.
+    // Delete it so withConfigOverride({ APP: { USE_SIMULATOR: false } }) sticks.
     originalUseSimulator = process.env.USE_SIMULATOR;
     originalUseDevMode = process.env.USE_DEVELOPMENT_MODE;
     delete process.env.USE_SIMULATOR;

--- a/tests/v2/integration/server-initialization-v2.spec.js
+++ b/tests/v2/integration/server-initialization-v2.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { sequelizeV2 } from '../../../src/database/v2/index.js';
 import { GovernanceV2 } from '../../../src/models/v2/index.js';
 import { pullPickListValuesV2 } from '../../../src/utils/v2-data-loaders.js';
+import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
 
 /**
  * Server Initialization Order Tests
@@ -23,6 +24,11 @@ describe('V2 Server Initialization Order Tests', function () {
   let originalUseSimulator;
   let originalUseDevelopmentMode;
 
+  const clearConfigCaches = () => {
+    getConfig.cache?.clear();
+    getConfigV2.cache?.clear();
+  };
+
   before(async function () {
     // Save original config values
     originalUseSimulator = process.env.USE_SIMULATOR;
@@ -41,6 +47,7 @@ describe('V2 Server Initialization Order Tests', function () {
     } else {
       delete process.env.USE_DEVELOPMENT_MODE;
     }
+    clearConfigCaches();
 
     // Clean up - ensure migrations run so other tests can use the database
     const { prepareV2Db } = await import('../../../src/database/v2/index.js');
@@ -52,6 +59,8 @@ describe('V2 Server Initialization Order Tests', function () {
     // This is the critical test that would catch the original bug
     process.env.USE_SIMULATOR = 'false';
     process.env.USE_DEVELOPMENT_MODE = 'false';
+    clearConfigCaches();
+    expect(getConfig().APP.USE_SIMULATOR).to.equal(false);
 
     // Drop tables to simulate fresh install
     try {
@@ -103,6 +112,8 @@ describe('V2 Server Initialization Order Tests', function () {
 
     process.env.USE_SIMULATOR = 'false';
     process.env.USE_DEVELOPMENT_MODE = 'false';
+    clearConfigCaches();
+    expect(getConfig().APP.USE_SIMULATOR).to.equal(false);
 
     // Simulate the server initialization path:
     // 1. Authenticate
@@ -127,6 +138,8 @@ describe('V2 Server Initialization Order Tests', function () {
     // (simulating a server restart scenario)
     process.env.USE_SIMULATOR = 'true';
     process.env.USE_DEVELOPMENT_MODE = 'false';
+    clearConfigCaches();
+    expect(getConfig().APP.USE_SIMULATOR).to.equal(true);
 
     // Ensure tables exist
     const { prepareV2Db } = await import('../../../src/database/v2/index.js');

--- a/tests/v2/integration/use-simulator-env.spec.js
+++ b/tests/v2/integration/use-simulator-env.spec.js
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as yaml from 'js-yaml';
+
+import TaskManager from '../../../src/tasks/index.js';
+import { getConfig, getConfigV2 } from '../../../src/utils/config-loader.js';
+import { getChiaRoot } from '../../../src/utils/chia-root.js';
+
+describe('USE_SIMULATOR env override', function () {
+  let testChiaRoot;
+  let configFile;
+  let savedUseSimulator;
+  let savedChiaRoot;
+
+  const clearConfigCaches = () => {
+    getChiaRoot.cache?.clear();
+    getConfig.cache?.clear();
+    getConfigV2.cache?.clear();
+  };
+
+  const restoreEnv = (name, saved) => {
+    if (saved === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = saved;
+    }
+  };
+
+  const writeConfig = (app) => {
+    fs.writeFileSync(
+      configFile,
+      yaml.dump({ APP: app, V1: { ENABLE: true }, V2: { ENABLE: true } }),
+      'utf8',
+    );
+    clearConfigCaches();
+  };
+
+  before(function () {
+    TaskManager.stopAll();
+  });
+
+  beforeEach(function () {
+    testChiaRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'cadt-use-simulator-env-'),
+    );
+    fs.mkdirSync(path.join(testChiaRoot, 'cadt'), { recursive: true });
+    configFile = path.join(testChiaRoot, 'cadt', 'config.yaml');
+
+    savedUseSimulator = process.env.USE_SIMULATOR;
+    savedChiaRoot = process.env.CHIA_ROOT;
+    delete process.env.USE_SIMULATOR;
+    process.env.CHIA_ROOT = testChiaRoot;
+    clearConfigCaches();
+  });
+
+  afterEach(function () {
+    fs.rmSync(testChiaRoot, { recursive: true, force: true });
+    restoreEnv('CHIA_ROOT', savedChiaRoot);
+    restoreEnv('USE_SIMULATOR', savedUseSimulator);
+    clearConfigCaches();
+  });
+
+  it('leaves YAML false when the env var is unset', function () {
+    writeConfig({ USE_SIMULATOR: false, CHIA_NETWORK: 'mainnet' });
+
+    expect(getConfig().APP.USE_SIMULATOR).to.equal(false);
+    expect(getConfig().APP.CHIA_NETWORK).to.equal('mainnet');
+  });
+
+  it('leaves YAML true when the env var is unset', function () {
+    writeConfig({ USE_SIMULATOR: true, CHIA_NETWORK: 'mainnet' });
+
+    expect(getConfig().APP.USE_SIMULATOR).to.equal(true);
+    expect(getConfig().APP.CHIA_NETWORK).to.equal('mainnet');
+  });
+
+  it('enables simulator mode only for the string true', function () {
+    writeConfig({ USE_SIMULATOR: false, CHIA_NETWORK: 'mainnet' });
+
+    process.env.USE_SIMULATOR = 'true';
+    clearConfigCaches();
+
+    const app = getConfig().APP;
+    expect(app.USE_SIMULATOR).to.equal(true);
+    expect(app.CHIA_NETWORK).to.equal('testnet');
+  });
+
+  it('does not enable simulator mode for USE_SIMULATOR=false', function () {
+    writeConfig({ USE_SIMULATOR: true, CHIA_NETWORK: 'mainnet' });
+
+    process.env.USE_SIMULATOR = 'false';
+    clearConfigCaches();
+
+    const app = getConfig().APP;
+    expect(app.USE_SIMULATOR).to.equal(false);
+    expect(app.CHIA_NETWORK).to.equal('mainnet');
+  });
+
+  it('treats other set values as false', function () {
+    writeConfig({ USE_SIMULATOR: true, CHIA_NETWORK: 'mainnet' });
+
+    for (const value of ['', '0', 'FALSE', 'yes']) {
+      process.env.USE_SIMULATOR = value;
+      clearConfigCaches();
+      expect(getConfig().APP.USE_SIMULATOR, JSON.stringify(value)).to.equal(
+        false,
+      );
+    }
+  });
+
+  it('applies the same override to the V2 config', function () {
+    writeConfig({ USE_SIMULATOR: true, CHIA_NETWORK: 'mainnet' });
+
+    process.env.USE_SIMULATOR = 'false';
+    clearConfigCaches();
+
+    expect(getConfigV2().APP.USE_SIMULATOR).to.equal(false);
+    expect(getConfigV2().APP.CHIA_NETWORK).to.equal('mainnet');
+  });
+});


### PR DESCRIPTION
## Summary
- Parse `USE_SIMULATOR` as a boolean env override: only the string `true` enables simulator mode; any other set value (including `false`) disables it; unset leaves YAML.
- `docker-compose-example.yml` already sets `USE_SIMULATOR=false`; that now actually turns simulator off instead of on, and no longer forces `CHIA_NETWORK=testnet`.
- `splitCoins` uses the same env contract so a set `false` can disable simulator mode even if config was memoized earlier.

## Test plan
- [x] `tests/v2/integration/use-simulator-env.spec.js` — unset / `true` / `false` / other strings, V1 and V2
- [x] `tests/v2/integration/server-initialization-v2.spec.js` — cache clear so `false` reloads config
- [x] `tests/v2/integration/governance-sync-subscribe-first.spec.js`
- [ ] CI v2 integration tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the app uses simulator vs real wallet/config paths based on environment variables, which can affect production behavior if operators rely on the old “any set value enables” semantics.
> 
> **Overview**
> Fixes **`USE_SIMULATOR` env handling** so only the string **`true`** turns simulator mode on; any other **set** value (including **`false`**) turns it off, and an unset var keeps the YAML/default. That fixes deployments like **`docker-compose-example.yml`**, where **`USE_SIMULATOR=false`** used to force simulator on and **`CHIA_NETWORK=testnet`**.
> 
> In **`config-loader`**, testnet and audit-interval overrides run only when env enables simulator. **`splitCoins`** in **`wallet.js`** uses the same rule so a later **`USE_SIMULATOR=false`** can override memoized config and run the real split RPC.
> 
> Integration tests clear memoized config caches and add **`use-simulator-env.spec.js`** for unset / **`true`** / **`false`** / other strings on V1 and V2 config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de028560a49ae3db544b1586375e9418c86f280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->