### PR TITLE
test(V2): consolidate core resource CRUD tests behind a shared factory

### DIFF
--- a/tests/v2/integration/issuance-v2.spec.js
+++ b/tests/v2/integration/issuance-v2.spec.js
@@ -13,6 +13,7 @@ import {
   getV2HomeOrgId,
   addUuidIfNeeded,
 } from '../utils/v2-test-helpers.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Issuance API - Basic CRUD Tests', function () {
   this.timeout(30000);
@@ -130,47 +131,29 @@ describe('V2 Issuance API - Basic CRUD Tests', function () {
     }));
   });
 
+  runCrudStagingSuite({
+    resource: 'issuance',
+    label: 'Issuance',
+    pk: 'cadTrustIssuanceId',
+    pkColumn: 'cad_trust_issuance_id',
+    missingId: '999999',
+    requiredFields: ['issuanceId', 'cadTrustVerificationId', 'cadTrustProjectMethodologyId'],
+    context: () => ({ testVerification, testProjectMethodology }),
+    validPayload: (ctx) => ({
+      issuanceId: 'TEST-ISSUANCE-001',
+      issuanceDate: '2024-01-01',
+      cadTrustVerificationId: ctx.testVerification.cadTrustVerificationId,
+      cadTrustProjectMethodologyId: ctx.testProjectMethodology.cadTrustProjectMethodologyId,
+    }),
+    expectStagedInsert: (staged, ctx) => {
+      expect(staged.issuance_id).to.equal('TEST-ISSUANCE-001');
+      expect(staged.issuance_date).to.equal('2024-01-01');
+      expect(staged.cad_trust_verification_id).to.equal(ctx.testVerification.cadTrustVerificationId);
+      expect(staged.cad_trust_project_methodology_id).to.equal(ctx.testProjectMethodology.cadTrustProjectMethodologyId);
+    },
+  });
+
   describe('POST /v2/issuance (Create)', function () {
-    it('should create a new issuance record', async function () {
-      const issuanceData = {
-        issuanceId: 'TEST-ISSUANCE-001',
-        issuanceDate: '2024-01-01',
-        cadTrustVerificationId: testVerification.cadTrustVerificationId,
-        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/issuance')
-        .send(issuanceData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body).to.have.property('message');
-      expect(response.body.message).to.equal('Issuance staged successfully');
-      expect(response.body).to.have.property('uuid');
-      expect(response.body).to.have.property('success', true);
-
-      // Verify record was staged
-      expect(response.body).to.have.property('uuid');
-      const stagingRecord = await StagingV2.findOne({
-        where: { uuid: response.body.uuid },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.table).to.equal('issuance');
-      expect(stagingRecord.action).to.equal('INSERT');
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].issuance_id).to.equal('TEST-ISSUANCE-001');
-      expect(stagedData[0].issuance_date).to.equal('2024-01-01');
-      expect(stagedData[0].cad_trust_verification_id).to.equal(testVerification.cadTrustVerificationId);
-      expect(stagedData[0].cad_trust_project_methodology_id).to.equal(testProjectMethodology.cadTrustProjectMethodologyId);
-    });
-
     it('should create issuance with minimal required data', async function () {
       const minimalData = {
         issuanceId: 'MIN-ISSUANCE-001',
@@ -185,52 +168,6 @@ describe('V2 Issuance API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body.uuid).to.exist;
-    });
-
-    // Validation tests
-    it('should reject issuance without required issuanceId', async function () {
-      const invalidData = {
-        cadTrustVerificationId: testVerification.cadTrustVerificationId,
-        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/issuance')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('issuanceId');
-    });
-
-    it('should reject issuance without required cadTrustVerificationId', async function () {
-      const invalidData = {
-        issuanceId: 'MISSING-VERIFICATION-FK',
-        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/issuance')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('cadTrustVerificationId');
-    });
-
-    it('should reject issuance without required cadTrustProjectMethodologyId', async function () {
-      const invalidData = {
-        issuanceId: 'MISSING-PROJECT-METHODOLOGY-FK',
-        cadTrustVerificationId: testVerification.cadTrustVerificationId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/issuance')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('cadTrustProjectMethodologyId');
     });
 
     it('should reject issuance with invalid issuanceDate format', async function () {
@@ -315,92 +252,9 @@ describe('V2 Issuance API - Basic CRUD Tests', function () {
       expect(response.body.success).to.be.true;
     });
 
-    it('should reject issuance with forbidden createdAt field', async function () {
-      const invalidData = {
-        issuanceId: 'FORBIDDEN-FIELD',
-        cadTrustVerificationId: testVerification.cadTrustVerificationId,
-        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
-        createdAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/issuance')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('createdAt');
-    });
-
-    it('should reject issuance with forbidden updatedAt field', async function () {
-      const invalidData = {
-        issuanceId: 'FORBIDDEN-FIELD',
-        cadTrustVerificationId: testVerification.cadTrustVerificationId,
-        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/issuance')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('updatedAt');
-    });
-  });
-
-  describe('GET /v2/issuance (List)', function () {
-    it('should return empty array when no issuances exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/issuance')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-  });
-
-  describe('GET /v2/issuance/:id (Get One)', function () {
-    it('should return 404 for non-existent issuance', async function () {
-      const response = await supertest(app)
-        .get('/v2/issuance/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Issuance not found');
-      expect(response.body.success).to.be.false;
-    });
-  });
-
-  describe('PUT /v2/issuance/:id (Update)', function () {
-    it('should return 404 for non-existent issuance', async function () {
-      const updateData = {
-        issuanceId: 'Updated ID',
-        cadTrustVerificationId: testVerification.cadTrustVerificationId,
-        cadTrustProjectMethodologyId: testProjectMethodology.cadTrustProjectMethodologyId,
-      };
-
-      const response = await supertest(app)
-        .put('/v2/issuance/999999')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.message).to.equal('Issuance not found');
-      expect(response.body.success).to.be.false;
-    });
   });
 
   describe('DELETE /v2/issuance/:id (Delete)', function () {
-    it('should return 404 for non-existent issuance', async function () {
-      const response = await supertest(app)
-        .delete('/v2/issuance/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Issuance not found');
-      expect(response.body.success).to.be.false;
-    });
-
     it('should stage issuance deletion with no children', async function () {
       await waitForV2DataLayerSync();
       const issuance = await IssuanceV2.create(addUuidIfNeeded('IssuanceV2', {

--- a/tests/v2/integration/location-v2.spec.js
+++ b/tests/v2/integration/location-v2.spec.js
@@ -9,6 +9,7 @@ import {
   createV2TestProgramChain,
 } from '../utils/v2-test-helpers.js';
 import { ProgramV2, ProjectV2, LocationV2, IssuanceV2, StagingV2 } from '../../../src/models/v2/index.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Location API - Basic CRUD Tests', function () {
   let testProgram;
@@ -43,27 +44,71 @@ describe('V2 Location API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('POST /v2/location (Create)', function () {
-    it('should create a new location record', async function () {
-      const locationData = {
+  runCrudStagingSuite({
+    resource: 'location',
+    label: 'Location',
+    pk: 'cadTrustLocationId',
+    pkColumn: 'cad_trust_location_id',
+    missingId: '550e8400-e29b-41d4-a716-446655440999',
+    updatedMessage: 'Location updated successfully',
+    deletedMessage: 'Location deleted successfully',
+    requiredFields: [
+      'locationCountry',
+      { field: 'cadTrustProjectId', message: 'cadTrustProjectId" is required' },
+    ],
+    forbiddenFields: [
+      { field: 'createdAt', message: 'createdAt" is not allowed' },
+      { field: 'updatedAt', message: 'updatedAt" is not allowed' },
+    ],
+    context: () => ({ testProject }),
+    validPayload: (ctx) => ({
+      locationCountry: 'Canada',
+      locationRegion: 'British Columbia',
+      locationGis: '{"lat": 49.2827, "lng": -123.1207}',
+      locationMapType: 'geojson',
+      locationMapFileLink: 'https://example.com/map.geojson',
+      cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+    }),
+    expectStagedInsert: (staged, ctx) => {
+      expect(staged.location_country).to.equal('Canada');
+      expect(staged.location_region).to.equal('British Columbia');
+      expect(staged.cad_trust_project_id).to.equal(ctx.testProject.cadTrustProjectId);
+    },
+    list: {
+      seed: (ctx) =>
+        LocationV2.create({
+          cadTrustLocationId: uuidv4(),
+          locationCountry: 'Canada',
+          locationRegion: 'British Columbia',
+          cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+        }),
+      expectRow: (row) => {
+        expect(row.locationCountry).to.equal('Canada');
+        expect(row.locationRegion).to.equal('British Columbia');
+      },
+    },
+    seed: (ctx) =>
+      LocationV2.create({
+        cadTrustLocationId: uuidv4(),
         locationCountry: 'Canada',
         locationRegion: 'British Columbia',
-        locationGis: '{"lat": 49.2827, "lng": -123.1207}',
-        locationMapType: 'geojson',
-        locationMapFileLink: 'https://example.com/map.geojson',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
+        cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+      }),
+    updatePayload: (ctx) => ({
+      locationCountry: 'United States of America',
+      locationRegion: 'Updated Region',
+      locationGis: '{"lat": 50.0, "lng": -120.0}',
+      locationMapType: 'geojson',
+      locationMapFileLink: 'https://example.com/updated-map.geojson',
+      cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+    }),
+    expectStagedUpdate: (staged) => {
+      expect(staged.location_country).to.equal('United States of America');
+      expect(staged.location_region).to.equal('Updated Region');
+    },
+  });
 
-      const response = await supertest(app)
-        .post('/v2/location')
-        .send(locationData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Location staged successfully');
-      expect(response.body).to.have.property('uuid');
-    });
-
+  describe('POST /v2/location (Create)', function () {
     it('should create location with all required data', async function () {
       const locationData = {
         locationCountry: 'Canada',
@@ -77,35 +122,6 @@ describe('V2 Location API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body).to.have.property('uuid');
-    });
-
-    it('should reject location without required locationCountry', async function () {
-      const locationData = {
-        locationRegion: 'British Columbia',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/location')
-        .send(locationData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('locationCountry');
-    });
-
-    it('should reject location without required cadTrustProjectId', async function () {
-      const locationData = {
-        locationCountry: 'Canada',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/location')
-        .send(locationData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('cadTrustProjectId" is required');
     });
 
     it('should reject location with invalid locationMapFileLink format', async function () {
@@ -170,38 +186,6 @@ describe('V2 Location API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body).to.have.property('uuid');
-    });
-
-    it('should reject location with forbidden createdAt field', async function () {
-      const locationData = {
-        locationCountry: 'Canada',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/location')
-        .send(locationData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('createdAt" is not allowed');
-    });
-
-    it('should reject location with forbidden updatedAt field', async function () {
-      const locationData = {
-        locationCountry: 'Canada',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        updatedAt: '2024-01-01T00:00:00.000Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/location')
-        .send(locationData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('updatedAt" is not allowed');
     });
 
     it('should reject location with forbidden cadTrustLocationId field', async function () {
@@ -307,49 +291,7 @@ describe('V2 Location API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('GET /v2/location (List)', function () {
-    it('should return empty array when no locations exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/location')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-
-    it('should return locations from database', async function () {
-      // Create a location directly in database
-      const location = await LocationV2.create({
-        cadTrustLocationId: '550e8400-e29b-41d4-a716-446655440003',
-        locationCountry: 'Canada',
-        locationRegion: 'British Columbia',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      });
-
-      const response = await supertest(app)
-        .get('/v2/location')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(1);
-      expect(response.body.data[0].locationCountry).to.equal('Canada');
-      expect(response.body.data[0].locationRegion).to.equal('British Columbia');
-      // Note: Project association is not included by default - use columns parameter if needed
-    });
-  });
-
   describe('GET /v2/location/:id (Get One)', function () {
-    it('should return 404 for non-existent location', async function () {
-      const response = await supertest(app)
-        .get('/v2/location/550e8400-e29b-41d4-a716-446655440999')
-        .expect(404);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.message).to.equal('Location not found');
-    });
-
     it('should return location by ID', async function () {
       // Create a location directly in database
       const location = await LocationV2.create({
@@ -370,81 +312,7 @@ describe('V2 Location API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('PUT /v2/location/:id (Update)', function () {
-    it('should return 404 for non-existent location', async function () {
-      const updateData = {
-        locationCountry: 'United States of America',
-        locationRegion: 'Updated Region',
-        locationGis: '{"lat": 50.0, "lng": -120.0}',
-        locationMapType: 'geojson',
-        locationMapFileLink: 'https://example.com/updated-map.geojson',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .put('/v2/location/550e8400-e29b-41d4-a716-446655440999')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.message).to.equal('Location not found');
-    });
-
-    it('should stage location update', async function () {
-      // Create a location directly in database
-      const location = await LocationV2.create({
-        cadTrustLocationId: '550e8400-e29b-41d4-a716-446655440005',
-        locationCountry: 'Canada',
-        locationRegion: 'British Columbia',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      });
-
-      const updateData = {
-        locationCountry: 'United States of America',
-        locationRegion: 'Updated Region',
-        locationGis: '{"lat": 50.0, "lng": -120.0}',
-        locationMapType: 'geojson',
-        locationMapFileLink: 'https://example.com/updated-map.geojson',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .put(`/v2/location/${location.cadTrustLocationId}`)
-        .send(updateData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Location updated successfully');
-    });
-  });
-
   describe('DELETE /v2/location/:id (Delete)', function () {
-    it('should return 404 for non-existent location', async function () {
-      const response = await supertest(app)
-        .delete('/v2/location/550e8400-e29b-41d4-a716-446655440999')
-        .expect(404);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.message).to.equal('Location not found');
-    });
-
-    it('should stage location deletion', async function () {
-      // Create a location directly in database
-      const location = await LocationV2.create({
-        cadTrustLocationId: '550e8400-e29b-41d4-a716-446655440006',
-        locationCountry: 'Canada',
-        locationRegion: 'British Columbia',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      });
-
-      const response = await supertest(app)
-        .delete(`/v2/location/${location.cadTrustLocationId}`)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Location deleted successfully');
-    });
-
     it('should return 409 when issuance references location', async function () {
       const chain = await createV2TestProgramChain({ testId: `LOC-REF-${uuidv4().slice(0, 8)}` });
       const location = await LocationV2.create({

--- a/tests/v2/integration/methodology-v2.spec.js
+++ b/tests/v2/integration/methodology-v2.spec.js
@@ -7,10 +7,10 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   resetV2StagingTable,
   resetV2DataTables,
-  waitForV2DataLayerSync,
   createV2TestHomeOrg,
   getV2HomeOrgId,
 } from '../utils/v2-test-helpers.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Methodology API - Basic CRUD Tests', function () {
   this.timeout(30000);
@@ -31,57 +31,67 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
     await resetV2DataTables();
   });
 
+  runCrudStagingSuite({
+    resource: 'methodology',
+    label: 'Methodology',
+    plural: 'methodologies',
+    pk: 'cadTrustMethodologyId',
+    pkColumn: 'cad_trust_methodology_id',
+    missingId: 'non-existent-id',
+    requiredFields: ['methodologyCode', 'methodologyName'],
+    forbiddenFields: [],
+    picklists: [
+      { field: 'methodologyType', invalid: 'InvalidType', valid: 'Avoidance - nature' },
+    ],
+    validPayload: () => ({
+      methodologyCode: 'TEST-METHOD-001',
+      methodologyName: 'Test Methodology',
+      methodologyVersion: '1.0',
+      methodologyDate: '2024-01-01',
+      methodologyLink: 'https://example.com/methodology',
+      methodologyType: 'Avoidance - nature',
+    }),
+    expectStagedInsert: (staged) => {
+      expect(staged.methodology_code).to.equal('TEST-METHOD-001');
+      expect(staged.methodology_name).to.equal('Test Methodology');
+      expect(staged).to.have.property('org_uid');
+      expect(staged.org_uid).to.equal('test-home-org-v2');
+    },
+    list: {
+      seed: () =>
+        MethodologyV2.create({
+          cadTrustMethodologyId: 'test-uuid-123',
+          methodologyCode: 'DB-METHOD-001',
+          methodologyName: 'Database Methodology',
+          methodologyVersion: '2.0',
+        }),
+      expectRow: (row) => {
+        expect(row.methodologyCode).to.equal('DB-METHOD-001');
+        expect(row.methodologyName).to.equal('Database Methodology');
+      },
+    },
+    seed: async () =>
+      MethodologyV2.create({
+        cadTrustMethodologyId: uuidv4(),
+        methodologyCode: 'UPDATE-METHOD-001',
+        methodologyName: 'Original Name',
+        orgUid: await getV2HomeOrgId(),
+      }),
+    updatePayload: () => ({
+      methodologyCode: 'UPDATE-METHOD-001',
+      methodologyName: 'Updated Name',
+      methodologyVersion: '2.0',
+    }),
+    // Omits the required methodologyCode: the 404 only comes back if the
+    // controller looks the record up before validating.
+    notFoundPayload: () => ({ methodologyName: 'Updated Name' }),
+    expectStagedUpdate: (staged) => {
+      expect(staged.methodology_name).to.equal('Updated Name');
+      expect(staged.methodology_version).to.equal('2.0');
+    },
+  });
+
   describe('POST /v2/methodology (Create)', function () {
-        it('should create a new methodology record', async function () {
-          const methodologyData = {
-            methodologyCode: 'TEST-METHOD-001',
-            methodologyName: 'Test Methodology',
-            methodologyVersion: '1.0',
-            methodologyDate: '2024-01-01',
-            methodologyLink: 'https://example.com/methodology',
-            methodologyType: 'Avoidance - nature',
-          };
-
-          const response = await supertest(app)
-            .post('/v2/methodology')
-            .send(methodologyData);
-
-          if (response.status !== 200) {
-            console.log('Error response:', response.body);
-          }
-
-          expect(response.status).to.equal(200);
-          expect(response.body).to.have.property('message');
-          expect(response.body.message).to.equal('Methodology staged successfully');
-          expect(response.body).to.have.property('uuid');
-          expect(response.body).to.have.property('success', true);
-
-          // Verify record was staged
-          expect(response.body).to.have.property('uuid');
-
-
-          const stagingRecord = await StagingV2.findOne({
-
-
-            where: { uuid: response.body.uuid },
-
-
-          });
-
-
-          expect(stagingRecord).to.exist;
-          expect(stagingRecord.table).to.equal('methodology');
-          expect(stagingRecord.action).to.equal('INSERT');
-          expect(stagingRecord.committed).to.be.false;
-
-          // Verify staged data
-          const stagedData = JSON.parse(stagingRecord.data);
-          expect(stagedData[0].methodology_code).to.equal('TEST-METHOD-001');
-          expect(stagedData[0].methodology_name).to.equal('Test Methodology');
-          expect(stagedData[0]).to.have.property('org_uid');
-          expect(stagedData[0].org_uid).to.equal('test-home-org-v2');
-        });
-
         it('should create methodology with minimal data', async function () {
           const minimalData = {
             methodologyCode: 'MIN-001',
@@ -95,35 +105,6 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
 
           expect(response.body.success).to.be.true;
           expect(response.body.uuid).to.exist;
-        });
-
-        // Validation tests
-        it('should reject methodology without required methodologyCode', async function () {
-          const invalidData = {
-            methodologyName: 'Missing Code',
-          };
-
-          const response = await supertest(app)
-            .post('/v2/methodology')
-            .send(invalidData)
-            .expect(400);
-
-          expect(response.body.success).to.be.false;
-          expect(response.body.error).to.include('methodologyCode');
-        });
-
-        it('should reject methodology without required methodologyName', async function () {
-          const invalidData = {
-            methodologyCode: 'MISSING-NAME',
-          };
-
-          const response = await supertest(app)
-            .post('/v2/methodology')
-            .send(invalidData)
-            .expect(400);
-
-          expect(response.body.success).to.be.false;
-          expect(response.body.error).to.include('methodologyName');
         });
 
         it('should reject methodology with invalid methodologyDate format', async function () {
@@ -157,71 +138,9 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
           expect(response.body.success).to.be.false;
           expect(response.body.error).to.include('methodologyLink');
         });
-
-        it('should reject methodology with invalid methodologyType (not in V2 picklist)', async function () {
-          const invalidData = {
-            methodologyCode: 'INV-TYPE',
-            methodologyName: 'Invalid Type',
-            methodologyType: 'InvalidType',
-          };
-
-          const response = await supertest(app)
-            .post('/v2/methodology')
-            .send(invalidData)
-            .expect(400);
-
-          expect(response.body.success).to.be.false;
-          expect(response.body.error).to.include('methodologyType');
-        });
-
-        it('should accept methodology with valid V2 methodologyType', async function () {
-          const validData = {
-            methodologyCode: 'VALID-TYPE',
-            methodologyName: 'Valid Type',
-            methodologyType: 'Avoidance - nature',
-          };
-
-          const response = await supertest(app)
-            .post('/v2/methodology')
-            .send(validData)
-            .expect(200);
-
-          expect(response.body.success).to.be.true;
-          expect(response.body.uuid).to.exist;
-        });
   });
 
   describe('GET /v2/methodology (List)', function () {
-    it('should return empty array when no methodologies exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/methodology')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-
-    it('should return methodologies from database', async function () {
-      // Create a methodology directly in database
-      const methodology = await MethodologyV2.create({
-        cadTrustMethodologyId: 'test-uuid-123',
-        methodologyCode: 'DB-METHOD-001',
-        methodologyName: 'Database Methodology',
-        methodologyVersion: '2.0',
-      });
-
-      const response = await supertest(app)
-        .get('/v2/methodology')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(1);
-      expect(response.body.data[0].methodologyCode).to.equal('DB-METHOD-001');
-      expect(response.body.data[0].methodologyName).to.equal('Database Methodology');
-    });
-
     it('should filter methodologies by orgUid', async function () {
       await MethodologyV2.create({
         cadTrustMethodologyId: 'org-filter-1',
@@ -274,15 +193,6 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
   });
 
   describe('GET /v2/methodology/:id (Get One)', function () {
-    it('should return 404 for non-existent methodology', async function () {
-      const response = await supertest(app)
-        .get('/v2/methodology/non-existent-id')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Methodology not found');
-      expect(response.body.success).to.be.false;
-    });
-
     it('should return methodology by ID', async function () {
       // Create a methodology directly in database
       const methodology = await MethodologyV2.create({
@@ -297,110 +207,6 @@ describe('V2 Methodology API - Basic CRUD Tests', function () {
 
       expect(response.body.methodologyCode).to.equal('GET-METHOD-001');
       expect(response.body.methodologyName).to.equal('Get Test Methodology');
-    });
-  });
-
-  describe('PUT /v2/methodology/:id (Update)', function () {
-    it('should return 404 for non-existent methodology', async function () {
-      const updateData = {
-        methodologyName: 'Updated Name',
-      };
-
-      const response = await supertest(app)
-        .put('/v2/methodology/non-existent-id')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.message).to.equal('Methodology not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage methodology update', async function () {
-      // Create a methodology directly in database
-      const homeOrgId = await getV2HomeOrgId();
-      const methodology = await MethodologyV2.create({
-        methodologyCode: 'UPDATE-METHOD-001',
-        methodologyName: 'Original Name',
-        orgUid: homeOrgId,
-      });
-
-      const updateData = {
-        methodologyCode: 'UPDATE-METHOD-001',
-        methodologyName: 'Updated Name',
-        methodologyVersion: '2.0',
-      };
-
-      const response = await supertest(app)
-        .put(`/v2/methodology/${methodology.cadTrustMethodologyId}`)
-        .send(updateData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-
-      expect(response.body.message).to.equal('Methodology update staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify update was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'methodology',
-          action: 'UPDATE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged update data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_methodology_id).to.equal(methodology.cadTrustMethodologyId);
-      expect(stagedData[0].methodology_name).to.equal('Updated Name');
-      expect(stagedData[0].methodology_version).to.equal('2.0');
-    });
-  });
-
-  describe('DELETE /v2/methodology/:id (Delete)', function () {
-    it('should return 404 for non-existent methodology', async function () {
-      const response = await supertest(app)
-        .delete('/v2/methodology/non-existent-id')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Methodology not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage methodology deletion', async function () {
-      // Create a methodology directly in database
-      const homeOrgId = await getV2HomeOrgId();
-      const methodology = await MethodologyV2.create({
-        cadTrustMethodologyId: 'test-uuid-delete',
-        methodologyCode: 'DELETE-METHOD-001',
-        methodologyName: 'To Be Deleted',
-        orgUid: homeOrgId,
-      });
-
-      const response = await supertest(app)
-        .delete(`/v2/methodology/${methodology.cadTrustMethodologyId}`)
-        .expect(200);
-
-      expect(response.body.message).to.equal('Methodology delete staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify deletion was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'methodology',
-          action: 'DELETE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged deletion data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_methodology_id).to.equal('test-uuid-delete');
     });
   });
 

--- a/tests/v2/integration/program-v2.spec.js
+++ b/tests/v2/integration/program-v2.spec.js
@@ -9,9 +9,8 @@ import {
   resetV2DataTables,
   createV2TestHomeOrg,
   getV2HomeOrgId,
-  waitForV2DataLayerSync,
-  addUuidIfNeeded,
 } from '../utils/v2-test-helpers.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Program API - Basic CRUD Tests', function () {
   this.timeout(30000);
@@ -32,57 +31,64 @@ describe('V2 Program API - Basic CRUD Tests', function () {
     await resetV2DataTables();
   });
 
+  runCrudStagingSuite({
+    resource: 'program',
+    label: 'Program',
+    pk: 'cadTrustProgramId',
+    pkColumn: 'cad_trust_program_id',
+    missingId: '999999',
+    requiredFields: ['programName', 'programRegistry'],
+    validPayload: () => ({
+      programName: 'Test Program',
+      programRegistry: 'Test Registry',
+      programRegistryActivityId: 'ACT-001',
+      programRegistryProgramId: 'PROG-001',
+      programDescription: 'Test program description',
+    }),
+    expectStagedInsert: (staged) => {
+      expect(staged.program_name).to.equal('Test Program');
+      expect(staged.program_registry).to.equal('Test Registry');
+      expect(staged.program_registry_activity_id).to.equal('ACT-001');
+      expect(staged).to.have.property('org_uid');
+      expect(staged.org_uid).to.equal('test-home-org-v2');
+    },
+    list: {
+      seed: () =>
+        ProgramV2.create({
+          cadTrustProgramId: uuidv4(),
+          programName: 'Database Program',
+          programRegistry: 'DB Registry',
+          programRegistryActivityId: 'DB-ACT-001',
+          programRegistryProgramId: 'DB-PROG-001',
+          programDescription: 'Database program description',
+        }),
+      expectRow: (row) => {
+        expect(row.programName).to.equal('Database Program');
+        expect(row.programRegistry).to.equal('DB Registry');
+      },
+    },
+    seed: async () =>
+      ProgramV2.create({
+        cadTrustProgramId: uuidv4(),
+        programName: 'Original Name',
+        programRegistry: 'Original Registry',
+        programRegistryActivityId: 'ORIGINAL-001',
+        orgUid: await getV2HomeOrgId(),
+      }),
+    updatePayload: () => ({
+      programName: 'Updated Name',
+      programRegistry: 'Updated Registry',
+      programRegistryActivityId: 'UPDATED-001',
+      programRegistryProgramId: 'UPDATED-PROG-001',
+      programDescription: 'Updated description',
+    }),
+    expectStagedUpdate: (staged) => {
+      expect(staged.program_name).to.equal('Updated Name');
+      expect(staged.program_registry).to.equal('Updated Registry');
+    },
+  });
+
   describe('POST /v2/program (Create)', function () {
-    it('should create a new program record', async function () {
-      const programData = {
-        programName: 'Test Program',
-        programRegistry: 'Test Registry',
-        programRegistryActivityId: 'ACT-001',
-        programRegistryProgramId: 'PROG-001',
-        programDescription: 'Test program description',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/program')
-        .send(programData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body).to.have.property('message');
-      expect(response.body.message).to.equal('Program staged successfully');
-      expect(response.body).to.have.property('uuid');
-      expect(response.body).to.have.property('success', true);
-
-      // Verify record was staged
-      expect(response.body).to.have.property('uuid');
-
-
-      const stagingRecord = await StagingV2.findOne({
-
-
-        where: { uuid: response.body.uuid },
-
-
-      });
-
-
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.table).to.equal('program');
-      expect(stagingRecord.action).to.equal('INSERT');
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].program_name).to.equal('Test Program');
-      expect(stagedData[0].program_registry).to.equal('Test Registry');
-      expect(stagedData[0].program_registry_activity_id).to.equal('ACT-001');
-      expect(stagedData[0]).to.have.property('org_uid');
-      expect(stagedData[0].org_uid).to.equal('test-home-org-v2');
-    });
-
     it('should create program with minimal required data', async function () {
       const minimalData = {
         programName: 'Minimal Program',
@@ -97,37 +103,6 @@ describe('V2 Program API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body.uuid).to.exist;
-    });
-
-    // Validation tests
-    it('should reject program without required programName', async function () {
-      const invalidData = {
-        programRegistry: 'Missing Name Registry',
-        programRegistryActivityId: 'MISSING-NAME',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/program')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('programName');
-    });
-
-    it('should reject program without required programRegistry', async function () {
-      const invalidData = {
-        programName: 'Missing Registry Program',
-        programRegistryActivityId: 'MISSING-REGISTRY',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/program')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('programRegistry');
     });
 
     it('should reject requests with cadTrustProgramId in create', async function () {
@@ -171,75 +146,9 @@ describe('V2 Program API - Basic CRUD Tests', function () {
       expect(stagedData[0].cad_trust_program_id).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
       expect(stagedData[0].cad_trust_program_id).to.have.length(36);
     });
-
-    it('should reject program with forbidden createdAt field', async function () {
-      const invalidData = {
-        programName: 'Forbidden Field Program',
-        programRegistry: 'FORBIDDEN-FIELD',
-        programRegistryActivityId: 'FORBIDDEN-001',
-        createdAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/program')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('createdAt');
-    });
-
-    it('should reject program with forbidden updatedAt field', async function () {
-      const invalidData = {
-        programName: 'Forbidden Field Program',
-        programRegistry: 'FORBIDDEN-FIELD',
-        programRegistryActivityId: 'FORBIDDEN-002',
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/program')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('updatedAt');
-    });
   });
 
   describe('GET /v2/program (List)', function () {
-    it('should return empty array when no programs exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/program')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-
-    it('should return programs from database', async function () {
-      // Create a program directly in database
-      const program = await ProgramV2.create({
-        cadTrustProgramId: '550e8400-e29b-41d4-a716-446655440001', // Provide explicit UUID
-        programName: 'Database Program',
-        programRegistry: 'DB Registry',
-        programRegistryActivityId: 'DB-ACT-001',
-        programRegistryProgramId: 'DB-PROG-001',
-        programDescription: 'Database program description',
-      });
-
-      const response = await supertest(app)
-        .get('/v2/program')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(1);
-      expect(response.body.data[0].programName).to.equal('Database Program');
-      expect(response.body.data[0].programRegistry).to.equal('DB Registry');
-    });
-
     it('should filter programs by orgUid', async function () {
       await ProgramV2.create({
         cadTrustProgramId: '550e8400-e29b-41d4-a716-446655440010',
@@ -296,15 +205,6 @@ describe('V2 Program API - Basic CRUD Tests', function () {
   });
 
   describe('GET /v2/program/:id (Get One)', function () {
-    it('should return 404 for non-existent program', async function () {
-      const response = await supertest(app)
-        .get('/v2/program/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Program not found');
-      expect(response.body.success).to.be.false;
-    });
-
     it('should return program by ID', async function () {
       // Create a program directly in database
       const program = await ProgramV2.create({
@@ -321,116 +221,6 @@ describe('V2 Program API - Basic CRUD Tests', function () {
       expect(response.body.programName).to.equal('Get Test Program');
       expect(response.body.programRegistry).to.equal('GET Registry');
       expect(response.body.programRegistryActivityId).to.equal('GET-ACT-001');
-    });
-  });
-
-  describe('PUT /v2/program/:id (Update)', function () {
-    it('should return 404 for non-existent program', async function () {
-      const updateData = {
-        programName: 'Updated Name',
-        programRegistry: 'Updated Registry',
-        programRegistryActivityId: 'UPDATED-001',
-      };
-
-      const response = await supertest(app)
-        .put('/v2/program/999999')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.message).to.equal('Program not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage program update', async function () {
-      // Create a program directly in database
-      const homeOrgId = await getV2HomeOrgId();
-      const program = await ProgramV2.create({
-        cadTrustProgramId: '550e8400-e29b-41d4-a716-446655440003', // Provide explicit UUID
-        programName: 'Original Name',
-        programRegistry: 'Original Registry',
-        programRegistryActivityId: 'ORIGINAL-001',
-        orgUid: homeOrgId,
-      });
-
-      const updateData = {
-        programName: 'Updated Name',
-        programRegistry: 'Updated Registry',
-        programRegistryActivityId: 'UPDATED-001',
-        programRegistryProgramId: 'UPDATED-PROG-001',
-        programDescription: 'Updated description',
-      };
-
-      const response = await supertest(app)
-        .put(`/v2/program/${program.cadTrustProgramId}`)
-        .send(updateData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body.message).to.equal('Program update staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify update was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'program',
-          action: 'UPDATE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged update data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_program_id).to.equal(program.cadTrustProgramId);
-      expect(stagedData[0].program_name).to.equal('Updated Name');
-      expect(stagedData[0].program_registry).to.equal('Updated Registry');
-    });
-  });
-
-  describe('DELETE /v2/program/:id (Delete)', function () {
-    it('should return 404 for non-existent program', async function () {
-      const response = await supertest(app)
-        .delete('/v2/program/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Program not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage program deletion', async function () {
-      // Create a program directly in database
-      const homeOrgId = await getV2HomeOrgId();
-      const program = await ProgramV2.create({
-        cadTrustProgramId: '550e8400-e29b-41d4-a716-446655440004', // Provide explicit UUID
-        programName: 'To Be Deleted',
-        programRegistry: 'DELETE Registry',
-        programRegistryActivityId: 'DELETE-001',
-        orgUid: homeOrgId,
-      });
-
-      const response = await supertest(app)
-        .delete(`/v2/program/${program.cadTrustProgramId}`)
-        .expect(200);
-
-      expect(response.body.message).to.equal('Program delete staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify deletion was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'program',
-          action: 'DELETE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged deletion data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_program_id).to.equal(program.cadTrustProgramId);
     });
   });
 

--- a/tests/v2/integration/project-v2.spec.js
+++ b/tests/v2/integration/project-v2.spec.js
@@ -17,6 +17,7 @@ import {
   pauseSchedulerTasks,
   resumeSchedulerTasks,
 } from '../utils/v2-test-helpers.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Project API - Basic CRUD Tests', function () {
   this.timeout(30000);
@@ -63,57 +64,132 @@ describe('V2 Project API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('POST /v2/project (Create)', function () {
-    it('should create a new project record', async function () {
-      const projectData = {
-        projectRegistryName: 'Test Registry',
-        projectId: 'TEST-PROJECT-001',
-        projectCreditingProgram: 'Test Crediting Program',
-        projectName: 'Test Project',
-        projectLink: 'https://example.com/project',
-        projectDescription: 'Test project description',
+  runCrudStagingSuite({
+    resource: 'project',
+    label: 'Project',
+    pk: 'cadTrustProjectId',
+    pkColumn: 'cad_trust_project_id',
+    missingId: '999999',
+    requiredFields: [
+      'projectLink',
+      'projectSector',
+      'projectType',
+      'projectStatus',
+      'projectStatusDate',
+      'projectUnitMetric',
+      'projectRegistryName',
+      'projectId',
+      'projectName',
+    ],
+    picklists: [
+      {
+        field: 'projectSector',
+        invalid: ['InvalidSector'],
+        valid: ['Agriculture'],
+        validTitle: 'should accept project with valid V2 projectSector array',
+      },
+      {
+        field: 'projectType',
+        invalid: ['InvalidType'],
+        valid: ['Landfill gas'],
+        validTitle: 'should accept project with valid V2 projectType array',
+      },
+      { field: 'projectStatus', invalid: 'InvalidStatus', valid: 'Listed' },
+      { field: 'projectUnitMetric', invalid: 'InvalidMetric', valid: 'tCO2e' },
+    ],
+    context: () => ({ testProgram }),
+    validPayload: (ctx) => ({
+      projectRegistryName: 'Test Registry',
+      projectId: 'TEST-PROJECT-001',
+      projectCreditingProgram: 'Test Crediting Program',
+      projectName: 'Test Project',
+      projectLink: 'https://example.com/project',
+      projectDescription: 'Test project description',
+      projectSector: ['Agriculture'],
+      projectType: ['Landfill gas'],
+      projectSubtype: 'Test Subtype',
+      projectStatus: 'Listed',
+      projectStatusDate: '2024-01-01',
+      projectUnitMetric: 'tCO2e',
+      cadTrustReferenceProjectId: 'REF-001',
+      cadTrustProgramId: ctx.testProgram.cadTrustProgramId,
+    }),
+    expectStagedInsert: (staged, ctx) => {
+      expect(staged.project_name).to.equal('Test Project');
+      expect(staged.project_registry_name).to.equal('Test Registry');
+      expect(JSON.parse(staged.project_sector)).to.deep.equal(['Agriculture']);
+      expect(staged.cad_trust_program_id).to.equal(ctx.testProgram.cadTrustProgramId);
+    },
+    list: {
+      title: 'should return projects from database with program association',
+      query: { columns: 'program' },
+      seed: async (ctx) =>
+        ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+          projectRegistryName: 'Database Registry',
+          projectId: 'DB-PROJECT-001',
+          projectName: 'Database Project',
+          projectSector: ['Agriculture'],
+          projectType: ['Landfill gas'],
+          projectStatus: 'Listed',
+          projectUnitMetric: 'tCO2e',
+          cadTrustProgramId: ctx.testProgram.cadTrustProgramId,
+          orgUid: await getV2HomeOrgId(),
+        })),
+      expectRow: (row) => {
+        expect(row.projectName).to.equal('Database Project');
+        expect(row.projectRegistryName).to.equal('Database Registry');
+        expect(row.projectSector).to.deep.equal(['Agriculture']);
+        expect(row.program).to.exist;
+        expect(row.program.programName).to.equal('Test Program for Project');
+        expect(row.program.createdAt).to.exist;
+        expect(row.program.updatedAt).to.exist;
+        expect(row.program).to.not.have.property('created_at');
+        expect(row.program).to.not.have.property('updated_at');
+      },
+    },
+    seed: async () =>
+      ProjectV2.create(addUuidIfNeeded('ProjectV2', {
+        projectRegistryName: 'Original Registry',
+        projectId: 'ORIGINAL-001',
+        projectName: 'Original Name',
         projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectSubtype: 'Test Subtype',
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-        cadTrustReferenceProjectId: 'REF-001',
-        cadTrustProgramId: testProgram.cadTrustProgramId,
-      };
+        orgUid: await getV2HomeOrgId(),
+      })),
+    updatePayload: (ctx) => ({
+      projectRegistryName: 'Updated Registry',
+      projectId: 'UPDATED-001',
+      projectCreditingProgram: 'Updated Crediting Program',
+      projectName: 'Updated Name',
+      projectLink: 'https://example.com/updated',
+      projectDescription: 'Updated description',
+      projectSector: ['Energy industries (renewable-/ non renewable sources)'],
+      projectType: ['Wind'],
+      projectSubtype: 'Updated Subtype',
+      projectStatus: 'Registered',
+      projectStatusDate: '2024-02-01',
+      projectUnitMetric: 'gCO2eq/kWh',
+      cadTrustReferenceProjectId: 'UPDATED-REF-001',
+      cadTrustProgramId: ctx.testProgram.cadTrustProgramId,
+    }),
+    // Omits required fields such as projectLink: the 404 only comes back if the
+    // controller looks the record up before validating.
+    notFoundPayload: () => ({
+      projectRegistryName: 'Updated Registry',
+      projectId: 'UPDATED-001',
+      projectName: 'Updated Name',
+    }),
+    expectStagedUpdate: async (staged, ctx) => {
+      expect(staged.project_name).to.equal('Updated Name');
+      expect(staged.project_registry_name).to.equal('Updated Registry');
+      expect(JSON.parse(staged.project_sector)).to.deep.equal(['Energy industries (renewable-/ non renewable sources)']);
+      expect(staged.cad_trust_program_id).to.equal(ctx.testProgram.cadTrustProgramId);
+      // Verify org_uid is automatically set in update
+      expect(staged).to.have.property('org_uid');
+      expect(staged.org_uid).to.equal(await getV2HomeOrgId());
+    },
+  });
 
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(projectData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body).to.have.property('message');
-      expect(response.body.message).to.equal('Project staged successfully');
-      expect(response.body).to.have.property('uuid');
-      expect(response.body).to.have.property('success', true);
-
-      // Verify record was staged
-      expect(response.body).to.have.property('uuid');
-      const stagingRecord = await StagingV2.findOne({
-        where: { uuid: response.body.uuid },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.table).to.equal('project');
-      expect(stagingRecord.action).to.equal('INSERT');
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].project_name).to.equal('Test Project');
-      expect(stagedData[0].project_registry_name).to.equal('Test Registry');
-      expect(JSON.parse(stagedData[0].project_sector)).to.deep.equal(['Agriculture']);
-      expect(stagedData[0].cad_trust_program_id).to.equal(testProgram.cadTrustProgramId);
-    });
-
+  describe('POST /v2/project (Create)', function () {
     it('should create project with all required data', async function () {
       const minimalData = {
         projectRegistryName: 'Minimal Registry',
@@ -134,178 +210,6 @@ describe('V2 Project API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body.uuid).to.exist;
-    });
-
-    it('should reject project without required projectLink', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-LINK',
-        projectId: 'MISSING-LINK-001',
-        projectName: 'Missing Link Project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectLink');
-    });
-
-    it('should reject project without required projectSector', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-SECTOR',
-        projectId: 'MISSING-SECTOR-001',
-        projectName: 'Missing Sector Project',
-        projectLink: 'https://example.com/project',
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectSector');
-    });
-
-    it('should reject project without required projectType', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-TYPE',
-        projectId: 'MISSING-TYPE-001',
-        projectName: 'Missing Type Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectType');
-    });
-
-    it('should reject project without required projectStatus', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-STATUS',
-        projectId: 'MISSING-STATUS-001',
-        projectName: 'Missing Status Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectStatus');
-    });
-
-    it('should reject project without required projectStatusDate', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-STATUSDATE',
-        projectId: 'MISSING-STATUSDATE-001',
-        projectName: 'Missing StatusDate Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectStatusDate');
-    });
-
-    it('should reject project without required projectUnitMetric', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-UNITMETRIC',
-        projectId: 'MISSING-UNITMETRIC-001',
-        projectName: 'Missing UnitMetric Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectUnitMetric');
-    });
-
-    // Validation tests
-    it('should reject project without required projectRegistryName', async function () {
-      const invalidData = {
-        projectId: 'MISSING-REGISTRY',
-        projectName: 'Missing Registry Project',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectRegistryName');
-    });
-
-    it('should reject project without required projectId', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-ID',
-        projectName: 'Missing ID Project',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectId');
-    });
-
-    it('should reject project without required projectName', async function () {
-      const invalidData = {
-        projectRegistryName: 'MISSING-NAME',
-        projectId: 'MISSING-NAME-001',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectName');
     });
 
     it('should reject project with invalid projectLink format', async function () {
@@ -346,46 +250,6 @@ describe('V2 Project API - Basic CRUD Tests', function () {
       expect(response.body.error).to.include('projectStatusDate');
     });
 
-    // Picklist validation tests
-    it('should reject project with invalid projectSector (not in V2 picklist)', async function () {
-      const invalidData = {
-        projectRegistryName: 'INVALID-SECTOR',
-        projectId: 'INVALID-SECTOR-001',
-        projectName: 'Invalid Sector Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['InvalidSector'],
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectSector');
-    });
-
-    it('should accept project with valid V2 projectSector array', async function () {
-      const validData = {
-        projectRegistryName: 'VALID-SECTOR',
-        projectId: 'VALID-SECTOR-001',
-        projectName: 'Valid Sector Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(validData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-    });
-
     it('should accept project with multiple valid V2 projectSectors', async function () {
       const validData = {
         projectRegistryName: 'VALID-MULTI-SECTOR',
@@ -393,46 +257,6 @@ describe('V2 Project API - Basic CRUD Tests', function () {
         projectName: 'Valid Multi-Sector Project',
         projectLink: 'https://example.com/project',
         projectSector: ['Agriculture', 'Energy demand'],
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(validData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-    });
-
-    it('should reject project with invalid projectType (not in V2 picklist)', async function () {
-      const invalidData = {
-        projectRegistryName: 'INVALID-TYPE',
-        projectId: 'INVALID-TYPE-001',
-        projectName: 'Invalid Type Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['InvalidType'],
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectType');
-    });
-
-    it('should accept project with valid V2 projectType array', async function () {
-      const validData = {
-        projectRegistryName: 'VALID-TYPE',
-        projectId: 'VALID-TYPE-001',
-        projectName: 'Valid Type Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
         projectType: ['Landfill gas'],
         projectStatus: 'Listed',
         projectStatusDate: '2024-01-01',
@@ -455,90 +279,6 @@ describe('V2 Project API - Basic CRUD Tests', function () {
         projectLink: 'https://example.com/project',
         projectSector: ['Agriculture'],
         projectType: ['Landfill gas', 'Solar', 'Wind'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(validData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-    });
-
-    it('should reject project with invalid projectStatus (not in V2 picklist)', async function () {
-      const invalidData = {
-        projectRegistryName: 'INVALID-STATUS',
-        projectId: 'INVALID-STATUS-001',
-        projectName: 'Invalid Status Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Solar'],
-        projectStatus: 'InvalidStatus',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectStatus');
-    });
-
-    it('should accept project with valid V2 projectStatus', async function () {
-      const validData = {
-        projectRegistryName: 'VALID-STATUS',
-        projectId: 'VALID-STATUS-001',
-        projectName: 'Valid Status Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(validData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-    });
-
-    it('should reject project with invalid projectUnitMetric (not in V2 picklist)', async function () {
-      const invalidData = {
-        projectRegistryName: 'INVALID-METRIC',
-        projectId: 'INVALID-METRIC-001',
-        projectName: 'Invalid Metric Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Solar'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'InvalidMetric',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('projectUnitMetric');
-    });
-
-    it('should accept project with valid V2 projectUnitMetric', async function () {
-      const validData = {
-        projectRegistryName: 'VALID-METRIC',
-        projectId: 'VALID-METRIC-001',
-        projectName: 'Valid Metric Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
         projectStatus: 'Listed',
         projectStatusDate: '2024-01-01',
         projectUnitMetric: 'tCO2e',
@@ -599,52 +339,6 @@ describe('V2 Project API - Basic CRUD Tests', function () {
       expect(response.body.success).to.be.true;
     });
 
-    it('should reject project with forbidden createdAt field', async function () {
-      const invalidData = {
-        projectRegistryName: 'FORBIDDEN-FIELD',
-        projectId: 'FORBIDDEN-FIELD-001',
-        projectName: 'Forbidden Field Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Solar'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-        createdAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('createdAt');
-    });
-
-    it('should reject project with forbidden updatedAt field', async function () {
-      const invalidData = {
-        projectRegistryName: 'FORBIDDEN-FIELD',
-        projectId: 'FORBIDDEN-FIELD-002',
-        projectName: 'Forbidden Field Project',
-        projectLink: 'https://example.com/project',
-        projectSector: ['Agriculture'],
-        projectType: ['Solar'],
-        projectStatus: 'Listed',
-        projectStatusDate: '2024-01-01',
-        projectUnitMetric: 'tCO2e',
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/project')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('updatedAt');
-    });
-
     it('should reject project with forbidden orgUid field', async function () {
       const invalidData = {
         projectRegistryName: 'FORBIDDEN-ORGUID',
@@ -703,61 +397,7 @@ describe('V2 Project API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('GET /v2/project (List)', function () {
-    it('should return empty array when no projects exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/project')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-
-    it('should return projects from database with program association', async function () {
-      // Create a project directly in database
-      const homeOrgId = await getV2HomeOrgId();
-      const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
-        projectRegistryName: 'Database Registry',
-        projectId: 'DB-PROJECT-001',
-        projectName: 'Database Project',
-        projectSector: ['Agriculture'],
-        projectType: ['Landfill gas'],
-        projectStatus: 'Listed',
-        projectUnitMetric: 'tCO2e',
-        cadTrustProgramId: testProgram.cadTrustProgramId,
-        orgUid: homeOrgId,
-      }));
-
-      const response = await supertest(app)
-        .get('/v2/project')
-        .query({ page: 1, limit: 10, columns: 'program' })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(1);
-      expect(response.body.data[0].projectName).to.equal('Database Project');
-      expect(response.body.data[0].projectRegistryName).to.equal('Database Registry');
-      expect(response.body.data[0].projectSector).to.deep.equal(['Agriculture']);
-      expect(response.body.data[0].program).to.exist;
-      expect(response.body.data[0].program.programName).to.equal('Test Program for Project');
-      expect(response.body.data[0].program.createdAt).to.exist;
-      expect(response.body.data[0].program.updatedAt).to.exist;
-      expect(response.body.data[0].program).to.not.have.property('created_at');
-      expect(response.body.data[0].program).to.not.have.property('updated_at');
-    });
-  });
-
   describe('GET /v2/project/:id (Get One)', function () {
-    it('should return 404 for non-existent project', async function () {
-      const response = await supertest(app)
-        .get('/v2/project/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Project not found');
-      expect(response.body.success).to.be.false;
-    });
-
     it('should return project by ID with program association', async function () {
       // Create a project directly in database
       const homeOrgId = await getV2HomeOrgId();
@@ -787,85 +427,6 @@ describe('V2 Project API - Basic CRUD Tests', function () {
   });
 
   describe('PUT /v2/project/:id (Update)', function () {
-    it('should return 404 for non-existent project', async function () {
-      const updateData = {
-        projectRegistryName: 'Updated Registry',
-        projectId: 'UPDATED-001',
-        projectName: 'Updated Name',
-      };
-
-      const response = await supertest(app)
-        .put('/v2/project/999999')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.message).to.equal('Project not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage project update', async function () {
-      // Create a project directly in database
-      const homeOrgId = await getV2HomeOrgId();
-      const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
-        projectRegistryName: 'Original Registry',
-        projectId: 'ORIGINAL-001',
-        projectName: 'Original Name',
-        projectSector: ['Agriculture'],
-        orgUid: homeOrgId,
-      }));
-
-      const updateData = {
-        projectRegistryName: 'Updated Registry',
-        projectId: 'UPDATED-001',
-        projectCreditingProgram: 'Updated Crediting Program',
-        projectName: 'Updated Name',
-        projectLink: 'https://example.com/updated',
-        projectDescription: 'Updated description',
-        projectSector: ['Energy industries (renewable-/ non renewable sources)'],
-        projectType: ['Wind'],
-        projectSubtype: 'Updated Subtype',
-        projectStatus: 'Registered',
-        projectStatusDate: '2024-02-01',
-        projectUnitMetric: 'gCO2eq/kWh',
-        cadTrustReferenceProjectId: 'UPDATED-REF-001',
-        cadTrustProgramId: testProgram.cadTrustProgramId,
-      };
-
-      const response = await supertest(app)
-        .put(`/v2/project/${project.cadTrustProjectId}`)
-        .send(updateData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body.message).to.equal('Project update staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify update was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'project',
-          action: 'UPDATE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged update data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_project_id).to.equal(project.cadTrustProjectId);
-      expect(stagedData[0].project_name).to.equal('Updated Name');
-      expect(stagedData[0].project_registry_name).to.equal('Updated Registry');
-      expect(JSON.parse(stagedData[0].project_sector)).to.deep.equal(['Energy industries (renewable-/ non renewable sources)']);
-      expect(stagedData[0].cad_trust_program_id).to.equal(testProgram.cadTrustProgramId);
-      // Verify org_uid is automatically set in update
-      expect(stagedData[0]).to.have.property('org_uid');
-      const actualHomeOrgId = await getV2HomeOrgId();
-      expect(stagedData[0].org_uid).to.equal(actualHomeOrgId);
-    });
-
     it('should reject update for a project owned by another organization', async function () {
       const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
         projectRegistryName: 'Other Registry',
@@ -1027,47 +588,6 @@ describe('V2 Project API - Basic CRUD Tests', function () {
   });
 
   describe('DELETE /v2/project/:id (Delete)', function () {
-    it('should return 404 for non-existent project', async function () {
-      const response = await supertest(app)
-        .delete('/v2/project/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Project not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage project deletion', async function () {
-      // Create a project directly in database
-      const homeOrgId = await getV2HomeOrgId();
-      const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
-        projectRegistryName: 'To Be Deleted',
-        projectId: 'DELETE-001',
-        projectName: 'To Be Deleted Project',
-        orgUid: homeOrgId,
-      }));
-
-      const response = await supertest(app)
-        .delete(`/v2/project/${project.cadTrustProjectId}`)
-        .expect(200);
-
-      expect(response.body.message).to.equal('Project delete staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify deletion was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'project',
-          action: 'DELETE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged deletion data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_project_id).to.equal(project.cadTrustProjectId);
-    });
-
     it('should reject delete for a project owned by another organization', async function () {
       const project = await ProjectV2.create(addUuidIfNeeded('ProjectV2', {
         projectRegistryName: 'Other Registry',

--- a/tests/v2/integration/unit-v2.spec.js
+++ b/tests/v2/integration/unit-v2.spec.js
@@ -16,6 +16,7 @@ import {
   addUuidIfNeeded,
   createV2TestProgramChain,
 } from '../utils/v2-test-helpers.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Unit API - Basic CRUD Tests', function () {
   this.timeout(30000);
@@ -151,46 +152,123 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
     await resetV2StagingTable();
   });
 
-  describe('POST /v2/unit (Create)', function () {
-    it('should create a new unit record', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
+  runCrudStagingSuite({
+    resource: 'unit',
+    label: 'Unit',
+    pk: 'cadTrustUnitId',
+    pkColumn: 'cad_trust_unit_id',
+    missingId: '99999',
+    requiredFields: [
+      'unitCount',
+      'unitType',
+      'unitStatus',
+      'unitStatusReason',
+      'unitMetric',
+      'unitSerialId',
+      'unitStartBlock',
+      'unitEndBlock',
+      'unitVintageYear',
+      'cadTrustIssuanceId',
+    ],
+    forbiddenFields: [
+      { field: 'createdAt', message: 'createdAt" is not allowed' },
+      { field: 'updatedAt', message: 'updatedAt" is not allowed' },
+    ],
+    picklists: [
+      {
+        field: 'unitType',
+        invalid: 'Invalid Unit Type',
+        invalidMessage: 'Unit Type does not include a valid option',
+        valid: 'Avoidance - nature',
+      },
+      {
+        field: 'unitStatus',
+        invalid: 'Invalid Status',
+        invalidMessage: 'Unit Status does not include a valid option',
+        valid: 'Issued',
+      },
+      {
+        field: 'unitMetric',
+        invalid: 'Invalid Metric',
+        invalidMessage: 'Unit Metric does not include a valid option',
+        valid: 'tCO2e',
+      },
+    ],
+    context: () => ({ testIssuance }),
+    validPayload: (ctx) => ({
+      unitSerialId: 'TEST-UNIT-001',
+      unitStartBlock: '1000',
+      unitEndBlock: '2000',
+      unitCount: 100.5,
+      unitType: 'Avoidance - nature',
+      unitVintageYear: 2024,
+      unitStatus: 'Issued',
+      unitStatusReason: 'Issued and active',
+      unitStatusDate: '2024-01-01',
+      unitRetirementDetail: 'Retired for compliance',
+      unitRetirementBeneficiary: 'Test Beneficiary',
+      unitRetirementBeneficiaryId: 'BEN-001',
+      unitLink: 'https://example.com/unit',
+      unitMetric: 'tCO2e',
+      unitCurrentOwner: 'Test Owner',
+      unitItmosReferenceId: 'ITMO-001',
+      cadTrustIssuanceId: ctx.testIssuance.cadTrustIssuanceId,
+    }),
+    list: {
+      seed: async (ctx) =>
+        UnitV2.create(addUuidIfNeeded('UnitV2', {
+          unitSerialId: 'TEST-UNIT-DB-001',
+          unitStartBlock: '1000',
+          unitEndBlock: '2000',
+          unitVintageYear: 2024,
+          cadTrustIssuanceId: ctx.testIssuance.cadTrustIssuanceId,
+          orgUid: await getV2HomeOrgId(),
+        })),
+      expectRow: (row) => {
+        expect(row.unitSerialId).to.equal('TEST-UNIT-DB-001');
+      },
+    },
+    seed: async (ctx) =>
+      UnitV2.create(addUuidIfNeeded('UnitV2', {
+        unitSerialId: 'TEST-UNIT-UPDATE-001',
         unitStartBlock: '1000',
         unitEndBlock: '2000',
-        unitCount: 100.5,
-        unitType: 'Avoidance - nature',
         unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Issued and active',
-        unitStatusDate: '2024-01-01',
-        unitRetirementDetail: 'Retired for compliance',
-        unitRetirementBeneficiary: 'Test Beneficiary',
-        unitRetirementBeneficiaryId: 'BEN-001',
-        unitLink: 'https://example.com/unit',
-        unitMetric: 'tCO2e',
-        unitCurrentOwner: 'Test Owner',
-        unitItmosReferenceId: 'ITMO-001',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
+        cadTrustIssuanceId: ctx.testIssuance.cadTrustIssuanceId,
+        orgUid: await getV2HomeOrgId(),
+      })),
+    updatePayload: (ctx) => ({
+      unitSerialId: 'UPDATED-UNIT-001',
+      unitStartBlock: '1000',
+      unitEndBlock: '2000',
+      unitCount: 100,
+      unitType: 'Avoidance - nature',
+      unitVintageYear: 2024,
+      unitStatus: 'Issued',
+      unitStatusReason: 'Test reason',
+      unitMetric: 'tCO2e',
+      cadTrustIssuanceId: ctx.testIssuance.cadTrustIssuanceId,
+    }),
+    // Omits required fields such as unitCount: the 404 only comes back if the
+    // controller looks the record up before validating.
+    notFoundPayload: (ctx) => ({
+      unitSerialId: 'UPDATED-UNIT-001',
+      unitStartBlock: '1000',
+      unitEndBlock: '2000',
+      unitVintageYear: 2024,
+      cadTrustIssuanceId: ctx.testIssuance.cadTrustIssuanceId,
+    }),
+    expectStagedUpdate: async (staged) => {
+      // Verify staged update data includes org_uid from home organization
+      expect(staged).to.have.property('org_uid');
+      expect(staged.org_uid).to.equal(await getV2HomeOrgId());
+    },
+    expectDeleteResponse: (body) => {
+      expect(body.stagedChildDeletes).to.equal(0);
+    },
+  });
 
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Unit staged successfully');
-      expect(response.body.uuid).to.exist;
-
-      // Verify the record was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: { uuid: response.body.uuid },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.table).to.equal('unit');
-      expect(stagingRecord.action).to.equal('INSERT');
-    });
-
+  describe('POST /v2/unit (Create)', function () {
     it('should create unit with all required data', async function () {
       const unitData = {
         unitSerialId: 'TEST-UNIT-MINIMAL',
@@ -212,208 +290,6 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body.message).to.equal('Unit staged successfully');
-    });
-
-    it('should reject unit without required unitCount', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-NOCOUNT',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitCount');
-    });
-
-    it('should reject unit without required unitType', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-NOTYPE',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitType');
-    });
-
-    it('should reject unit without required unitStatus', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-NOSTATUS',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitStatus');
-    });
-
-    it('should reject unit without required unitStatusReason', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-NOREASON',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitStatusReason');
-    });
-
-    it('should reject unit without required unitMetric', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-NOMETRIC',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitMetric');
-    });
-
-    it('should reject unit without required unitSerialId', async function () {
-      const unitData = {
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitSerialId');
-    });
-
-    it('should reject unit without required unitStartBlock', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitEndBlock: '2000',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitStartBlock');
-    });
-
-    it('should reject unit without required unitEndBlock', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitEndBlock');
-    });
-
-    it('should reject unit without required unitVintageYear', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('unitVintageYear');
-    });
-
-    it('should reject unit without required cadTrustIssuanceId', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('cadTrustIssuanceId');
     });
 
     it('should reject unit with invalid cadTrustIssuanceId (non-existent)', async function () {
@@ -482,187 +358,6 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.false;
       expect(response.body.error).to.include('unitStatusDate');
-    });
-
-    it('should reject unit with invalid unitType (not in V2 picklist)', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Invalid Unit Type',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('Unit Type does not include a valid option');
-    });
-
-    it('should accept unit with valid V2 unitType', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-VALID-TYPE',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Unit staged successfully');
-    });
-
-    it('should reject unit with invalid unitStatus (not in V2 picklist)', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Invalid Status',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('Unit Status does not include a valid option');
-    });
-
-    it('should accept unit with valid V2 unitStatus', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-VALID-STATUS',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Unit staged successfully');
-    });
-
-    it('should reject unit with invalid unitMetric (not in V2 picklist)', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'Invalid Metric',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('Unit Metric does not include a valid option');
-    });
-
-    it('should accept unit with valid V2 unitMetric', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-VALID-METRIC',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Unit staged successfully');
-    });
-
-    it('should reject unit with forbidden createdAt field', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-        createdAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('createdAt" is not allowed');
-    });
-
-    it('should reject unit with forbidden updatedAt field', async function () {
-      const unitData = {
-        unitSerialId: 'TEST-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/unit')
-        .send(unitData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('updatedAt" is not allowed');
     });
 
     it('should reject unit with forbidden orgUid field', async function () {
@@ -772,50 +467,7 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('GET /v2/unit (List)', function () {
-    it('should return empty array when no units exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/unit')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-
-    it('should return units from database', async function () {
-      // Create a unit directly in the database
-      const homeOrgId = await getV2HomeOrgId();
-      const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
-        unitSerialId: 'TEST-UNIT-DB-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-        orgUid: homeOrgId,
-      }));
-
-      const response = await supertest(app)
-        .get('/v2/unit')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(1);
-      expect(response.body.data[0].unitSerialId).to.equal('TEST-UNIT-DB-001');
-    });
-  });
-
   describe('GET /v2/unit/:id (Get One)', function () {
-    it('should return 404 for non-existent unit', async function () {
-      const response = await supertest(app)
-        .get('/v2/unit/99999')
-        .expect(404);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.message).to.equal('Unit not found');
-    });
-
     it('should return unit by ID', async function () {
       // Create a unit directly in the database
       const homeOrgId = await getV2HomeOrgId();
@@ -838,74 +490,6 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
   });
 
   describe('PUT /v2/unit/:id (Update)', function () {
-    it('should return 404 for non-existent unit', async function () {
-      const updateData = {
-        unitSerialId: 'UPDATED-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .put('/v2/unit/99999')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.message).to.equal('Unit not found');
-    });
-
-    it('should stage unit update', async function () {
-      // Create a unit directly in the database
-      const homeOrgId = await getV2HomeOrgId();
-      const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
-        unitSerialId: 'TEST-UNIT-UPDATE-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-        orgUid: homeOrgId,
-      }));
-
-      const updateData = {
-        unitSerialId: 'UPDATED-UNIT-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitCount: 100,
-        unitType: 'Avoidance - nature',
-        unitVintageYear: 2024,
-        unitStatus: 'Issued',
-        unitStatusReason: 'Test reason',
-        unitMetric: 'tCO2e',
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-      };
-
-      const response = await supertest(app)
-        .put(`/v2/unit/${unit.cadTrustUnitId}`)
-        .send(updateData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Unit update staged successfully');
-
-      // Verify the update was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'unit',
-          action: 'UPDATE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-
-      // Verify staged update data includes org_uid from home organization
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0]).to.have.property('org_uid');
-      // Verify org_uid matches the actual home organization
-      const actualHomeOrgId = await getV2HomeOrgId();
-      expect(stagedData[0].org_uid).to.equal(actualHomeOrgId);
-    });
-
     it('should reject unit update with forbidden orgUid field', async function () {
       const homeOrgId = await getV2HomeOrgId();
       const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
@@ -990,45 +574,6 @@ describe('V2 Unit API - Basic CRUD Tests', function () {
   });
 
   describe('DELETE /v2/unit/:id (Delete)', function () {
-    it('should return 404 for non-existent unit', async function () {
-      const response = await supertest(app)
-        .delete('/v2/unit/99999')
-        .expect(404);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.message).to.equal('Unit not found');
-    });
-
-    it('should stage unit deletion', async function () {
-      // Create a unit directly in the database
-      const homeOrgId = await getV2HomeOrgId();
-      const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {
-        unitSerialId: 'TEST-UNIT-DELETE-001',
-        unitStartBlock: '1000',
-        unitEndBlock: '2000',
-        unitVintageYear: 2024,
-        cadTrustIssuanceId: testIssuance.cadTrustIssuanceId,
-        orgUid: homeOrgId,
-      }));
-
-      const response = await supertest(app)
-        .delete(`/v2/unit/${unit.cadTrustUnitId}`)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-      expect(response.body.message).to.equal('Unit delete staged successfully');
-      expect(response.body.stagedChildDeletes).to.equal(0);
-
-      // Verify the delete was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'unit',
-          action: 'DELETE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-    });
-
     it('should cascade-stage unit_label deletes when deleting a unit', async function () {
       const homeOrgId = await getV2HomeOrgId();
       const unit = await UnitV2.create(addUuidIfNeeded('UnitV2', {

--- a/tests/v2/integration/validation-v2.spec.js
+++ b/tests/v2/integration/validation-v2.spec.js
@@ -13,6 +13,7 @@ import {
   getV2HomeOrgId,
   addUuidIfNeeded,
 } from '../utils/v2-test-helpers.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Validation API - Basic CRUD Tests', function () {
   this.timeout(30000);
@@ -74,50 +75,82 @@ describe('V2 Validation API - Basic CRUD Tests', function () {
     }));
   });
 
-  describe('POST /v2/validation (Create)', function () {
-    it('should create a new validation record', async function () {
-      const validationData = {
-        validationId: 'TEST-VALIDATION-001',
+  runCrudStagingSuite({
+    resource: 'validation',
+    label: 'Validation',
+    pk: 'cadTrustValidationId',
+    pkColumn: 'cad_trust_validation_id',
+    missingId: '999999',
+    requiredFields: ['validationType', 'validationBody', 'validationId', 'cadTrustProjectId'],
+    picklists: [
+      {
+        field: 'validationType',
+        invalid: 'InvalidType',
+        valid: 'Validation of Project Design Document',
+      },
+      {
+        field: 'validationBody',
+        invalid: 'InvalidBody',
+        valid: 'AENOR International S.A.U.',
+      },
+    ],
+    context: () => ({ testProject }),
+    validPayload: (ctx) => ({
+      validationId: 'TEST-VALIDATION-001',
+      validationType: 'Validation of Project Design Document',
+      validationBody: 'AENOR International S.A.U.',
+      validationDate: '2024-01-01',
+      validationCreditPeriodStartDate: '2024-01-01',
+      validationCreditPeriodEndDate: '2024-12-31',
+      cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+    }),
+    expectStagedInsert: (staged, ctx) => {
+      expect(staged.validation_id).to.equal('TEST-VALIDATION-001');
+      expect(staged.validation_type).to.equal('Validation of Project Design Document');
+      expect(staged.validation_body).to.equal('AENOR International S.A.U.');
+      expect(staged.cad_trust_project_id).to.equal(ctx.testProject.cadTrustProjectId);
+    },
+    list: {
+      title: 'should return validations from database with project association',
+      query: { columns: 'project' },
+      seed: (ctx) =>
+        ValidationV2.create(addUuidIfNeeded('ValidationV2', {
+          validationId: 'Database Validation',
+          validationType: 'Validation of Project Design Document',
+          validationBody: 'AENOR International S.A.U.',
+          cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+        })),
+      expectRow: (row) => {
+        expect(row.validationId).to.equal('Database Validation');
+        expect(row.validationType).to.equal('Validation of Project Design Document');
+        expect(row.project).to.exist;
+        expect(row.project.projectName).to.equal('Test Project for Validation');
+      },
+    },
+    seed: (ctx) =>
+      ValidationV2.create(addUuidIfNeeded('ValidationV2', {
+        validationId: 'Original ID',
         validationType: 'Validation of Project Design Document',
         validationBody: 'AENOR International S.A.U.',
-        validationDate: '2024-01-01',
-        validationCreditPeriodStartDate: '2024-01-01',
-        validationCreditPeriodEndDate: '2024-12-31',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
+        cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+      })),
+    updatePayload: (ctx) => ({
+      validationId: 'Updated ID',
+      validationType: 'Validation of Post Registration Change',
+      validationBody: 'AENOR International S.A.U.',
+      validationDate: '2024-02-01',
+      validationCreditPeriodStartDate: '2024-02-01',
+      validationCreditPeriodEndDate: '2024-12-31',
+      cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+    }),
+    expectStagedUpdate: (staged, ctx) => {
+      expect(staged.validation_id).to.equal('Updated ID');
+      expect(staged.validation_type).to.equal('Validation of Post Registration Change');
+      expect(staged.cad_trust_project_id).to.equal(ctx.testProject.cadTrustProjectId);
+    },
+  });
 
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(validationData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body).to.have.property('message');
-      expect(response.body.message).to.equal('Validation staged successfully');
-      expect(response.body).to.have.property('uuid');
-      expect(response.body).to.have.property('success', true);
-
-      // Verify record was staged
-      expect(response.body).to.have.property('uuid');
-      const stagingRecord = await StagingV2.findOne({
-        where: { uuid: response.body.uuid },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.table).to.equal('validation');
-      expect(stagingRecord.action).to.equal('INSERT');
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].validation_id).to.equal('TEST-VALIDATION-001');
-      expect(stagedData[0].validation_type).to.equal('Validation of Project Design Document');
-      expect(stagedData[0].validation_body).to.equal('AENOR International S.A.U.');
-      expect(stagedData[0].cad_trust_project_id).to.equal(testProject.cadTrustProjectId);
-    });
-
+  describe('POST /v2/validation (Create)', function () {
     it('should create validation with all required data', async function () {
       const minimalData = {
         validationId: 'MIN-VALIDATION-001',
@@ -133,69 +166,6 @@ describe('V2 Validation API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body.uuid).to.exist;
-    });
-
-    it('should reject validation without required validationType', async function () {
-      const invalidData = {
-        validationId: 'MISSING-TYPE-001',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('validationType');
-    });
-
-    it('should reject validation without required validationBody', async function () {
-      const invalidData = {
-        validationId: 'MISSING-BODY-001',
-        validationType: 'Validation of Project Design Document',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('validationBody');
-    });
-
-    // Validation tests
-    it('should reject validation without required validationId', async function () {
-      const invalidData = {
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('validationId');
-    });
-
-    it('should reject validation without required cadTrustProjectId', async function () {
-      const invalidData = {
-        validationId: 'MISSING-FK',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('cadTrustProjectId');
     });
 
     it('should reject validation with invalid validationDate format', async function () {
@@ -214,72 +184,6 @@ describe('V2 Validation API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.false;
       expect(response.body.error).to.include('validationDate');
-    });
-
-    // Picklist validation tests
-    it('should reject validation with invalid validationType (not in V2 picklist)', async function () {
-      const invalidData = {
-        validationId: 'INVALID-TYPE',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        validationType: 'InvalidType',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('validationType');
-    });
-
-    it('should accept validation with valid V2 validationType', async function () {
-      const validData = {
-        validationId: 'VALID-TYPE',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(validData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
-    });
-
-    it('should reject validation with invalid validationBody (not in V2 picklist)', async function () {
-      const invalidData = {
-        validationId: 'INVALID-BODY',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'InvalidBody',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('validationBody');
-    });
-
-    it('should accept validation with valid V2 validationBody', async function () {
-      const validData = {
-        validationId: 'VALID-BODY',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(validData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
     });
 
     // Foreign key validation tests
@@ -317,87 +221,9 @@ describe('V2 Validation API - Basic CRUD Tests', function () {
       expect(response.body.success).to.be.true;
     });
 
-    it('should reject validation with forbidden createdAt field', async function () {
-      const invalidData = {
-        validationId: 'FORBIDDEN-FIELD',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        createdAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('createdAt');
-    });
-
-    it('should reject validation with forbidden updatedAt field', async function () {
-      const invalidData = {
-        validationId: 'FORBIDDEN-FIELD',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/validation')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('updatedAt');
-    });
-  });
-
-  describe('GET /v2/validation (List)', function () {
-    it('should return empty array when no validations exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/validation')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-
-    it('should return validations from database with project association', async function () {
-      // Create a validation directly in database
-      const validation = await ValidationV2.create(addUuidIfNeeded('ValidationV2', {
-        validationId: 'Database Validation',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      }));
-
-      const response = await supertest(app)
-        .get('/v2/validation')
-        .query({ page: 1, limit: 10, columns: 'project' })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(1);
-      expect(response.body.data[0].validationId).to.equal('Database Validation');
-      expect(response.body.data[0].validationType).to.equal('Validation of Project Design Document');
-      expect(response.body.data[0].project).to.exist;
-      expect(response.body.data[0].project.projectName).to.equal('Test Project for Validation');
-    });
   });
 
   describe('GET /v2/validation/:id (Get One)', function () {
-    it('should return 404 for non-existent validation', async function () {
-      const response = await supertest(app)
-        .get('/v2/validation/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Validation not found');
-      expect(response.body.success).to.be.false;
-    });
-
     it('should return validation by ID with project association', async function () {
       // Create a validation directly in database
       const validation = await ValidationV2.create(addUuidIfNeeded('ValidationV2', {
@@ -419,113 +245,7 @@ describe('V2 Validation API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('PUT /v2/validation/:id (Update)', function () {
-    it('should return 404 for non-existent validation', async function () {
-      const updateData = {
-        validationId: 'Updated ID',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .put('/v2/validation/999999')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.message).to.equal('Validation not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage validation update', async function () {
-      // Create a validation directly in database
-      const validation = await ValidationV2.create(addUuidIfNeeded('ValidationV2', {
-        validationId: 'Original ID',
-        validationType: 'Validation of Project Design Document',
-        validationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      }));
-
-      const updateData = {
-        validationId: 'Updated ID',
-        validationType: 'Validation of Post Registration Change',
-        validationBody: 'AENOR International S.A.U.',
-        validationDate: '2024-02-01',
-        validationCreditPeriodStartDate: '2024-02-01',
-        validationCreditPeriodEndDate: '2024-12-31',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .put(`/v2/validation/${validation.cadTrustValidationId}`)
-        .send(updateData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body.message).to.equal('Validation update staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify update was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'validation',
-          action: 'UPDATE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged update data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_validation_id).to.equal(validation.cadTrustValidationId);
-      expect(stagedData[0].validation_id).to.equal('Updated ID');
-      expect(stagedData[0].validation_type).to.equal('Validation of Post Registration Change');
-      expect(stagedData[0].cad_trust_project_id).to.equal(testProject.cadTrustProjectId);
-    });
-  });
-
   describe('DELETE /v2/validation/:id (Delete)', function () {
-    it('should return 404 for non-existent validation', async function () {
-      const response = await supertest(app)
-        .delete('/v2/validation/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Validation not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage validation deletion', async function () {
-      // Create a validation directly in database
-      const validation = await ValidationV2.create(addUuidIfNeeded('ValidationV2', {
-        validationId: 'To Be Deleted',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      }));
-
-      const response = await supertest(app)
-        .delete(`/v2/validation/${validation.cadTrustValidationId}`)
-        .expect(200);
-
-      expect(response.body.message).to.equal('Validation delete staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify deletion was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'validation',
-          action: 'DELETE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged deletion data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_validation_id).to.equal(validation.cadTrustValidationId);
-    });
-
     it('should return 409 when verification still references validation', async function () {
       const validation = await ValidationV2.create(addUuidIfNeeded('ValidationV2', {
         validationId: `VAL-DEL-GUARD-${uuidv4().slice(0, 8)}`,

--- a/tests/v2/integration/verification-v2.spec.js
+++ b/tests/v2/integration/verification-v2.spec.js
@@ -12,6 +12,7 @@ import {
   getV2HomeOrgId,
   addUuidIfNeeded,
 } from '../utils/v2-test-helpers.js';
+import { runCrudStagingSuite } from '../utils/crud-suite-factory.js';
 
 describe('V2 Verification API - Basic CRUD Tests', function () {
   this.timeout(30000);
@@ -88,51 +89,84 @@ describe('V2 Verification API - Basic CRUD Tests', function () {
     }));
   });
 
-  describe('POST /v2/verification (Create)', function () {
-    it('should create a new verification record', async function () {
-      const verificationData = {
-        verificationId: 'TEST-VERIFICATION-001',
-        verificationStartDate: '2024-01-01',
-        verificationEndDate: '2024-12-31',
+  runCrudStagingSuite({
+    resource: 'verification',
+    label: 'Verification',
+    pk: 'cadTrustVerificationId',
+    pkColumn: 'cad_trust_verification_id',
+    missingId: '999999',
+    requiredFields: ['verificationBody', 'verificationId', 'cadTrustProjectId'],
+    picklists: [
+      {
+        field: 'verificationBody',
+        invalid: 'InvalidBody',
+        valid: 'AENOR International S.A.U.',
+      },
+    ],
+    context: () => ({ testProject, testValidation }),
+    validPayload: (ctx) => ({
+      verificationId: 'TEST-VERIFICATION-001',
+      verificationStartDate: '2024-01-01',
+      verificationEndDate: '2024-12-31',
+      verificationBody: 'AENOR International S.A.U.',
+      cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+      cadTrustValidationId: ctx.testValidation.cadTrustValidationId,
+    }),
+    expectStagedInsert: (staged, ctx) => {
+      expect(staged.verification_id).to.equal('TEST-VERIFICATION-001');
+      expect(staged.verification_start_date).to.equal('2024-01-01');
+      expect(staged.verification_end_date).to.equal('2024-12-31');
+      expect(staged.verification_body).to.equal('AENOR International S.A.U.');
+      expect(staged.cad_trust_project_id).to.equal(ctx.testProject.cadTrustProjectId);
+      expect(staged.cad_trust_validation_id).to.equal(ctx.testValidation.cadTrustValidationId);
+    },
+    list: {
+      title: 'should return verifications from database with project and validation associations',
+      query: { columns: 'project,validation' },
+      seed: (ctx) =>
+        VerificationV2.create(addUuidIfNeeded('VerificationV2', {
+          verificationId: 'Database Verification',
+          verificationBody: 'AENOR International S.A.U.',
+          cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+          cadTrustValidationId: ctx.testValidation.cadTrustValidationId,
+        })),
+      expectRow: (row) => {
+        expect(row.verificationId).to.equal('Database Verification');
+        expect(row.verificationBody).to.equal('AENOR International S.A.U.');
+        expect(row.project).to.exist;
+        expect(row.project.projectName).to.equal('Test Project for Verification');
+        expect(row.validation).to.exist;
+        expect(row.validation.validationId).to.equal('TEST-VALIDATION-001');
+      },
+    },
+    seed: (ctx) =>
+      VerificationV2.create(addUuidIfNeeded('VerificationV2', {
+        verificationId: 'Original ID',
         verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        cadTrustValidationId: testValidation.cadTrustValidationId,
-      };
+        cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+        cadTrustValidationId: ctx.testValidation.cadTrustValidationId,
+      })),
+    updatePayload: (ctx) => ({
+      verificationId: 'Updated ID',
+      verificationStartDate: '2024-02-01',
+      verificationEndDate: '2024-11-30',
+      verificationBody: 'AENOR International S.A.U.',
+      cadTrustProjectId: ctx.testProject.cadTrustProjectId,
+      cadTrustValidationId: ctx.testValidation.cadTrustValidationId,
+    }),
+    expectStagedUpdate: (staged, ctx) => {
+      expect(staged.verification_id).to.equal('Updated ID');
+      expect(staged.verification_start_date).to.equal('2024-02-01');
+      expect(staged.verification_end_date).to.equal('2024-11-30');
+      expect(staged.cad_trust_project_id).to.equal(ctx.testProject.cadTrustProjectId);
+      expect(staged.cad_trust_validation_id).to.equal(ctx.testValidation.cadTrustValidationId);
+    },
+    expectDeleteResponse: (body) => {
+      expect(body.stagedChildDeletes).to.equal(0);
+    },
+  });
 
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(verificationData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body).to.have.property('message');
-      expect(response.body.message).to.equal('Verification staged successfully');
-      expect(response.body).to.have.property('uuid');
-      expect(response.body).to.have.property('success', true);
-
-      // Verify record was staged
-      expect(response.body).to.have.property('uuid');
-      const stagingRecord = await StagingV2.findOne({
-        where: { uuid: response.body.uuid },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.table).to.equal('verification');
-      expect(stagingRecord.action).to.equal('INSERT');
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].verification_id).to.equal('TEST-VERIFICATION-001');
-      expect(stagedData[0].verification_start_date).to.equal('2024-01-01');
-      expect(stagedData[0].verification_end_date).to.equal('2024-12-31');
-      expect(stagedData[0].verification_body).to.equal('AENOR International S.A.U.');
-      expect(stagedData[0].cad_trust_project_id).to.equal(testProject.cadTrustProjectId);
-      expect(stagedData[0].cad_trust_validation_id).to.equal(testValidation.cadTrustValidationId);
-    });
-
+  describe('POST /v2/verification (Create)', function () {
     it('should create verification with all required data', async function () {
       const minimalData = {
         verificationId: 'MIN-VERIFICATION-001',
@@ -147,52 +181,6 @@ describe('V2 Verification API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.true;
       expect(response.body.uuid).to.exist;
-    });
-
-    it('should reject verification without required verificationBody', async function () {
-      const invalidData = {
-        verificationId: 'MISSING-BODY-001',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('verificationBody');
-    });
-
-    // Validation tests
-    it('should reject verification without required verificationId', async function () {
-      const invalidData = {
-        verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('verificationId');
-    });
-
-    it('should reject verification without required cadTrustProjectId', async function () {
-      const invalidData = {
-        verificationId: 'MISSING-FK',
-        verificationBody: 'AENOR International S.A.U.',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('cadTrustProjectId');
     });
 
     it('should reject verification with invalid verificationStartDate format', async function () {
@@ -227,38 +215,6 @@ describe('V2 Verification API - Basic CRUD Tests', function () {
 
       expect(response.body.success).to.be.false;
       expect(response.body.error).to.include('verificationEndDate');
-    });
-
-    // Picklist validation tests
-    it('should reject verification with invalid verificationBody (not in V2 picklist)', async function () {
-      const invalidData = {
-        verificationId: 'INVALID-BODY',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        verificationBody: 'InvalidBody',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('verificationBody');
-    });
-
-    it('should accept verification with valid V2 verificationBody', async function () {
-      const validData = {
-        verificationId: 'VALID-BODY',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        verificationBody: 'AENOR International S.A.U.',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(validData)
-        .expect(200);
-
-      expect(response.body.success).to.be.true;
     });
 
     // Foreign key validation tests
@@ -328,87 +284,9 @@ describe('V2 Verification API - Basic CRUD Tests', function () {
       expect(response.body.success).to.be.true;
     });
 
-    it('should reject verification with forbidden createdAt field', async function () {
-      const invalidData = {
-        verificationId: 'FORBIDDEN-FIELD',
-        verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        createdAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('createdAt');
-    });
-
-    it('should reject verification with forbidden updatedAt field', async function () {
-      const invalidData = {
-        verificationId: 'FORBIDDEN-FIELD',
-        verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        updatedAt: '2024-01-01T00:00:00Z',
-      };
-
-      const response = await supertest(app)
-        .post('/v2/verification')
-        .send(invalidData)
-        .expect(400);
-
-      expect(response.body.success).to.be.false;
-      expect(response.body.error).to.include('updatedAt');
-    });
-  });
-
-  describe('GET /v2/verification (List)', function () {
-    it('should return empty array when no verifications exist', async function () {
-      const response = await supertest(app)
-        .get('/v2/verification')
-        .query({ page: 1, limit: 10 })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(0);
-    });
-
-    it('should return verifications from database with project and validation associations', async function () {
-      // Create a verification directly in database
-      const verification = await VerificationV2.create(addUuidIfNeeded('VerificationV2', {
-        verificationId: 'Database Verification',
-        verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        cadTrustValidationId: testValidation.cadTrustValidationId,
-      }));
-
-      const response = await supertest(app)
-        .get('/v2/verification')
-        .query({ page: 1, limit: 10, columns: 'project,validation' })
-        .expect(200);
-
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data).to.have.length(1);
-      expect(response.body.data[0].verificationId).to.equal('Database Verification');
-      expect(response.body.data[0].verificationBody).to.equal('AENOR International S.A.U.');
-      expect(response.body.data[0].project).to.exist;
-      expect(response.body.data[0].project.projectName).to.equal('Test Project for Verification');
-      expect(response.body.data[0].validation).to.exist;
-      expect(response.body.data[0].validation.validationId).to.equal('TEST-VALIDATION-001');
-    });
   });
 
   describe('GET /v2/verification/:id (Get One)', function () {
-    it('should return 404 for non-existent verification', async function () {
-      const response = await supertest(app)
-        .get('/v2/verification/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Verification not found');
-      expect(response.body.success).to.be.false;
-    });
-
     it('should return verification by ID with project and validation associations', async function () {
       // Create a verification directly in database
       const verification = await VerificationV2.create(addUuidIfNeeded('VerificationV2', {
@@ -431,114 +309,7 @@ describe('V2 Verification API - Basic CRUD Tests', function () {
     });
   });
 
-  describe('PUT /v2/verification/:id (Update)', function () {
-    it('should return 404 for non-existent verification', async function () {
-      const updateData = {
-        verificationId: 'Updated ID',
-        verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      };
-
-      const response = await supertest(app)
-        .put('/v2/verification/999999')
-        .send(updateData)
-        .expect(404);
-
-      expect(response.body.message).to.equal('Verification not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage verification update', async function () {
-      // Create a verification directly in database
-      const verification = await VerificationV2.create(addUuidIfNeeded('VerificationV2', {
-        verificationId: 'Original ID',
-        verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        cadTrustValidationId: testValidation.cadTrustValidationId,
-      }));
-
-      const updateData = {
-        verificationId: 'Updated ID',
-        verificationStartDate: '2024-02-01',
-        verificationEndDate: '2024-11-30',
-        verificationBody: 'AENOR International S.A.U.',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-        cadTrustValidationId: testValidation.cadTrustValidationId,
-      };
-
-      const response = await supertest(app)
-        .put(`/v2/verification/${verification.cadTrustVerificationId}`)
-        .send(updateData);
-
-      if (response.status !== 200) {
-        console.log('Error response:', response.body);
-      }
-
-      expect(response.status).to.equal(200);
-      expect(response.body.message).to.equal('Verification update staged successfully');
-      expect(response.body.success).to.be.true;
-
-      // Verify update was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'verification',
-          action: 'UPDATE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged update data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_verification_id).to.equal(verification.cadTrustVerificationId);
-      expect(stagedData[0].verification_id).to.equal('Updated ID');
-      expect(stagedData[0].verification_start_date).to.equal('2024-02-01');
-      expect(stagedData[0].verification_end_date).to.equal('2024-11-30');
-      expect(stagedData[0].cad_trust_project_id).to.equal(testProject.cadTrustProjectId);
-      expect(stagedData[0].cad_trust_validation_id).to.equal(testValidation.cadTrustValidationId);
-    });
-  });
-
   describe('DELETE /v2/verification/:id (Delete)', function () {
-    it('should return 404 for non-existent verification', async function () {
-      const response = await supertest(app)
-        .delete('/v2/verification/999999')
-        .expect(404);
-
-      expect(response.body.message).to.equal('Verification not found');
-      expect(response.body.success).to.be.false;
-    });
-
-    it('should stage verification deletion', async function () {
-      // Create a verification directly in database
-      const verification = await VerificationV2.create(addUuidIfNeeded('VerificationV2', {
-        verificationId: 'To Be Deleted',
-        cadTrustProjectId: testProject.cadTrustProjectId,
-      }));
-
-      const response = await supertest(app)
-        .delete(`/v2/verification/${verification.cadTrustVerificationId}`)
-        .expect(200);
-
-      expect(response.body.message).to.equal('Verification delete staged successfully');
-      expect(response.body.success).to.be.true;
-      expect(response.body.stagedChildDeletes).to.equal(0);
-
-      // Verify deletion was staged
-      const stagingRecord = await StagingV2.findOne({
-        where: {
-          table: 'verification',
-          action: 'DELETE',
-        },
-      });
-      expect(stagingRecord).to.exist;
-      expect(stagingRecord.committed).to.be.false;
-
-      // Verify staged deletion data
-      const stagedData = JSON.parse(stagingRecord.data);
-      expect(stagedData[0].cad_trust_verification_id).to.equal(verification.cadTrustVerificationId);
-    });
-
     it('should cascade-stage issuance, unit, and unit_label deletes when deleting a verification', async function () {
       const homeOrgId = await getV2HomeOrgId();
 

--- a/tests/v2/utils/crud-suite-factory.js
+++ b/tests/v2/utils/crud-suite-factory.js
@@ -1,0 +1,277 @@
+import { expect } from 'chai';
+import supertest from 'supertest';
+import app from '../../../src/server.js';
+import { StagingV2 } from '../../../src/models/v2/index.js';
+
+// Any value works for the forbidden-field cases: the API rejects on presence.
+const FORBIDDEN_FIELD_VALUE = '2024-01-01T00:00:00Z';
+
+// Field entries accept a bare name or `{ field, message }` when a resource
+// asserts on more of the error string than the field name alone.
+const asFieldEntry = (entry) => (typeof entry === 'string' ? { field: entry } : entry);
+
+const expectFieldError = (response, { field, message }) => {
+  expect(response.body.success).to.be.false;
+  expect(response.body.error).to.include(message ?? field);
+};
+
+// Mirrors the production staging readers, which skip rows they cannot parse
+// rather than letting one bad row throw.
+const parseStagedRow = (row) => {
+  try {
+    const parsed = JSON.parse(row.data);
+    return Array.isArray(parsed) ? parsed[0] : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const expectStagedRow = async (where) => {
+  const record = await StagingV2.findOne({ where });
+  expect(record).to.exist;
+  expect(record.committed).to.be.false;
+
+  const data = parseStagedRow(record);
+  expect(data, `staged payload for ${record.uuid}`).to.exist;
+  return { record, data };
+};
+
+// Not every resource spec truncates staging between tests, so mutations are
+// matched on the row they target rather than on the first row for the table.
+const expectStagedRowFor = async ({ table, action, pkColumn, id }) => {
+  const rows = await StagingV2.findAll({ where: { table, action } });
+  const matches = rows.filter((row) => parseStagedRow(row)?.[pkColumn] === id);
+
+  expect(matches, `staged ${action} rows for ${table} ${id}`).to.have.lengthOf(1);
+  expect(matches[0].committed).to.be.false;
+  return parseStagedRow(matches[0]);
+};
+
+/**
+ * Emits the CRUD/staging cases every core V2 resource shares: the 404 trio,
+ * empty and populated list reads, staged INSERT/UPDATE/DELETE, and the
+ * missing-required, forbidden-timestamp, and picklist rejection batteries.
+ *
+ * Call it from inside a resource's own top-level `describe` so the emitted cases
+ * reuse that file's hooks, and pass fixtures those hooks rebuild per test through
+ * `context` rather than capturing them at call time. The emitted describes are
+ * named after the endpoint, matching the blocks the specs already use for their
+ * resource-specific cases.
+ *
+ * `updatePayload` and `seed` gate the staged UPDATE and DELETE cases; `list`
+ * gates the populated list case. Omit them for resources that have no such case.
+ * `notFoundPayload` supplies a body for the PUT 404 case; give it one that fails
+ * schema validation where the controller checks existence before validating, so
+ * that ordering stays pinned.
+ * `requiredFields` and `forbiddenFields` take either a bare field name or
+ * `{ field, message }`; picklists use `invalidMessage` for the same purpose.
+ * Supply the longer string wherever a resource asserts on more of the error
+ * than the field name.
+ */
+// `seed`, `updatePayload`, and `list` gate whole cases, so a misspelled key
+// would drop coverage while the suite still reports green.
+const CONFIG_KEYS = new Set([
+  'resource', 'label', 'plural', 'endpoint', 'table', 'pk', 'pkColumn', 'missingId',
+  'context', 'validPayload', 'updatePayload', 'notFoundPayload', 'seed',
+  'requiredFields', 'forbiddenFields', 'picklists', 'list',
+  'expectStagedInsert', 'expectStagedUpdate', 'expectDeleteResponse',
+  'notFoundMessage', 'createdMessage', 'updatedMessage', 'deletedMessage',
+]);
+
+// An omitted `missingId` or `pk` yields a `/undefined` path that still 404s, so
+// the 404 cases would pass without ever exercising the option.
+const REQUIRED_KEYS = ['resource', 'label', 'missingId', 'validPayload'];
+const REQUIRED_WITH_SEED = ['pk', 'pkColumn'];
+
+export const runCrudStagingSuite = (cfg) => {
+  const unknownKeys = Object.keys(cfg).filter((key) => !CONFIG_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(`runCrudStagingSuite: unknown config key(s): ${unknownKeys.join(', ')}`);
+  }
+
+  const required = cfg.seed ? [...REQUIRED_KEYS, ...REQUIRED_WITH_SEED] : REQUIRED_KEYS;
+  const missingKeys = required.filter((key) => cfg[key] === undefined);
+  if (missingKeys.length > 0) {
+    throw new Error(`runCrudStagingSuite: missing config key(s): ${missingKeys.join(', ')}`);
+  }
+
+  const {
+    resource,
+    label,
+    plural = `${resource}s`,
+    endpoint = `/v2/${resource}`,
+    table = resource,
+    pk,
+    pkColumn,
+    missingId,
+    context = () => ({}),
+    validPayload,
+    updatePayload,
+    notFoundPayload,
+    seed,
+    requiredFields = [],
+    forbiddenFields = ['createdAt', 'updatedAt'],
+    picklists = [],
+    list,
+    expectStagedInsert,
+    expectStagedUpdate,
+    expectDeleteResponse,
+    notFoundMessage = `${label} not found`,
+    createdMessage = `${label} staged successfully`,
+    updatedMessage = `${label} update staged successfully`,
+    deletedMessage = `${label} delete staged successfully`,
+  } = cfg;
+
+  const expectNotFound = async (request) => {
+    const response = await request.expect(404);
+    expect(response.body.message).to.equal(notFoundMessage);
+    expect(response.body.success).to.be.false;
+  };
+
+  describe(`POST ${endpoint} (Create)`, function () {
+    it(`should create a new ${resource} record`, async function () {
+      const ctx = context();
+
+      const response = await supertest(app).post(endpoint).send(validPayload(ctx));
+
+      expect(response.status, JSON.stringify(response.body)).to.equal(200);
+      expect(response.body.message).to.equal(createdMessage);
+      expect(response.body).to.have.property('success', true);
+      expect(response.body).to.have.property('uuid');
+
+      const { record, data } = await expectStagedRow({ uuid: response.body.uuid });
+      expect(record.table).to.equal(table);
+      expect(record.action).to.equal('INSERT');
+      await expectStagedInsert?.(data, ctx);
+    });
+
+    requiredFields.map(asFieldEntry).forEach(({ field, message }) => {
+      it(`should reject ${resource} without required ${field}`, async function () {
+        const payload = validPayload(context());
+        delete payload[field];
+
+        const response = await supertest(app).post(endpoint).send(payload).expect(400);
+
+        expectFieldError(response, { field, message });
+      });
+    });
+
+    forbiddenFields.map(asFieldEntry).forEach(({ field, message }) => {
+      it(`should reject ${resource} with forbidden ${field} field`, async function () {
+        const payload = { ...validPayload(context()), [field]: FORBIDDEN_FIELD_VALUE };
+
+        const response = await supertest(app).post(endpoint).send(payload).expect(400);
+
+        expectFieldError(response, { field, message });
+      });
+    });
+
+    picklists.forEach(({ field, invalid, valid, invalidMessage, invalidTitle, validTitle }) => {
+      it(invalidTitle ?? `should reject ${resource} with invalid ${field} (not in V2 picklist)`, async function () {
+        const payload = { ...validPayload(context()), [field]: invalid };
+
+        const response = await supertest(app).post(endpoint).send(payload).expect(400);
+
+        expectFieldError(response, { field, message: invalidMessage });
+      });
+
+      it(validTitle ?? `should accept ${resource} with valid V2 ${field}`, async function () {
+        const payload = { ...validPayload(context()), [field]: valid };
+
+        const response = await supertest(app).post(endpoint).send(payload).expect(200);
+
+        expect(response.body.success).to.be.true;
+        expect(response.body.message).to.equal(createdMessage);
+        expect(response.body).to.have.property('uuid');
+      });
+    });
+  });
+
+  describe(`GET ${endpoint} (List)`, function () {
+    it(`should return empty array when no ${plural} exist`, async function () {
+      const response = await supertest(app)
+        .get(endpoint)
+        .query({ page: 1, limit: 10 })
+        .expect(200);
+
+      expect(response.body.data).to.be.an('array');
+      expect(response.body.data).to.have.length(0);
+    });
+
+    if (list) {
+      it(list.title ?? `should return ${plural} from database`, async function () {
+        const ctx = context();
+        await list.seed(ctx);
+
+        const response = await supertest(app)
+          .get(endpoint)
+          .query({ page: 1, limit: 10, ...list.query })
+          .expect(200);
+
+        expect(response.body.data).to.be.an('array');
+        expect(response.body.data).to.have.length(1);
+        await list.expectRow(response.body.data[0], ctx);
+      });
+    }
+  });
+
+  describe(`GET ${endpoint}/:id (Get One)`, function () {
+    it(`should return 404 for non-existent ${resource}`, async function () {
+      await expectNotFound(supertest(app).get(`${endpoint}/${missingId}`));
+    });
+  });
+
+  describe(`PUT ${endpoint}/:id (Update)`, function () {
+    it(`should return 404 for non-existent ${resource}`, async function () {
+      const payload = (notFoundPayload ?? updatePayload ?? validPayload)(context());
+
+      await expectNotFound(supertest(app).put(`${endpoint}/${missingId}`).send(payload));
+    });
+
+    if (seed && updatePayload) {
+      it(`should stage ${resource} update`, async function () {
+        const ctx = context();
+        const record = await seed(ctx);
+
+        const response = await supertest(app)
+          .put(`${endpoint}/${record[pk]}`)
+          .send(updatePayload(ctx));
+
+        expect(response.status, JSON.stringify(response.body)).to.equal(200);
+        expect(response.body.message).to.equal(updatedMessage);
+        expect(response.body.success).to.be.true;
+
+        const staged = await expectStagedRowFor({
+          table,
+          action: 'UPDATE',
+          pkColumn,
+          id: record[pk],
+        });
+        await expectStagedUpdate?.(staged, ctx);
+      });
+    }
+  });
+
+  describe(`DELETE ${endpoint}/:id (Delete)`, function () {
+    it(`should return 404 for non-existent ${resource}`, async function () {
+      await expectNotFound(supertest(app).delete(`${endpoint}/${missingId}`));
+    });
+
+    if (seed) {
+      it(`should stage ${resource} deletion`, async function () {
+        const ctx = context();
+        const record = await seed(ctx);
+
+        const response = await supertest(app)
+          .delete(`${endpoint}/${record[pk]}`)
+          .expect(200);
+
+        expect(response.body.message).to.equal(deletedMessage);
+        expect(response.body.success).to.be.true;
+        await expectDeleteResponse?.(response.body);
+
+        await expectStagedRowFor({ table, action: 'DELETE', pkColumn, id: record[pk] });
+      });
+    }
+  });
+};


### PR DESCRIPTION
## Summary

Each of the eight core V2 resource specs carried its own copy of the same CRUD and staging cases, so a change to the shared API contract meant editing eight near-identical blocks. This adds `tests/v2/utils/crud-suite-factory.js` and migrates program, project, unit, issuance, location, methodology, validation, and verification onto it.

`runCrudStagingSuite(cfg)` emits the cases every core resource shares:

- the GET/PUT/DELETE 404 trio
- empty and populated list reads
- staged `INSERT` / `UPDATE` / `DELETE` rows in `StagingV2`
- the missing-required-field, forbidden-timestamp, and picklist rejection batteries

Everything resource-specific stays where it was: transfer, XLSX, batch/CSV, split, cascade delete, reference guards, and orgUid handling are untouched.

Net effect is 2,721 deletions against 872 insertions.

## Notes for reviewers

- **Test titles are byte-identical to `v2-rc2`.** The suite reports the same 339 cases with the same names, so this is a pure consolidation with no coverage change. Diffing the reporter output between the two branches yields nothing.
- **A few generated cases are stronger than what they replaced.** Staged `UPDATE`/`DELETE` rows are now matched by primary key and required to be unique, rather than taking the first row for the table; location's create/update/delete now inspect the staging table at all; and the missing-required and forbidden-field cases build from a complete valid payload so the asserted field is the only error.
- **The factory validates its config.** Unknown and missing keys throw. This matters because `seed`, `updatePayload`, and `list` gate whole cases and `missingId` defaults into a `/undefined` path that still returns 404 — either mistake would drop coverage while the suite stayed green.
- **`notFoundPayload` exists on purpose.** Project, unit, and methodology check that a record exists *before* validating the body, and their PUT 404 tests pinned that ordering by sending a deliberately incomplete payload. That option preserves it; reversing the two blocks in any of those controllers still fails the test.

## Test plan

- [x] `npm run test:v2` — 1758 passing, 0 failing
- [x] `npm run test:v1` — 165 passing, 0 failing (unaffected by this change)
- [x] The eight migrated specs — 339 passing, 0 failing
- [x] Test-title diff against `v2-rc2` — identical
- [x] ESLint clean on the new factory; the migration also clears 10 pre-existing unused-variable errors
- [x] Mutation-checked that the generated cases are load-bearing: reversing the existence/validation order in a controller, and misconfiguring the factory, both fail the suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no application runtime changes; risk is limited to accidental test coverage gaps, which the factory’s config validation and PK-based staging checks aim to prevent.
> 
> **Overview**
> Introduces **`tests/v2/utils/crud-suite-factory.js`** with **`runCrudStagingSuite`**, which registers the shared V2 integration cases (404s, list reads, staged INSERT/UPDATE/DELETE, required-field, forbidden timestamp, and picklist checks) from per-resource config instead of duplicating them in each spec.
> 
> **Program, project, unit, issuance, location, methodology, validation, and verification** specs now call the factory and drop the repeated blocks; cascade deletes, reference guards, org filters, FK checks, and similar resource-specific tests stay in place.
> 
> The factory **throws on bad config keys** so optional gates like **`seed`**, **`updatePayload`**, and **`list`** cannot silently drop cases. Staged UPDATE/DELETE rows are matched by **primary key** (not “first row for the table”). **`notFoundPayload`** keeps PUT 404 tests honest where controllers check existence before body validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f0cb0c2cb1f31b1839a7bccbaa9fcf444b256fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->